### PR TITLE
Change license from private to MIT Open Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,4 +206,4 @@ python -m pytest tests/ -v
 
 ## 📄 Lizenz
 
-Privates Projekt – Thorsten Diederichs
+MIT - Open Source – Thorsten Diederichs


### PR DESCRIPTION
Angleichen der Lizenzangabe in der README mit der tatsächlich hinterlegten im GitHub-Repository.