### PR TITLE
Fix: leeren/None-Content der Provider sauber als Fehler behandeln

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Die App implementiert das SOMAS-Framework mit Content-Type-spezifischen Analyse-
 
 | Version | Datum | Änderungen |
 | --------- | ------- | ------------ |
+| 0.9.1 | 2026-05-30 | Fix: leeren/None-Content der Provider (z.B. OpenRouter `tencent/hy3-preview`) sauber als Fehler behandeln statt Crash; `reasoning`-Fallback + `finish_reason`-Diagnose; alle 4 Clients abgesichert; Regressionstest |
 | 0.9.0 | 2026-05-29 | Modellvergleich: zwei SOMAS-Analysen eines Videos + automatische Synthese-Kurzbeschreibung, deterministisches Markdown-Layout (Thumbnail), ProviderModelPicker, Export nach exports/ |
 | 0.8.0 | 2026-03-30 | Custom Prompt Editor (System-Prompt + Modul anpassen), Benutzerdefinierte Presets (Auto-Save, Rename, Delete), Export-Branding "Analyse · SOMAS" |
 | 0.7.0 | 2026-03-08 | Batch-Verarbeitung (2-5 URLs), Anthropic API direkt, OpenAI API direkt, 4 Provider |

--- a/src/core/anthropic_client.py
+++ b/src/core/anthropic_client.py
@@ -75,9 +75,25 @@ class AnthropicClient(LLMClient):
             if message.content:
                 text_parts = [
                     block.text for block in message.content
-                    if hasattr(block, "text")
+                    if hasattr(block, "text") and block.text
                 ]
                 content = "\n".join(text_parts)
+
+            stop_reason = getattr(message, "stop_reason", None)
+
+            # Leerer Inhalt: sauber als Fehler melden (im Vergleich nicht
+            # weiterverarbeiten, statt ein leeres "Erfolgs"-Ergebnis zu liefern).
+            if not content.strip():
+                logger.error(
+                    f"Anthropic: leerer Inhalt (stop_reason={stop_reason})"
+                )
+                return APIResponse(
+                    status=APIStatus.ERROR,
+                    error_message=(
+                        f"Modell lieferte leeren Inhalt "
+                        f"(stop_reason={stop_reason})"
+                    ),
+                )
 
             tokens_used = 0
             if message.usage:

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.9.0"
+APP_VERSION = "0.9.1"
 
 
 class DebugLogger:

--- a/src/core/openai_client.py
+++ b/src/core/openai_client.py
@@ -83,6 +83,22 @@ class OpenAIClient(LLMClient):
             response = client.chat.completions.create(**params)
 
             content = response.choices[0].message.content or ""
+            finish_reason = getattr(response.choices[0], "finish_reason", None)
+
+            # Leerer Inhalt: sauber als Fehler melden (im Vergleich nicht
+            # weiterverarbeiten, statt ein leeres "Erfolgs"-Ergebnis zu liefern).
+            if not content.strip():
+                logger.error(
+                    f"OpenAI: leerer Inhalt (finish_reason={finish_reason})"
+                )
+                return APIResponse(
+                    status=APIStatus.ERROR,
+                    error_message=(
+                        f"Modell lieferte leeren Inhalt "
+                        f"(finish_reason={finish_reason})"
+                    ),
+                )
+
             tokens_used = response.usage.total_tokens if response.usage else 0
 
             logger.info(

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -149,13 +149,34 @@ class OpenRouterClient(LLMClient):
             if response.status_code == 200:
                 data = response.json()
                 try:
-                    content = data["choices"][0]["message"]["content"]
+                    choice = data["choices"][0]
+                    message = choice.get("message", {}) or {}
+                    finish_reason = choice.get("finish_reason")
                 except (KeyError, IndexError, TypeError) as e:
                     logger.error(f"Unerwartete API-Antwort-Struktur: {e}")
                     return APIResponse(
                         status=APIStatus.ERROR,
                         error_message=f"Unerwartete API-Antwort: {e}",
                     )
+
+                # content kann fehlen oder None sein; manche (Reasoning-)Modelle
+                # liefern den Text stattdessen im Feld 'reasoning'.
+                content = message.get("content") or message.get("reasoning")
+
+                # Leerer/fehlender Inhalt: sauber als Fehler melden statt bei
+                # len(content) zu crashen (NoneType has no len()).
+                if not content or not content.strip():
+                    logger.error(
+                        f"OpenRouter: leerer Inhalt (finish_reason={finish_reason})"
+                    )
+                    return APIResponse(
+                        status=APIStatus.ERROR,
+                        error_message=(
+                            f"Modell lieferte leeren Inhalt "
+                            f"(finish_reason={finish_reason})"
+                        ),
+                    )
+
                 tokens = data.get("usage", {}).get("total_tokens", 0)
 
                 logger.info(

--- a/src/core/perplexity_client.py
+++ b/src/core/perplexity_client.py
@@ -85,13 +85,34 @@ class PerplexityClient(LLMClient):
             if response.status_code == 200:
                 data = response.json()
                 try:
-                    content = data["choices"][0]["message"]["content"]
+                    choice = data["choices"][0]
+                    message = choice.get("message", {}) or {}
+                    finish_reason = choice.get("finish_reason")
                 except (KeyError, IndexError, TypeError) as e:
                     logger.error(f"Unerwartete API-Antwort-Struktur: {e}")
                     return APIResponse(
                         status=APIStatus.ERROR,
                         error_message=f"Unerwartete API-Antwort: {e}",
                     )
+
+                # content kann fehlen oder None sein; Reasoning-Modelle liefern den
+                # Text ggf. im Feld 'reasoning'.
+                content = message.get("content") or message.get("reasoning")
+
+                # Leerer/fehlender Inhalt: sauber als Fehler melden statt bei
+                # len(content) zu crashen (NoneType has no len()).
+                if not content or not content.strip():
+                    logger.error(
+                        f"Perplexity: leerer Inhalt (finish_reason={finish_reason})"
+                    )
+                    return APIResponse(
+                        status=APIStatus.ERROR,
+                        error_message=(
+                            f"Modell lieferte leeren Inhalt "
+                            f"(finish_reason={finish_reason})"
+                        ),
+                    )
+
                 tokens = data.get("usage", {}).get("total_tokens", 0)
                 citations = data.get("citations", [])
 

--- a/tests/test_empty_content.py
+++ b/tests/test_empty_content.py
@@ -1,0 +1,118 @@
+"""Regressionstest: leerer/None-Content der Provider -> APIResponse(ERROR) statt Crash.
+
+Hintergrund (v0.9.0): OpenRouter-Modell `tencent/hy3-preview` lieferte HTTP 200
+mit `choices[0].message.content == None`. Das alte `len(content)` warf
+`object of type 'NoneType' has no len()` und wurde nur vom generischen except
+als "unerwarteter Fehler" gefangen. Erwartet wird stattdessen eine klare
+APIResponse(status=ERROR) mit finish_reason in der Meldung.
+
+Lauf (ohne pytest):  python tests/test_empty_content.py
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Projekt-Root auf den Importpfad legen (Lauf ohne Installation/pytest)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.api_client import APIStatus
+from src.core.openrouter_client import OpenRouterClient
+from src.core.perplexity_client import PerplexityClient
+
+
+class FakeResp:
+    status_code = 200
+    def __init__(self, payload): self._p = payload
+    def json(self): return self._p
+
+
+def _run_requests_client(cls, module_path, payload):
+    with patch(f"{module_path}.requests.post", return_value=FakeResp(payload)):
+        return cls("dummy-key").send_prompt("prompt", "some/model")
+
+
+def test_requests_based(name, cls, module_path):
+    # 1) content == None -> ERROR (kein Crash), finish_reason in Meldung
+    r = _run_requests_client(cls, module_path,
+        {"choices": [{"message": {"content": None}, "finish_reason": "error"}],
+         "usage": {"total_tokens": 0}})
+    assert r.status == APIStatus.ERROR, f"{name}: None sollte ERROR sein"
+    assert "leeren Inhalt" in r.error_message and "finish_reason=error" in r.error_message
+    # 2) content == "" + reasoning gesetzt -> RECEIVED mit reasoning-Text
+    r = _run_requests_client(cls, module_path,
+        {"choices": [{"message": {"content": "", "reasoning": "Denkprozess"}, "finish_reason": "stop"}]})
+    assert r.status == APIStatus.RECEIVED and r.content == "Denkprozess", f"{name}: reasoning-Fallback"
+    # 3) content nur Whitespace, kein reasoning -> ERROR
+    r = _run_requests_client(cls, module_path,
+        {"choices": [{"message": {"content": "   "}, "finish_reason": "length"}]})
+    assert r.status == APIStatus.ERROR, f"{name}: leer ohne reasoning -> ERROR"
+    # 4) Normalfall -> RECEIVED
+    r = _run_requests_client(cls, module_path,
+        {"choices": [{"message": {"content": "Hallo Welt"}}], "usage": {"total_tokens": 5}})
+    assert r.status == APIStatus.RECEIVED and r.content == "Hallo Welt", f"{name}: Normalfall"
+    # 5) message fehlt -> ERROR (kein Crash)
+    r = _run_requests_client(cls, module_path, {"choices": [{}]})
+    assert r.status == APIStatus.ERROR, f"{name}: fehlende message -> ERROR"
+    print(f"  {name}: OK (None/reasoning/leer/normal/fehlend)")
+
+
+def test_openai():
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        print("  OpenAI: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.openai_client import OpenAIClient
+    def fake_response(content):
+        resp = MagicMock()
+        resp.choices[0].message.content = content
+        resp.choices[0].finish_reason = "stop"
+        resp.usage.total_tokens = 3
+        return resp
+    with patch("openai.OpenAI") as M:
+        M.return_value.chat.completions.create.return_value = fake_response(None)
+        assert OpenAIClient("k").send_prompt("p", "gpt-4o").status == APIStatus.ERROR
+        M.return_value.chat.completions.create.return_value = fake_response("Antwort")
+        r = OpenAIClient("k").send_prompt("p", "gpt-4o")
+        assert r.status == APIStatus.RECEIVED and r.content == "Antwort"
+    print("  OpenAI: OK (None -> ERROR, Text -> RECEIVED)")
+
+
+def test_anthropic():
+    try:
+        import anthropic  # noqa: F401
+    except ImportError:
+        print("  Anthropic: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.anthropic_client import AnthropicClient
+    def block(text):
+        b = MagicMock(); b.text = text; return b
+    def fake_message(blocks):
+        msg = MagicMock()
+        msg.content = blocks
+        msg.stop_reason = "end_turn"
+        msg.usage.input_tokens = 1
+        msg.usage.output_tokens = 2
+        return msg
+    with patch("anthropic.Anthropic") as M:
+        M.return_value.messages.create.return_value = fake_message([])
+        assert AnthropicClient("k").send_prompt("p", "claude-sonnet-4-6").status == APIStatus.ERROR
+        M.return_value.messages.create.return_value = fake_message([block(None)])
+        assert AnthropicClient("k").send_prompt("p", "claude-sonnet-4-6").status == APIStatus.ERROR
+        M.return_value.messages.create.return_value = fake_message([block("Hallo")])
+        r = AnthropicClient("k").send_prompt("p", "claude-sonnet-4-6")
+        assert r.status == APIStatus.RECEIVED and r.content == "Hallo"
+    print("  Anthropic: OK (leer/None-Block -> ERROR, Text -> RECEIVED)")
+
+
+def main():
+    print("Tests leerer/None-Content:")
+    test_requests_based("OpenRouter", OpenRouterClient, "src.core.openrouter_client")
+    test_requests_based("Perplexity", PerplexityClient, "src.core.perplexity_client")
+    test_openai()
+    test_anthropic()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_empty_content.py
+++ b/tests/test_empty_content.py
@@ -86,7 +86,9 @@ def test_anthropic():
         return
     from src.core.anthropic_client import AnthropicClient
     def block(text):
-        b = MagicMock(); b.text = text; return b
+        b = MagicMock()
+        b.text = text
+        return b
     def fake_message(blocks):
         msg = MagicMock()
         msg.content = blocks


### PR DESCRIPTION
## Bug

Im Modellvergleich (Schritt A) crasht der OpenRouter-Client bei leerem Modell-Content:

```
src.core.openrouter_client - ERROR - OpenRouter unerwarteter Fehler: object of type 'NoneType' has no len()
```

Aufgetreten bei `tencent/hy3-preview` — **HTTP 200, aber `choices[0].message.content == None`**. Der Key existiert, daher fing das `try/except (KeyError/IndexError/TypeError)` nichts; das nachfolgende `len(content)` warf die Exception, die nur als generischer „unerwarteter Fehler" gefangen wurde.

Verifiziert am Debug-Artefakt (`somas_debug/2026-05-30_06-42-33_openrouter_tencent_hy3-preview`): `content_length_chars: 0`, `error: True`.

## Fix

| Client | Vorher | Nachher |
|--------|--------|---------|
| **openrouter** | `content = data[...]["content"]` → `len(None)` crasht | `.get()` + `reasoning`-Fallback, leer/None → `APIResponse(ERROR)` |
| **perplexity** | identisches Muster (crasht) | analog abgesichert |
| **openai** | `... or ""` (crash-sicher) | minimaler Leer-Guard für Vergleichs-Konsistenz |
| **anthropic** | `content=""` (crash-sicher) | Leer-Guard + Filter für `None`-Text-Blocks |

Bei leerem/fehlendem Content gibt es jetzt eine klare Meldung
„Modell lieferte leeren Inhalt (finish_reason=…)" statt eines Crashs — der `ComparisonWorker` bricht Schritt A/B dadurch sauber ab (statt ein kaputtes Dokument zu bauen).

## Tests

Neuer Regressionstest `tests/test_empty_content.py` (self-contained, ohne pytest lauffähig):
`None` / `reasoning`-Fallback / nur-Whitespace / Normalfall / fehlende `message`; openai & anthropic via SDK-Mock. **Alle grün.**

## Hinweis

`tencent/hy3-preview` kann providerseitig weiterhin leer liefern — Ziel des Fixes ist die robuste, klare Fehlermeldung statt Crash. Als Modell A kann alternativ ein anderes gewählt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Fehlerbehebungen**
  * Verbesserte Fehlerbehandlung bei leeren oder ungültigen Antworten von KI-Anbietern (OpenAI, Anthropic, OpenRouter, Perplexity): Das System gibt nun aussagekräftige Fehlermeldungen zurück, statt abzustürzen oder ungültige Daten zu verarbeiten.
  * Robustere Verarbeitung von API-Antworten mit defensiven Zugriffsmustern und Fallback-Optionen.

* **Tests**
  * Neue Regressionstests für Szenarien mit leerem oder null-Inhalt aus API-Anbietern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddumdi11/somas_prompt_generator/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->