### PR TITLE
Feature: Faktencheck-Verifikation – Hybrid (v0.10.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.9.1
+**Version:** 0.10.0
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -55,6 +55,8 @@ somas_prompt_generator/
 │   │   ├── user_preset_store.py # Benutzerdefinierte Presets (JSON-CRUD)
 │   │   ├── comparison_item.py  # ModelChoice/ComparisonConfig/ComparisonResult (Modellvergleich)
 │   │   ├── comparison_worker.py # QThread-Worker: 2 Analysen + Synthese + Layout-Render
+│   │   ├── verification_item.py # VerificationConfig/VerificationResult (Faktencheck Stufe 2)
+│   │   ├── verification_worker.py # QThread-Worker: Behauptungen verifizieren (Verdikt + Quelle)
 │   │   └── debug_logger.py     # Debug-Logging mit Version/Session-Info
 │   │
 │   └── config/             # Konfiguration
@@ -75,13 +77,15 @@ somas_prompt_generator/
 │   ├── somas_research.txt      # Research-Preset (unbegrenzt)
 │   ├── somas_music.txt         # Musik-Preset (2.400 Zeichen, Songtext-Analyse)
 │   ├── somas_songstruktur.txt  # Songstruktur-Preset (Formanalyse)
-│   └── somas_comparison.txt    # Modellvergleich-Layout (Jinja2-Dokumentlayout)
+│   ├── somas_comparison.txt    # Modellvergleich-Layout (Jinja2-Dokumentlayout)
+│   └── somas_verification.txt  # Faktencheck-Verifikation-Abschnitt (Stufe 2)
 │
 ├── specs/                  # Entwicklungs-Spezifikationen
 │   ├── API_INTEGRATION_SPEC.md
 │   ├── api_providers.json
 │   ├── SOMAS_v0.6.0_SPEC.md
-│   └── SOMAS_v0.9.0_SPEC_modellvergleich.md
+│   ├── SOMAS_v0.9.0_SPEC_modellvergleich.md
+│   └── SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
 │
 ├── docs/                   # GitHub Pages Landing Page
 │   ├── index.html
@@ -312,8 +316,26 @@ TEST_URLS = [
   fehlende `message`) — grün
 - [x] Versionskonstante + README-Changelog auf 0.9.1 (PR #38)
 
+### Phase 12: Faktencheck-Verifikation ✅ (v0.10.0)
+
+- [x] Stufe 1 (Dekonstruktion): FAKTENCHECK trennt Meinungen/Interpretationen/Behauptungen,
+  relevanz-sortiert. `FAKTENCHECK_FORMAT`-Konstante + Injektion via `_apply_custom_overrides`
+  (deckt alle Presets ab, Header bleibt exakt `### FAKTENCHECK`)
+- [x] Parser `extract_claims_from_faktencheck` (zeilen- UND inline-nummeriert, robust gegen
+  interne Zahlen), `cap_claims` (Top-N, Default 10, 0=unbegrenzt), `build_verification_prompt`
+  (nur Behauptungen, Riegel gegen erfundene Quellen), `clean_verification_output`
+- [x] Stufe 2 (Verifikation, optional): `verification_item.py`, `VerificationWorker`,
+  `somas_verification.txt` (Verdikt + Quelle pro Behauptung, 4-stufige Skala)
+- [x] GUI: Toggle + Verifikationsmodell-Picker + Max-Behauptungen-SpinBox + `:online`-Schalter
+  (OpenRouter) + Web-Disclaimer; Auto-Anhang an die Analyse; Ausschluss mit Modellvergleich
+- [x] Race-Fix (Quelle während Verifikation gesperrt) + CollapsibleSection-Stylesheet gescoped
+- [x] Tests `tests/test_faktencheck_parser.py`; headless + real-web getestet
+- [x] Spec dokumentiert (SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md)
+
 ### Backlog
 
+- [ ] „Verifikation erneut versuchen"-Button (nur Stufe 2 wiederholen) — v0.10.1, hohe Priorität
+- [ ] Einheitlicher Export-Kopf (Einzelanalyse wie Modellvergleich: Titel-Block + Thumbnail) — v0.10.1
 - [ ] Wochentags-basierte Perspektive-Defaults (nach Recherche)
 - [ ] Englisch-Support
 - [ ] PDF-Export (auch für Modellvergleich)
@@ -338,4 +360,4 @@ Bei Unklarheiten: Frag nach! Lieber einmal zu viel als eine falsche Annahme tref
 
 ---
 
-Letzte Aktualisierung: 2026-05-30
+Letzte Aktualisierung: 2026-06-14

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.9.0) — Modellvergleich
+### Aktuell (v0.10.0) — Faktencheck-Verifikation
+
+- **Zweistufige Faktenprüfung** – Das FAKTENCHECK-Modul trennt jetzt strikt **Meinungen**, **Interpretationen** und **überprüfbare Behauptungen** (relevanz-sortiert). Optional prüft danach ein web-fähiges Modell **nur die nackten Behauptungen** und liefert pro Behauptung **Verdikt + Quelle**
+- **Halluzinations-Schutz** – In der Verifikation stehen **keine Meinungen** im Prompt – das Modell kann nicht durch rhetorische Sprache „verführt" werden. Zusätzlicher Riegel gegen erfundene Quellen (kann nicht belegt werden → Verdikt „nicht überprüfbar", Quelle „—")
+- **4-stufige Verdikt-Skala** – bestätigt · teilweise bestätigt · widerlegt · nicht überprüfbar
+- **Frei wählbares Verifikationsmodell** – ProviderModelPicker über alle 4 Provider; `:online`-Schalter für echten Web-Zugriff (OpenRouter); Web-Disclaimer, wenn kein bestätigter Web-Zugriff
+- **Konfigurierbare Obergrenze** – Default 10 zu prüfende Behauptungen (app-seitig, deterministisch gekappt; `0 = unbegrenzt`); Meinungen/Interpretationen werden vollständig angezeigt
+- **Sauberer Anhang** – Der Verifikationsabschnitt wird an die Analyse angehängt (Export enthält beide Teile); Stufe-2-Fehler ist nicht fatal (Analyse bleibt erhalten)
+
+### Seit v0.9.0 — Modellvergleich
 
 - **Zwei Analysen, ein Video** – Dasselbe YouTube-Video (oder Transkript) von zwei frei wählbaren Modellen nach dem SOMAS-Schema analysieren lassen. Gleiches Preset, gleiche Perspektive, gleiche Tiefe für beide – nur das Modell variiert (fairer Vergleich)
 - **Automatische Synthese** – Ein drittes Modell erzeugt aus beiden Analysen eine neutrale Kurzbeschreibung (ein Absatz). Eingabe sind die vollständigen Analysetexte, nicht das Transkript
@@ -88,6 +97,8 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ### Nächste Schritte
 
+- „Verifikation erneut versuchen"-Button (nur Stufe 2 wiederholen) — v0.10.1
+- Einheitlicher Export-Kopf (Einzelanalyse mit Titel-Block + Thumbnail) — v0.10.1
 - Wochentags-basierte Perspektive-Defaults (nach Recherche)
 - Englisch-Support
 - PDF-Export
@@ -134,6 +145,8 @@ somas_prompt_generator/
 │   │   ├── user_preset_store.py # Benutzerdefinierte Presets (JSON-Persistenz)
 │   │   ├── comparison_item.py  # ModelChoice/ComparisonConfig/ComparisonResult
 │   │   ├── comparison_worker.py # QThread: 2 Analysen + Synthese + Layout-Render
+│   │   ├── verification_item.py # VerificationConfig/VerificationResult (Faktencheck Stufe 2)
+│   │   ├── verification_worker.py # QThread: Behauptungen verifizieren (Verdikt + Quelle)
 │   │   └── debug_logger.py     # Debug-Logging
 │   │
 │   └── config/
@@ -154,7 +167,8 @@ somas_prompt_generator/
 │   ├── somas_research.txt      # Research-Preset
 │   ├── somas_music.txt         # Musik-Preset (Songtext-Analyse)
 │   ├── somas_songstruktur.txt  # Songstruktur-Preset (Formanalyse)
-│   └── somas_comparison.txt    # Modellvergleich-Dokumentlayout (Jinja2)
+│   ├── somas_comparison.txt    # Modellvergleich-Dokumentlayout (Jinja2)
+│   └── somas_verification.txt  # Faktencheck-Verifikation-Abschnitt (Stufe 2)
 │
 ├── docs/                   # GitHub Pages Landing Page
 │   ├── index.html
@@ -248,6 +262,14 @@ python main.py
 4. **"Modellvergleich starten"** → beide Analysen + Synthese laufen sequenziell, Fortschritt im Bereichs-Header
 5. Das fertige Markdown erscheint im Ergebnisfeld → **"Export: Markdown"** speichert nach `exports/…_Modellvergleich.md`
 
+### Faktencheck-Verifikation-Modus
+
+1. Im API-Bereich **"Behauptungen verifizieren (Faktencheck Stufe 2)"** aktivieren → Bereich "Faktencheck-Verifikation" klappt auf
+2. **Verifikationsmodell** wählen (web-fähig empfohlen, z. B. Perplexity Sonar; für OpenRouter das **`:online`-Häkchen** setzen)
+3. Optional **Max. zu prüfende Behauptungen** anpassen (Default 10, `0 = unbegrenzt`)
+4. **"Generate Prompt"** → die Analyse erzwingt das FAKTENCHECK-Modul; danach läuft **automatisch** die Verifikation
+5. Der Abschnitt `### FAKTENCHECK · VERIFIKATION` (Verdikt + Quelle pro Behauptung) wird an die Analyse angehängt und mitexportiert
+
 ### API-Integration
 
 - API-Keys werden sicher im System-Keyring gespeichert
@@ -283,6 +305,7 @@ Die App implementiert das SOMAS-Framework mit Content-Type-spezifischen Analyse-
 3. **ELABORATION** – Vertiefung, Belege, Details
 4. **IMPLIKATION** – Fazit, Empfehlung, Bedeutung
 5. **[MODUL]** – Automatisch gewählt: Kritik · Zitate · Offene Fragen · Verbindungen · Subtext · Faktencheck
+   - **FAKTENCHECK** trennt seit v0.10.0 Meinungen / Interpretationen / überprüfbare Behauptungen; die Behauptungen können optional in einer zweiten Stufe web-verifiziert werden (Verdikt + Quelle)
 
 ### Musik-Schema (Songtexte, Musikvideos)
 
@@ -297,6 +320,7 @@ Die App implementiert das SOMAS-Framework mit Content-Type-spezifischen Analyse-
 
 | Version | Datum | Änderungen |
 | --------- | ------- | ------------ |
+| 0.10.0 | 2026-06-14 | Faktencheck-Verifikation (Hybrid): Stufe 1 trennt Meinungen/Interpretationen/Behauptungen; optionale Stufe 2 verifiziert Behauptungen per web-fähigem Modell (Verdikt + Quelle, 4-stufige Skala), Halluzinations-Schutz + Riegel gegen erfundene Quellen, `:online`-Schalter, Top-N-Kappung, Auto-Anhang |
 | 0.9.1 | 2026-05-30 | Fix: leeren/None-Content der Provider (z.B. OpenRouter `tencent/hy3-preview`) sauber als Fehler behandeln statt Crash; `reasoning`-Fallback + `finish_reason`-Diagnose; alle 4 Clients abgesichert; Regressionstest |
 | 0.9.0 | 2026-05-29 | Modellvergleich: zwei SOMAS-Analysen eines Videos + automatische Synthese-Kurzbeschreibung, deterministisches Markdown-Layout (Thumbnail), ProviderModelPicker, Export nach exports/ |
 | 0.8.0 | 2026-03-30 | Custom Prompt Editor (System-Prompt + Modul anpassen), Benutzerdefinierte Presets (Auto-Save, Rename, Delete), Export-Branding "Analyse · SOMAS" |

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="SOMAS Prompt Generator v0.9.1 – Strukturierte YouTube-Analysen mit KI-Power. Modellvergleich (2 Analysen + Synthese), Custom Prompt Editor, 4 API-Provider, Batch-Modus, 200+ Modelle.">
+    <meta name="description" content="SOMAS Prompt Generator v0.10.0 – Strukturierte YouTube-Analysen mit KI-Power. Faktencheck-Verifikation (Verdikt + Quelle), Modellvergleich, Custom Prompt Editor, 4 API-Provider, Batch-Modus, 200+ Modelle.">
     <title>SOMAS Prompt Generator – KI-gestützte Video-Analysen</title>
     <link rel="stylesheet" href="style.css">
 </head>
@@ -13,7 +13,7 @@
         <div class="container">
             <h1>🎯 SOMAS Prompt Generator</h1>
             <p class="tagline">Strukturierte YouTube-Analysen mit KI-Power.<br>200+ Modelle · Ein Klick · LinkedIn-ready.</p>
-            <p class="version-badge">✨ v0.9.1: Modellvergleich · Custom Prompt Editor · 4 API-Provider · Batch-Modus · 200+ Modelle</p>
+            <p class="version-badge">✨ v0.10.0: Faktencheck-Verifikation · Modellvergleich · 4 API-Provider · Batch-Modus · 200+ Modelle</p>
             <div class="cta-buttons">
                 <a href="https://github.com/ddumdi11/somas_prompt_generator" class="btn btn-primary">GitHub Repo</a>
                 <a href="https://github.com/ddumdi11/somas_prompt_generator/releases" class="btn btn-secondary">Download</a>
@@ -29,10 +29,44 @@
         </div>
     </section>
 
-    <!-- NEU in v0.9.0 -->
+    <!-- NEU in v0.10.0 -->
     <section class="whats-new">
         <div class="container">
-            <h2>🆕 Neu in v0.9.0 – Modellvergleich</h2>
+            <h2>🆕 Neu in v0.10.0 – Faktencheck-Verifikation</h2>
+            <p class="section-intro">Von der rhetorischen Analyse zur harten Faktenprüfung – in zwei Stufen, mit Halluzinations-Schutz.</p>
+            <div class="new-features-grid">
+                <div class="new-feature-card new-feature-card-highlight">
+                    <span class="new-feature-icon">🔎</span>
+                    <h3>Zwei Stufen</h3>
+                    <p>Stufe 1 trennt <strong>Meinungen</strong>, <strong>Interpretationen</strong> und <strong>überprüfbare Behauptungen</strong>. Stufe 2 prüft optional nur die Behauptungen per web-fähigem Modell.</p>
+                    <span class="new-feature-detail">Dekonstruktion → Verifikation</span>
+                </div>
+                <div class="new-feature-card new-feature-card-highlight">
+                    <span class="new-feature-icon">🛡️</span>
+                    <h3>Halluzinations-Schutz</h3>
+                    <p>In Stufe 2 stehen <strong>keine Meinungen</strong> im Prompt – das Modell lässt sich nicht durch Rhetorik verführen. Riegel gegen erfundene Quellen: kein Beleg → „nicht überprüfbar / —".</p>
+                    <span class="new-feature-detail">Nur nackte Behauptungen</span>
+                </div>
+                <div class="new-feature-card">
+                    <span class="new-feature-icon">⚖️</span>
+                    <h3>Verdikt + Quelle</h3>
+                    <p>Pro Behauptung ein Verdikt (bestätigt · teilweise bestätigt · widerlegt · nicht überprüfbar) plus Quelle – angehängt an die Analyse, mitexportiert.</p>
+                    <span class="new-feature-detail">4-stufige Skala</span>
+                </div>
+                <div class="new-feature-card">
+                    <span class="new-feature-icon">🌐</span>
+                    <h3>Echter Web-Zugriff</h3>
+                    <p>Verifikationsmodell frei wählbar; <code>:online</code>-Schalter für OpenRouter, Web-Disclaimer ohne bestätigten Zugriff. Top-N-Kappung (Default 10) gegen Kosten.</p>
+                    <span class="new-feature-detail">Perplexity Sonar &amp; OpenRouter :online</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- v0.9.0 -->
+    <section class="whats-new whats-new-v07">
+        <div class="container">
+            <h2>⚖️ v0.9.0 – Modellvergleich</h2>
             <p class="section-intro">Ein Video, zwei Modelle, eine Synthese – vollautomatisch als fertiges Dokument.</p>
             <div class="new-features-grid">
                 <div class="new-feature-card new-feature-card-highlight">

--- a/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
+++ b/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
@@ -1,0 +1,588 @@
+# Feature: Faktencheck-Verifikation – Hybrid (Trennung im Hauptlauf + optionale Web-Verifikation) (v0.10.0)
+
+> Branch: `feature/faktencheck-verification-v0100`
+> Priorität: Hoch — nächste Funktionserweiterung nach Modellvergleich (v0.9.x)
+> Aufwand: Mittel — FAKTENCHECK-Modul umbauen, Claim-Parser, neuer Verifikations-Worker, ein Konfig-Toggle + ProviderModelPicker, Ergebnis-Anhang
+> Abhängigkeit: v0.9.x (ProviderModelPicker, `create_client()`, CollapsibleSection) abgeschlossen
+> Ursprung: Idee Thorsten, vorbesprochen mit Perplexity; architektonisch eingeordnet & spezifiziert durch Claude.ai (Cowork), Entscheidungen freigegeben durch Thorsten (PO)
+
+---
+
+## Hintergrund
+
+Das SOMAS-Schema entschlüsselt heute vor allem, *wie* ein Narrativ aufgebaut ist (FRAMING,
+KERNTHESE …). Es gibt bereits ein FAKTENCHECK-Modul, das aber bewusst nur eine **Vorstufe**
+ist: Es benennt die 3–4 überprüfungsbedürftigsten Aussagen und sagt, *wonach* man suchen
+müsste — fällt aber explizit **kein** Wahr/Falsch-Urteil und prüft nichts.
+
+Diese Erweiterung schließt die Lücke zwischen rhetorischer Analyse und harter empirischer
+Überprüfung in **zwei Stufen**:
+
+- **Stufe 1 (Dekonstruktion):** Das FAKTENCHECK-Modul wird ausgebaut. Es trennt im Transkript
+  strikt **Meinungen**, **Interpretationen** und **falsifizierbare Behauptungen** und liefert
+  die Behauptungen als sauber abgegrenzte, maschinell parsbare Liste.
+- **Stufe 2 (Verifikation):** **Ausschließlich** die nackten Behauptungen werden an ein vom
+  Nutzer gewähltes, web-fähiges Modell übergeben, das jede Behauptung prüft und pro Behauptung
+  ein **Verdikt + Quelle** zurückgibt.
+
+Der zentrale Qualitätsgewinn: In Stufe 2 stehen im Prompt **keine Meinungen mehr** — das
+Verifikationsmodell kann nicht durch emotionale/rhetorische Sprache „verführt" werden, weil
+es nur prüfbare Tatsachenaussagen sieht (Perplexity-Insight, vom PO bestätigt).
+
+### Vom PO freigegebene Designentscheidungen
+
+1. **Architektur = Hybrid.** Die **Trennung** (Stufe 1) wandert fest in den Haupt-SOMAS-Lauf
+   (als ausgebautes FAKTENCHECK-Modul) und liegt damit in jeder so erzeugten Analyse vor. Die
+   **Verifikation** (Stufe 2) ist davon entkoppelt und **optional**.
+2. **FAKTENCHECK wird erweitert/ersetzt**, **kein** zweites paralleles Modul. Der
+   Modul-Bezeichner bleibt aus Kompatibilitätsgründen `FAKTENCHECK` (siehe „Harte Constraints").
+3. **Nutzer wählt das Verifikationsmodell pro Lauf** (ProviderModelPicker, alle 4 Provider),
+   analog zum Modellvergleich. Kein hartkodiertes Default-Modell; letzte Auswahl wird gemerkt.
+4. **Stufe-2-Ausgabe = Verdikt + Quelle pro Behauptung.** Verdikt-Skala (4 Stufen):
+   `bestätigt` · `teilweise bestätigt` · `widerlegt` · `nicht überprüfbar`.
+6. **Relevanz-Priorisierung statt willkürlicher Kappung.** Stufe 1 listet **alle**
+   Behauptungen auf, ordnet sie aber **nach Prüf-Relevanz absteigend** (zentral für
+   Kernthese/Hauptthema und/oder strittig/folgenreich im Diskurs; triviale
+   Selbstverständlichkeiten ans Ende). Die **Kappung auf die Top-N** erfolgt erst beim
+   Übergang zu Stufe 2 und **app-seitig deterministisch** (Parser nimmt die ersten N) — nicht
+   im Vertrauen darauf, dass das Modell zählt. Default **N = 10**, in den Einstellungen
+   konfigurierbar (`0 = unbegrenzt`). Die Kappung betrifft **nur Behauptungen** (sie treiben
+   die Stufe-2-Kosten). **Meinungen und Interpretationen** werden ebenfalls nach Relevanz
+   geordnet, aber **vollständig angezeigt** (kein Cap — reine Anzeige, keine Web-Kosten).
+5. **Auslöser = Toggle (Checkbox **oder** Aktivieren/Deaktivieren-Button — Implementierer-Wahl).**
+   Verhalten ist identisch und folgt dem vom PO bestätigten Ablauf:
+   - **Toggle aus:** Analyse läuft wie immer; im Ergebnis steht der FAKTENCHECK-Block jetzt als
+     getrennte Liste Meinungen / Interpretationen / Behauptungen. Keine Web-Verifikation.
+   - **Toggle an:** Nach der Analyse startet **automatisch** ein zweiter Durchlauf
+     (Fortschritt + Abbrechen), der **nur** die Behauptungen prüft; das Ergebnis wird als
+     zusätzlicher Abschnitt an die Analyse angehängt.
+
+---
+
+## Begriffe & Benennung
+
+| Begriff | Bedeutung |
+| --- | --- |
+| **Stufe 1 / Dekonstruktion** | Das ausgebaute `FAKTENCHECK`-Modul im Haupt-SOMAS-Lauf. Trennt Meinung/Interpretation/Behauptung. |
+| **Stufe 2 / Verifikation** | Separater Web-Recherche-Lauf, der nur die Behauptungen prüft. Ausgabe-Überschrift im Dokument: `### FAKTENCHECK · VERIFIKATION`. |
+| **Verifikationsmodell** | Das vom Nutzer pro Lauf gewählte Modell für Stufe 2 (sollte web-fähig sein). |
+
+> **Hinweis zur Namenswahl:** Perplexity schlug „VERIFIKATION/DEKONSTRUKTION" als neuen
+> Modulnamen vor. Wir behalten bewusst `FAKTENCHECK` als **Modul-Identifier** (Statistik-/
+> Kompatibilitätsgründe) und nutzen „VERIFIKATION" nur als **Label des Stufe-2-Abschnitts**.
+
+---
+
+## Harte Constraints (nicht brechen)
+
+1. **Modul-Statistik bleibt intakt.** `rating_store.VALID_MODULES` enthält `FAKTENCHECK`, und
+   `extract_module_from_result()` erkennt das Modul per Regex `^###\s*FAKTENCHECK\b`
+   (case-insensitive, MULTILINE). Der **Modul-Header in Stufe 1 muss exakt `### FAKTENCHECK`
+   bleiben** (Sub-Header der Trennung darunter sind frei). Sonst bricht die Modul-Statistik
+   (DB-Schema v3). Kein neuer Modulname, keine geänderte Header-Form.
+2. **Anti-Monotonie/Modulpool unverändert.** `ALL_MODULES` (prompt_builder) und `VALID_MODULES`
+   (rating_store) bleiben 6 Module mit denselben Namen.
+3. **Erzwingen des Moduls** bei aktiver Verifikation läuft über den **bestehenden**
+   `custom_module`-Mechanismus (`_apply_custom_overrides` → „PFLICHT-MODUL: …"). Keine neue
+   Forcing-Logik erfinden — nur erweitern: bei `custom_module == "FAKTENCHECK"` zusätzlich die
+   Konstante `FAKTENCHECK_FORMAT` injizieren (s. PR 1). So ist das parsbare Format in **jedem**
+   Preset garantiert, auch in den namens-only-Templates.
+4. **API-Keys** kommen zur Laufzeit aus dem Keyring (`get_api_key`); niemals serialisieren.
+
+---
+
+## Ziel-Ausgabe (Referenz-Layout)
+
+### Stufe 1 – neues FAKTENCHECK-Output-Format (im Analyse-Ergebnis)
+
+```markdown
+### FAKTENCHECK
+**Meinungen:**
+1. <subjektive Wertung des Sprechers, nicht prüfbar>
+2. …
+
+**Interpretationen:**
+1. <Deutung/Schlussfolgerung des Sprechers, nicht direkt prüfbar>
+2. …
+
+**Behauptungen (überprüfbar):**
+1. <wichtigste/prüfrelevanteste falsifizierbare Tatsachenaussage>
+2. <nächstrelevante …>
+3. <…>
+```
+
+Regeln (im Modultext zu verankern): Eine Behauptung = ein nummerierter Punkt, je eine
+**einzelne, in sich abgeschlossene, falsifizierbare** Aussage; keine Meinungswörter, kein
+Konjunktiv der Wertung; das Modell fällt hier **noch kein Urteil**. **Alle drei Blöcke werden
+nach Prüf-/Diskurs-Relevanz absteigend geordnet** (wichtigste zuerst); triviale, unstrittige
+Selbstverständlichkeiten kommen ans Ende bzw. werden weggelassen.
+
+### Stufe 2 – Verifikations-Abschnitt (wird an die Analyse angehängt)
+
+```markdown
+---
+
+### FAKTENCHECK · VERIFIKATION
+*Geprüft mit {{ model_name }} ({{ provider_name }}) am {{ date }}*
+{% if claims_capped %}*Geprüft: die {{ checked_count }} von {{ total_count }} nach Relevanz priorisierten Behauptungen.*{% endif %}
+
+**1. „<Behauptung 1>"**
+- **Verdikt:** bestätigt
+- **Begründung:** <1–2 Sätze>
+- **Quelle:** <URL / Titel>
+
+**2. „<Behauptung 2>"**
+- **Verdikt:** nicht überprüfbar
+- **Begründung:** <…>
+- **Quelle:** —
+
+#### Quellen
+1. <url>
+2. <url>
+```
+
+Verdikt-Werte exakt: `bestätigt` | `teilweise bestätigt` | `widerlegt` | `nicht überprüfbar`.
+
+---
+
+## Bestehende Schnittstellen (verifiziert, zur Wiederverwendung)
+
+```python
+# src/core/api_client.py
+def create_client(provider_id: str, api_key: str) -> LLMClient        # bereits extrahiert (v0.9.0)
+class LLMClient(ABC):
+    def send_prompt(self, prompt: str, model: str) -> APIResponse
+@dataclass
+class APIResponse:
+    status: APIStatus; content: str = ""; error_message: str = ""; model_used: str = ""
+    provider_used: str = ""; tokens_used: int = 0; citations: list[str] = []
+    duration_seconds: float = 0.0
+
+# src/config/api_config.py
+def get_api_key(provider_id: str) -> str
+
+# src/core/prompt_builder.py
+def build_prompt(video_info, config, questions="", preset_name=None, perspective=None,
+                 anti_monotony_hint="", custom_system_prompt=None, custom_module=None) -> str
+def build_prompt_from_transcript(title, author, transcript, config, url=None, questions="",
+                 preset_name=None, is_auto_transcript=False, perspective=None,
+                 anti_monotony_hint="", custom_system_prompt=None, custom_module=None) -> str
+def normalize_markdown_headings(text: str) -> str
+def _apply_custom_overrides(rendered, custom_system_prompt=None, custom_module=None) -> str  # PFLICHT-MODUL
+
+# src/core/rating_store.py
+VALID_MODULES = frozenset({... "FAKTENCHECK"})
+def extract_module_from_result(store, analysis_id, result_text) -> str | None  # Regex ^###\s*FAKTENCHECK\b
+
+# src/gui/provider_model_picker.py  (aus v0.9.0)
+class ProviderModelPicker(QWidget):
+    selection_changed = pyqtSignal()
+    def get_selection(self) -> ModelChoice | None
+    def set_selection(self, choice: ModelChoice) -> None
+    def set_enabled(self, enabled: bool) -> None
+
+# src/gui/collapsible_section.py
+class CollapsibleSection(QWidget): ...  # set_content_widget / set_summary / expand / collapse
+
+# src/core/comparison_item.py
+@dataclass
+class ModelChoice:  # provider_id, model_id, model_name, provider_name  → wiederverwenden
+```
+
+---
+
+## Übersicht der Änderungen
+
+| # | Bereich | Datei(en) |
+| --- | --- | --- |
+| A | `FAKTENCHECK_FORMAT`-Konstante + Injektion via `_apply_custom_overrides`; nur die zwei beschreibenden Templates aktualisieren | `src/core/prompt_builder.py`, `templates/somas_prompt.txt`, `somas_prompt_transcript.txt` |
+| B | Claim-Parser + Cap + Verifikations-Prompt + Output-Cleaner | `src/core/prompt_builder.py` |
+| C | Datenmodell Verifikation | `src/core/verification_item.py` (neu) |
+| D | Worker Stufe 2 | `src/core/verification_worker.py` (neu) |
+| E | Rendering-Template Stufe 2 | `templates/somas_verification.txt` (neu) |
+| F | GUI-Integration (Toggle + Picker + Auto-Anhang) | `src/gui/main_window.py`, ggf. `settings`-Defaults |
+| G | Doku & Version | `CLAUDE.md`, `README.md`, `docs/`, Versionskonstante |
+
+---
+
+## Implementierung
+
+### PR 1: FAKTENCHECK-Format als Konstante + Injektion (Stufe 1)
+
+> **Wichtige Bestandsaufnahme (verifiziert im Code).** Die Module werden NICHT überall gleich
+> beschrieben:
+> - `somas_prompt.txt`, `somas_prompt_transcript.txt`: jedes Modul **mit voller Beschreibung**
+>   (FAKTENCHECK hat dort vollständigen Anweisungstext).
+> - `somas_standard.txt`, `somas_linkedin.txt`, `somas_minimal.txt`, `somas_academia.txt`:
+>   Module **nur als Namen** in einer Komma-Zeile (z. B. „MODUL-AUSWAHL: KRITIK, ZITATE, …,
+>   FAKTENCHECK"). **Kein** Beschreibungstext zum Ersetzen vorhanden.
+>
+> Daher NICHT „in allen Templates den Eintrag ersetzen", sondern: **eine Quelle der Wahrheit +
+> gezielte Injektion** (Begründung: das parsbare 3-Block-Format ist strikt nur im
+> Verifikationsfall nötig, und dort wird das Modul ohnehin erzwungen → ein einziger Code-Pfad).
+
+**1) Konstante (Single Source of Truth) in `prompt_builder.py`:**
+
+```python
+FAKTENCHECK_FORMAT = (
+    "FAKTENCHECK-FORMAT — gib den Abschnitt GENAU so aus (Header exakt '### FAKTENCHECK'):\n"
+    "**Meinungen:** subjektive Wertungen (nicht prüfbar), nummeriert.\n"
+    "**Interpretationen:** Deutungen/Schlussfolgerungen (nicht direkt prüfbar), nummeriert.\n"
+    "**Behauptungen (überprüfbar):** je eine einzelne, in sich abgeschlossene, falsifizierbare\n"
+    "Tatsachenaussage pro Punkt, nummeriert; neutral und kontextfrei formuliert (ohne\n"
+    "Meinungswörter); KEIN Urteil über Wahr/Falsch.\n"
+    "Ordne JEDEN Block nach Relevanz absteigend (wichtigste zuerst): zentral für Kernthese/\n"
+    "Hauptthema und/oder strittig bzw. folgenreich im Diskurs. Triviale Selbstverständlichkeiten\n"
+    "NICHT auflisten bzw. ans Ende stellen."
+)
+```
+
+Hier — und **nur hier** — leben die exakten Vertrags-Marker (`**Meinungen:**`,
+`**Interpretationen:**`, `**Behauptungen (überprüfbar):**`), auf die der Parser (PR 2) angewiesen
+ist. Kein Duplikat in mehreren Dateien → kein stiller Marker-Drift.
+
+**2) Injektion beim erzwungenen Modul (kritischer Pfad = Verifikation):**
+`_apply_custom_overrides()` erweitern: Wenn `custom_module == "FAKTENCHECK"`, nicht nur die
+„PFLICHT-MODUL: …"-Zeile voranstellen, sondern zusätzlich `FAKTENCHECK_FORMAT` einfügen. So
+erhält das Modell das vollständige Format **in JEDEM Preset** (auch den namens-only-Presets),
+unabhängig vom Template. Für andere erzwungene Module bleibt das Verhalten unverändert.
+
+**2b) Zeichenlimit für den Verifikationslauf aufheben.** Problem: Das Antwort-Zeichenlimit
+eines Presets (z. B. Minimal 800, LinkedIn 2.200) begrenzt, *wie viele* Behauptungen das Modell
+ausgibt — und schneidet die Liste ab, bevor das Top-N-Capping (PR 2) greifen kann. Lösung:
+Dieselbe FAKTENCHECK-Injektion ergänzt eine explizite, **vorangestellte** Klausel, die das
+Gesamtzeichenlimit **nur für diesen Lauf** aufhebt, z. B.:
+
+```
+HINWEIS: Für diesen Lauf ist ein etwaiges Gesamtzeichenlimit AUFGEHOBEN. Die Vollständigkeit
+der relevanz-sortierten Behauptungsliste hat Vorrang vor Kürze.
+```
+
+Da diese Klausel **vor** dem (im Template späteren) `GESAMTZEICHENLIMIT`-Text steht und
+spezifischer formuliert ist, überschreibt sie das Limit zuverlässig — **ohne** dass die vier
+namens-only-Template-Limitzeilen editiert werden müssen. Greift ausschließlich bei aktiver
+Verifikation (Modul erzwungen); **normale Analysen behalten ihr Preset-Limit unverändert.**
+
+**3) Organische Wahl (Verifikation aus, Modell wählt frei):** Nur die zwei beschreibenden
+Templates `somas_prompt.txt` und `somas_prompt_transcript.txt` bekommen die FAKTENCHECK-Modul-
+beschreibung auf das neue Format aktualisiert (gleicher Wortlaut wie die Konstante). Die vier
+namens-only-Presets bleiben unverändert (sie listen *alle* Module nur per Name — Status quo).
+
+**Constraint:** Header bleibt exakt `### FAKTENCHECK` (Modul-Statistik, s. o.).
+
+> **Bewusst dokumentierte Grenze:** Wird bei *ausgeschalteter* Verifikation in einem
+> namens-only-Preset organisch FAKTENCHECK gewählt, erscheint NICHT zwingend das strukturierte
+> 3-Block-Format (nur der Modulname ist bekannt) — das ist akzeptiert, da die Verifikation (der
+> einzige Konsument des Formats) dann ohnehin aus ist. Bei *eingeschalteter* Verifikation ist
+> das Format über die Injektion (Punkt 2) in allen Presets garantiert.
+>
+> **Zeichenlimit:** Die Limits (Minimal 800, LinkedIn 2.200 …) gelten für die ANTWORT, nicht für
+> den Prompt — die Injektion bläht also den Prompt, nicht das Antwortbudget. Bei aktiver
+> Verifikation in sehr knappen Presets soll das Modell den Block **Behauptungen** priorisieren;
+> der Parser toleriert fehlende/kürzere Meinungen-/Interpretationen-Blöcke (s. PR 2).
+
+---
+
+### PR 2: prompt_builder — Claim-Parser, Verifikations-Prompt, Cleaner
+
+Neue Funktionen in `src/core/prompt_builder.py`:
+
+```python
+def extract_claims_from_faktencheck(analysis_text: str) -> list[str]:
+    """Extrahiert NUR die nummerierten Punkte unter '**Behauptungen (überprüfbar):**'
+    aus dem FAKTENCHECK-Abschnitt einer SOMAS-Analyse.
+
+    - Findet den '### FAKTENCHECK'-Block (bis zur nächsten '### …'-Überschrift oder EOF).
+    - Innerhalb des Blocks: ab Marker 'Behauptungen' bis zum nächsten '**…:**'-Sub-Header
+      bzw. Blockende die nummerierten Zeilen (`^\s*\d+[\.\)]\s+`) einsammeln.
+    - Reihenfolge bleibt erhalten = bereits nach Relevanz sortiert (Stufe 1 ordnet
+      absteigend). KEINE Kappung hier — die Liste ist VOLLSTÄNDIG.
+    - Whitespace/Markup säubern; leere Einträge verwerfen.
+    - Robust: Marker case-insensitive; toleriert fehlende Meinungen/Interpretationen.
+
+    Returns: Liste ALLER Behauptungs-Strings in Relevanz-Reihenfolge (kann leer sein).
+    """
+
+def cap_claims(claims: list[str], max_claims: int) -> tuple[list[str], int]:
+    """Wendet die konfigurierbare Obergrenze deterministisch an.
+
+    Args:
+        claims: Vollständige, relevanz-sortierte Behauptungsliste.
+        max_claims: Obergrenze (0 = unbegrenzt).
+    Returns:
+        (gekappte_liste, total_count). Bei max_claims==0 oder len<=max: unverändert.
+        Die App entscheidet anhand len(capped) < total_count, ob 'claims_capped' True ist.
+    """
+
+def build_verification_prompt(claims: list[str], language: str = "Deutsch",
+                              source_hint: str = "") -> str:
+    """Baut den Stufe-2-Prompt. Enthält AUSSCHLIESSLICH die Behauptungen (keine Meinungen,
+    kein Transkript) → sauberer Handoff an das Web-Modell.
+
+    Vorgaben an das Modell:
+    - Prüfe jede Behauptung per Websuche/aktuellem Wissen.
+    - Pro Behauptung EXAKT: Verdikt (eines von: bestätigt | teilweise bestätigt | widerlegt |
+      nicht überprüfbar), 1–2 Sätze Begründung, mindestens eine Quelle (URL/Titel) bzwingend
+      bei bestätigt/teilweise/widerlegt; bei 'nicht überprüfbar' Quelle '—'.
+    - Festes Markdown-Format (siehe Ziel-Ausgabe Stufe 2), KEIN Vorspann, keine Meta.
+    - Keine neuen Behauptungen erfinden; nur die vorgelegten prüfen, in gegebener Reihenfolge.
+    Sprache der Ausgabe = `language`.
+    """
+
+def clean_verification_output(text: str) -> str:
+    """Analog clean_synthesis_output(): umschließende Code-Fences und führende Leer-/
+    Überschriftenzeilen entfernen, damit der Abschnitt sauber angehängt werden kann."""
+```
+
+**Hinweis:** Behauptungen werden als nummerierte Liste in den Prompt geschrieben, der Header
+`### FAKTENCHECK · VERIFIKATION` selbst wird **nicht** vom Modell verlangt, sondern beim
+Rendern (PR 3) deterministisch gesetzt — Modell liefert nur die Pro-Behauptung-Blöcke.
+
+---
+
+### PR 3: Datenmodell + Rendering-Template
+
+**`src/core/verification_item.py` (neu):**
+
+```python
+from dataclasses import dataclass, field
+from typing import Optional
+from .comparison_item import ModelChoice   # wiederverwenden
+
+@dataclass
+class VerificationConfig:
+    claims: list[str]             # bereits gekappte Liste (Top-N), die geprüft wird
+    model: ModelChoice
+    language: str = "Deutsch"
+    total_claims: int = 0         # Gesamtzahl VOR Kappung (für Transparenzzeile)
+    source_title: str = ""        # für Anzeige/Debug
+    source_url: str = ""
+
+@dataclass
+class VerificationResult:
+    config: VerificationConfig
+    status: str = "pending"       # pending|running|done|error|skipped
+    raw_output: str = ""          # bereinigte Modell-Ausgabe (Pro-Behauptung-Blöcke)
+    rendered_section: str = ""    # fertiger Markdown-Abschnitt inkl. Header
+    citations: list[str] = field(default_factory=list)
+    tokens_used: int = 0
+    error_message: str = ""
+```
+
+**Kappung:** Sie passiert **vor** dem Worker (in `main_window`, s. PR 5): die GUI ruft
+`extract_claims_from_faktencheck()` → `cap_claims(..., max_claims)`, setzt `claims` =
+gekappte Liste und `total_claims` = Gesamtzahl. So bleibt der Worker frei von UI-/
+Settings-Wissen und ist headless testbar.
+
+**`templates/somas_verification.txt` (neu, Jinja2):**
+
+```jinja2
+---
+
+### FAKTENCHECK · VERIFIKATION
+*Geprüft mit {{ model_name }} ({{ provider_name }}){% if date %} am {{ date }}{% endif %}*
+{% if claims_capped %}
+*Geprüft: die {{ checked_count }} von {{ total_count }} nach Relevanz priorisierten Behauptungen.*
+{% endif %}
+
+{{ verification_body }}
+{% if citations %}
+
+#### Quellen
+{% for c in citations %}
+{{ loop.index }}. {{ c }}
+{% endfor %}
+{% endif %}
+```
+
+`verification_body` = `clean_verification_output(response.content)`. `citations` =
+dedupliziert aus `APIResponse.citations` (falls der Provider welche liefert; Perplexity tut
+das). Unicode-Bereinigung für Export wie gehabt (`export.sanitize_unicode_for_export()`),
+Speicherung `utf-8-sig`.
+
+---
+
+### PR 4: `VerificationWorker(QThread)`
+
+**`src/core/verification_worker.py` (neu)** — bewusst schlank (ein API-Call), Muster wie
+`ComparisonWorker`/`APIWorker`:
+
+```python
+class VerificationWorker(QThread):
+    status_changed   = pyqtSignal(str)        # "running" | "done" | "error"
+    finished_ok      = pyqtSignal(str, object)  # rendered_section, VerificationResult
+    error_occurred   = pyqtSignal(str)        # message
+
+    def __init__(self, config: VerificationConfig, debug_logger=None) -> None: ...
+
+    def run(self) -> None:
+        # 0) Guard: keine Behauptungen → finished_ok mit Hinweis-Abschnitt
+        #    ("_Keine überprüfbaren Behauptungen gefunden._") ODER status "skipped".
+        # 1) Key prüfen (get_api_key(model.provider_id)); fehlt → error_occurred.
+        # 2) client = create_client(provider, key)
+        # 3) prompt = build_verification_prompt(claims, language, source_hint)
+        # 4) resp = client.send_prompt(prompt, model.model_id)   (+ Debug-Logging wie ComparisonWorker._send)
+        # 5) Leer-/Fehler-Guard (status != RECEIVED oder leerer content) → error_occurred.
+        # 6) body = clean_verification_output(resp.content)
+        # 7) rendered = Jinja2 somas_verification.txt (model_name/provider_name/date/body/citations)
+        # 8) finished_ok.emit(rendered, result)
+    def cancel(self) -> None: ...
+```
+
+**Fehlerstrategie (nicht fatal für die Analyse):** Stufe 2 ist ein optionaler Anhang. Schlägt
+sie fehl (Key fehlt, leerer Content, Exception), bleibt die **Analyse erhalten**; es wird ein
+deutlich gekennzeichneter Platzhalter-Abschnitt angehängt
+(`_Verifikation fehlgeschlagen: <Grund>. Behauptungen siehe FAKTENCHECK-Block oben._`) und
+eine GUI-Warnung gezeigt. Kein harter Absturz, kein Verlust der Analyse.
+
+---
+
+### PR 5: GUI-Integration (`main_window.py`)
+
+**UI-Elemente (in einer `CollapsibleSection("Faktencheck-Verifikation")`, nahe den
+API-Controls / analog zur Modellvergleich-Section):**
+
+1. `QCheckBox` „Behauptungen verifizieren (Faktencheck Stufe 2)" → `self.verify_checkbox`.
+   (Alternativ Toggle-Button — funktional identisch; Implementierer-Wahl.)
+2. Ein `ProviderModelPicker` „Verifikationsmodell" → `self.verify_picker`. Letzte Auswahl
+   merken (analog `get_last_model`). Nur aktiv, wenn Checkbox an.
+3. Dezenter Hinweistext: „Empfohlen: web-fähiges Modell (z. B. Perplexity Sonar)."
+4. Obergrenze: `QSpinBox` „Max. zu prüfende Behauptungen" (Default 10, `0 = unbegrenzt`),
+   persistiert in `user_preferences.json` (Key z. B. `verification_max_claims`). Alternativ
+   nur in `settings_dialog.py`, falls die Section nicht überfrachtet werden soll — PO-Wunsch:
+   konfigurierbar, Platzierung Implementierer-Wahl.
+
+**Verdrahtung in den bestehenden Einzelanalyse-Pfad (kein neuer Start-Button):**
+
+1. **Beim Start der Analyse** (vorhandener `_start_api_call`/`_on_generate_prompt`): Wenn
+   `verify_checkbox.isChecked()` → den Haupt-Prompt mit **erzwungenem Modul** bauen, d. h.
+   `custom_module="FAKTENCHECK"` an `build_prompt(...)` / `build_prompt_from_transcript(...)`
+   übergeben (nutzt bestehenden `_apply_custom_overrides`). So liegt die Behauptungsliste
+   garantiert vor. Picker-Auswahl vorher validieren (gesetzt? sonst Hinweis, kein Start).
+2. **Nach erfolgreicher Analyse** (im bestehenden `response_received`-Slot, nach Anzeige +
+   `extract_module_from_result(...)`): wenn Verifikation aktiv →
+   `all_claims = extract_claims_from_faktencheck(result_text)`;
+   `claims, total = cap_claims(all_claims, max_claims_setting)`;
+   `VerificationConfig(claims=claims, total_claims=total, …)` bauen; `VerificationWorker`
+   starten; Controls sperren; Fortschritt über
+   `verify_section.set_summary("Verifikation läuft … (Modell X)")` + „Abbrechen".
+   Die Transparenzzeile (`claims_capped = len(claims) < total`) rendert PR 3.
+3. **`finished_ok(section, result)`** → `section` an `self.result_text` **anhängen** (an die
+   bestehende Analyse, nicht ersetzen). Export enthält damit Analyse **inkl.**
+   Verifikationsabschnitt.
+4. **`error_occurred`** → Platzhalter-Abschnitt anhängen + `QMessageBox`-Warnung; Analyse
+   bleibt erhalten.
+5. **Gegenseitiger Ausschluss:** Ist der Modellvergleich-Toggle aktiv, Verifikation deaktivieren
+   (ausgrauen) und umgekehrt — wie der bestehende Ausschluss Einzelanalyse ↔ Modellvergleich.
+   (Verifikation im Modellvergleich = Backlog, s. Nicht-Ziele.)
+
+**Soft-Warnung Web-Fähigkeit:** Beim Start, wenn das gewählte Verifikationsmodell nicht als
+web-fähig bekannt ist (Heuristik: Provider == „perplexity" ODER OpenRouter-Modell-ID mit
+`:online` / bekannter Web-Plugin), eine **nicht-blockierende** `QMessageBox`-Info: „Das
+gewählte Modell hat evtl. keinen Web-Zugriff; Verifikation kann ungenau sein." Start trotzdem
+erlaubt (PO darf experimentieren).
+
+---
+
+### PR 6: Doku & Version
+
+- Versionsbump **v0.10.0** (zentrale Versionskonstante / Titelleiste / `debug_logger.APP_VERSION`).
+- `CLAUDE.md`: neue **Phase 12 „Faktencheck-Verifikation"**; Modul-Liste um
+  `verification_item.py`, `verification_worker.py`, `somas_verification.txt` ergänzen;
+  Template-/Modulbeschreibung (FAKTENCHECK neu) aktualisieren.
+- `README.md`: Feature-Abschnitt + Changelog 0.10.0.
+- `docs/` Landing Page: kurzer Abschnitt zur zweistufigen Faktenprüfung.
+- Diese Spec verbleibt in `specs/`.
+
+---
+
+## Reihenfolge
+
+1. **PR 1** FAKTENCHECK-Templates (Stufe-1-Format)
+2. **PR 2** `prompt_builder`: Parser + Verifikations-Prompt + Cleaner (headless testbar)
+3. **PR 3** `verification_item.py` + `somas_verification.txt`
+4. **PR 4** `VerificationWorker`
+5. **PR 5** GUI-Integration
+6. **PR 6** Doku/Version
+
+PRs 1–4 sind ohne GUI testbar (Parser-Unit-Tests + Worker-Lauf headless mit echtem Key).
+
+---
+
+## Verification (pro PR)
+
+- **PR 1:** `build_prompt(..., custom_module="FAKTENCHECK")` enthält `FAKTENCHECK_FORMAT` inkl.
+  aller drei Vertrags-Marker — **auch mit einem namens-only-Preset** (z. B. Standard, Minimal).
+  Eine reale Analyse mit erzwungenem FAKTENCHECK liefert die drei Sub-Header in der vorgegebenen
+  Form; `extract_module_from_result()` erkennt weiterhin `FAKTENCHECK`. Andere erzwungene Module
+  (z. B. KRITIK) bleiben unverändert (keine Format-Injektion).
+- **PR 2 (Unit-Tests, `tests/test_faktencheck_parser.py`):**
+  - Standardfall: 3 Behauptungen werden korrekt extrahiert, Meinungen/Interpretationen ignoriert.
+  - Robustheit: fehlender Meinungen-/Interpretationen-Block; abweichende Nummerierung (`1)` vs `1.`);
+    case-insensitive Marker; kein FAKTENCHECK-Block → `[]`.
+  - `cap_claims`: 14 Claims + N=10 → 10 zurück, total=14; N=0 → alle, total unverändert;
+    len<=N → unverändert; Reihenfolge bleibt erhalten (Relevanz).
+  - `build_verification_prompt` enthält alle Behauptungen, **keine** Meinungen, Verdikt-Skala,
+    festes Format; `clean_verification_output` entfernt Fences/Vorspann.
+- **PR 3:** Template rendert mit/ohne Quellenliste sauber; Sonderzeichen/Umlaute korrekt.
+- **PR 4:** End-to-end Stufe 2 mit Perplexity Sonar + 3 Beispielbehauptungen; Fehlerpfade:
+  fehlender Key, leerer Content (→ Platzhalter, keine Exception), leere Claim-Liste (→ skipped).
+- **PR 5:** Toggle an → Hauptlauf erzwingt FAKTENCHECK, Stufe 2 läuft automatisch, Abschnitt
+  wird **angehängt** (Analyse bleibt erhalten); Abbrechen funktioniert; gegenseitiger Ausschluss
+  mit Modellvergleich; Export enthält beide Teile.
+- **PR 6:** Version/Changelog/Docs konsistent.
+
+**Empfohlener Verifikations-Schlussschritt (Subagent/Review):** Einen realen Lauf auf einem
+Test-Video (siehe CLAUDE.md TEST_URLS) durchführen und prüfen, dass (a) Stufe 1 saubere,
+einzelne Behauptungen liefert, (b) Stufe 2 für jede Behauptung Verdikt+Quelle bringt und (c)
+keine Meinungen in den Stufe-2-Prompt gelangen (Debug-Log des Verifikations-Requests prüfen).
+
+---
+
+## Nicht-Ziele (bewusst ausgeschlossen für v0.10.0)
+
+1. **Verifikation im Modellvergleich** und **im Batch-Modus** — zunächst nur Einzelanalyse-Pfad.
+   Datenmodell/Worker sind so geschnitten, dass eine spätere Einbindung möglich ist (Backlog).
+2. **Automatische DB-Persistenz der Verdikte** (eigene Tabelle, Auswertung) — MVP hängt den
+   Abschnitt nur an den Ergebnistext an. Strukturierte Speicherung = Backlog.
+3. **Strikt geparstes Verdikt-Datenmodell pro Behauptung** (Claim→Verdict-Objekte) — v0.10.0
+   vertraut der Markdown-Ausgabe des Modells (wie bei der Einzelanalyse). Parsing in Felder ist
+   Backlog (Voraussetzung für DB-Persistenz/Statistik).
+4. **Erzwungener Web-Zugriff / Provider-seitige Tool-Use-Konfiguration** — wir warnen nur weich;
+   echte Online-Erzwingung (z. B. OpenRouter `:online`-Auto-Suffix) ist Backlog.
+5. **PDF-Export** des verifizierten Dokuments — wie gehabt nachgelagert durch den PO.
+6. **App-Einstellmöglichkeit für die Preset-Zeichenlimits** (Limits pro Preset in der GUI
+   regelbar) — vom PO gewünscht, aber bewusst später (~1 Monat). Backlog.
+7. **Academia-Zeichenlimit entfernen/lockern** — vom PO angedacht, aber unabhängig vom
+   Verifikations-Feature; nicht mitten in v0.10.0 anfassen. Separater kleiner Backlog-Punkt.
+
+---
+
+## Geklärte Entscheidungen (PO)
+
+1. **Architektur:** Hybrid — Trennung fest im Hauptlauf (FAKTENCHECK), Verifikation optional. ✅
+2. **Bestehendes Modul:** FAKTENCHECK erweitern/ersetzen, Identifier bleibt `FAKTENCHECK`. ✅
+3. **Verifikationsmodell:** Nutzer wählt pro Lauf (ProviderModelPicker, alle 4 Provider). ✅
+4. **Stufe-2-Output:** Verdikt + Quelle pro Behauptung; 4-stufige Verdikt-Skala. ✅
+5. **Auslöser:** Toggle (Checkbox oder Button); aus = nur getrennte Liste, an = Auto-Stufe-2
+   nach der Analyse mit Fortschritt + Abbrechen. ✅
+6. **Relevanz-Priorisierung:** Stufe 1 ordnet alle drei Blöcke nach Relevanz absteigend;
+   triviale Selbstverständlichkeiten ans Ende. ✅
+7. **Obergrenze:** Nur **Behauptungen** werden gekappt (app-seitig, deterministisch), Default
+   **N = 10**, konfigurierbar (`0 = unbegrenzt`). **Meinungen/Interpretationen**: nur ranken,
+   **kein Cap** (vollständige Anzeige). ✅
+8. **Sprache der Stufe-2-Ausgabe:** Default = Analysesprache (`config.language`), aktuell also
+   Deutsch (alle Templates sind deutsch). Der `language`-Parameter wird durch Stufe 1 → Parser
+   → Stufe 2 durchgereicht, damit die Verifikation **forward-kompatibel** ist: Sobald englische
+   Templates existieren (Backlog „Englisch-Support"), zieht die Verifikationssprache automatisch
+   mit. Keine separate Sprachwahl-UI in v0.10.0. ✅
+9. **Zeichenlimit bei Verifikation:** Bei erzwungenem FAKTENCHECK wird das Antwort-Zeichenlimit
+   **nur für diesen Lauf** aufgehoben (Klausel in der Injektion, s. PR 1.2b), damit die
+   vollständige Behauptungsliste für das Top-N-Capping entsteht. Normale Analysen behalten ihr
+   Preset-Limit. **Kein** neues Limit im FAKTENCHECK-Modul selbst (PO-Wunsch). ✅
+
+---
+
+## Offene Detailfragen für die Umsetzung (Kurt → ggf. PO)
+
+- Derzeit keine offenen Punkte. Alle Designentscheidungen sind getroffen (s. o.).

--- a/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
+++ b/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
@@ -718,3 +718,13 @@ hoch/runter beide funktionsfähig, in der Verifikations- UND der Vergleichs-Sect
 - **Debug-Logging nach Schritt/Feature benennen** (= Backlog #8, präzisiert): Logs trennen pro
   Call bereits in eigene Ordner (kein Datenverlust); sie sind nur nach Modell+Zeitstempel
   benannt. Nice-to-have: zusätzlich `feature`/`step` im Ordnernamen für leichtere Zuordnung.
+- **Einzelanalyse-Export an Modellvergleich-Kopf angleichen (PO-Wunsch).** `export.get_markdown_content`
+  hat aktuell nur „# Analyse · SOMAS: {Titel}" + Metazeilen. Es fehlen ggü. `somas_comparison.txt`:
+  der große Videotitel als H1, der Untertitel „**{Kanal}, YT**" und der Thumbnail-Link. Umsetzung:
+  in `get_markdown_content` bei YouTube-`video_info` einen Kopfblock voranstellen —
+  `# {title}` / `**{channel}, YT**` / `![Thumbnail zum Video „{title}"]({maxres})` — via bestehendem
+  `extract_video_id` + `build_thumbnail_urls` (YouTube-only; im Transkript-Modus kein Thumbnail/kein
+  „YT"). **Design-Entscheidung (PO):** neuer Titel-Block **ersetzt** das bisherige
+  „# Analyse · SOMAS: {Titel}" (Empfehlung, kein doppelter Titel bei Einzelanalyse) — Metazeilen
+  (Kanal/Dauer/URL/Modell) bleiben darunter. Optional analog der Fallback-Blockquote (sd/hq) wie im
+  Vergleich. Naheliegend zusammen mit dem Retry-Button als v0.10.1.

--- a/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
+++ b/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
@@ -670,3 +670,51 @@ wartungsintensiv). Backlog.
 > **Reihenfolge:** Diese Nachbesserungen vor PR 6 (Doku/Version), damit die Doku den finalen
 > Stand abbildet. Danach erneuter PO-Test (idealerweise: ein web-fähiges Modell via `:online`
 > oder Perplexity → Stufe 2 liefert echte, klickbare Quellen).
+
+---
+
+## Nachbesserungen Runde 3 (GUI-Bugs aus PO-Test 2)
+
+> Kontext: Erfolgreicher Web-Lauf (OpenRouter DeepSeek V4 Pro + `:online`) — Stufe 2 lieferte
+> echte, klickbare Quellen und angemessen skeptische Verdikte (mehrfach „nicht überprüfbar/—",
+> ein „widerlegt", ein „teilweise bestätigt"); der N3-Riegel wirkt sichtbar. Zwei GUI-Bugs:
+
+**G1 — `:online`-Checkbox unsichtbar im checked-Zustand UND QSpinBox-Buttons defekt
+(gemeinsame Ursache, Pflicht).** Beide Widgets (`verify_online_checkbox`, `verify_max_spin`)
+sind schmucklos. Ursache liegt in der geteilten `CollapsibleSection`: `_body.setStyleSheet(...)`
+setzt `background-color`/`border` **ohne Selektor** → kaskadiert auf alle Kind-Widgets. Geerbte
+`border`-Regeln schalten bei QCheckBox/QSpinBox die Compound-Subcontrols von nativ auf QSS:
+Checkbox-`::indicator` im checked-Zustand ohne Aussehen → unsichtbar; QSpinBox `::up-/down-button`
+→ eine Taste tot. (Der Autor hat das für die Header-Labels bereits mit
+`border:none;background:transparent` umgangen — bestätigt die Kaskade. Betrifft latent auch den
+Modellvergleich.) **Zentraler Fix in `collapsible_section.py` (~3 Zeilen, behebt es überall):**
+
+```python
+self._body.setObjectName("collapsibleBody")
+self._body.setStyleSheet(
+    "#collapsibleBody { background-color: white; border: 1px solid #C0C0C0; "
+    "border-top: none; border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }"
+)
+```
+
+Der ID-Selektor begrenzt die Regel auf das Body-Widget; Kinder rendern wieder nativ (SpinBox:
+vertikale Pfeile, beide funktionsfähig). Analog auch in `_update_arrow()` (dort wird der Header
+neu gestylt — Body bleibt unberührt, kein Eingriff nötig). Ein horizontales −/+ am SpinBox wäre
+rein optional/kosmetisch.
+
+**Verifikation: kurzer Re-Test nach dem Fix** — Checkbox sichtbar im checked-Zustand, SpinBox
+hoch/runter beide funktionsfähig, in der Verifikations- UND der Vergleichs-Section.
+
+---
+
+## Backlog / Folge-Version (v0.10.1+)
+
+- **„Verifikation erneut versuchen"-Button (hohe Priorität, PO-Wunsch).** Bei
+  fehlgeschlagener/abgebrochener Stufe 2 nur die Verifikation wiederholen — Claims via
+  `extract_claims_from_faktencheck(result_text)` aus dem vorhandenen Ergebnis ziehen und einen
+  neuen `VerificationWorker` starten, **ohne** die komplette Analyse erneut zu fahren. Spart
+  Kosten/Zeit und ist genau der ausfallanfällige Teil. Naheliegend kombiniert mit der
+  Fehler-Anzeige (`_on_verify_error` setzt einen Retry-Button aktiv).
+- **Debug-Logging nach Schritt/Feature benennen** (= Backlog #8, präzisiert): Logs trennen pro
+  Call bereits in eigene Ordner (kein Datenverlust); sie sind nur nach Modell+Zeitstempel
+  benannt. Nice-to-have: zusätzlich `feature`/`step` im Ordnernamen für leichtere Zuordnung.

--- a/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
+++ b/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
@@ -555,6 +555,12 @@ keine Meinungen in den Stufe-2-Prompt gelangen (Debug-Log des Verifikations-Requ
    regelbar) — vom PO gewünscht, aber bewusst später (~1 Monat). Backlog.
 7. **Academia-Zeichenlimit entfernen/lockern** — vom PO angedacht, aber unabhängig vom
    Verifikations-Feature; nicht mitten in v0.10.0 anfassen. Separater kleiner Backlog-Punkt.
+8. **Debug-Logging für zweistufige Läufe** — aktuell überschreibt im Einzelanalyse-Pfad der
+   Stufe-2-Call (Verifikation) das Stufe-1-Log (Analyse), bzw. pro Lauf bleibt nur der letzte
+   Request/Response erhalten (im PO-Test beobachtet). Wünschenswert: beide Schritte je Lauf
+   behalten und klar nach `feature`/`step` benennen (analog ComparisonWorker-Meta), damit ein
+   Verifikationslauf Analyse + Verifikation nebeneinander dokumentiert. Vom PO vorgemerkt,
+   Backlog (nicht v0.10.0).
 
 ---
 
@@ -586,3 +592,81 @@ keine Meinungen in den Stufe-2-Prompt gelangen (Debug-Log des Verifikations-Requ
 ## Offene Detailfragen für die Umsetzung (Kurt → ggf. PO)
 
 - Derzeit keine offenen Punkte. Alle Designentscheidungen sind getroffen (s. o.).
+
+---
+
+## Nachbesserungen nach PO-Test (Runde 2)
+
+> Kontext: Der PO-Test (PR 1–5) lief mechanisch korrekt, deckte aber einen **Parser-Bug**
+> (inline-nummerierte Behauptungen) und Schwächen rund um No-Web-Modelle auf. Befund:
+> - Lauf Claude Sonnet 4.6 (kein Web): Quellen-URLs **erfunden** (Story real, Links nicht
+>   auffindbar) — bestätigt die Halluzinationsgefahr.
+> - Lauf DeepSeek V4 via OpenRouter (ohne `:online` → ebenfalls kein Web): Stufe 2 meldete
+>   „keine Behauptungen". Ursache war NICHT Web, sondern der Parser: DeepSeek schrieb den
+>   FAKTENCHECK inline (`**Behauptungen (überprüfbar):** 1. … 2. …` in EINER Zeile);
+>   `extract_claims_from_faktencheck` sucht nur in Folgezeilen → `[]`. Headless reproduziert.
+
+**N1 — Parser-Robustheit (Pflicht, kritisch).** `extract_claims_from_faktencheck` muss
+Behauptungen erkennen, egal ob (a) je Punkt auf eigener Zeile, (b) inline hinter dem
+Sub-Header, (c) inline auf einer Folgezeile. Ansatz: Claim-Region = Resttext der
+Sub-Header-Zeile **nach** dem Marker + Folgezeilen bis zum nächsten `**…:**`-Sub-Header /
+`###` / Blockende, zusammengefügt; dann an **fortlaufenden** Nummern-Grenzen splitten (nach
+Item *n* folgt Grenze *n+1*), **nicht** an beliebigen Zahlen — sonst zerreißt „am 7. Oktober
+2023" einen Claim. Tests ergänzen: Inline-Block (echte DeepSeek-Fixture, s. u.),
+Claim mit interner Datums-Zahl, gemischt zeilen-/inline.
+
+**Reale Fixture (aus PO-Debug-Log, DeepSeek V4 Pro — als Test-Input verwenden):** Der
+FAKTENCHECK kam komplett inline (jeder Block in EINER Zeile, Punkte mit „ N. " getrennt):
+
+```text
+### FAKTENCHECK
+**Meinungen:** 1. Sanders pro-israelische Positionen sind nicht radikal. 2. Der Ausschluss aus dem Film ist eine himmelschreiende Ungerechtigkeit. 3. Die Branche war links, weil es in Mode war, nicht aus politischer Überzeugung. 4. Der moralische Kompass vieler Künstler ist verbogen. 5. Die Gesellschaft verroht zunehmend.
+**Interpretationen:** 1. Sanders Ausschluss zeigt ein strukturelles Problem der Filmbranche. 2. Anti-israelische Propaganda hat breite Gesellschaftsschichten erfasst. 3. Die Dominanz anti-israelischer Erzählungen schüchtert Politiker ein. 4. Antisemitismus stammt vor allem aus arabisch-muslimischen und linken Milieus. 5. Die deutsche Erinnerungskultur ist unzureichend.
+**Behauptungen (überprüfbar):** 1. Sander wurde wegen ihrer pro-israelischen Haltung aus dem Film „Die Todessehnsucht der Maria Om" ausgeschlossen. 2. Sie verfasste das Drehbuch mit einem Co-Autor. 3. Sie führt seit Ende 2024 einen Rechtsstreit gegen die Produktionsfirma. 4. Das Kammergericht Berlin entschied in der Berufung zugunsten der Produktionsfirma. 5. Auf dem Campus der Burg Giebichenstein Kunsthochschule Halle wurden Flugblätter verteilt, die die jüdische Gemeinde als rassistisch und zionistisch bezeichnen und ihre Ausladung fordern. 6. Die Hochschulleitung entfernte diese Plakate. 7. Sander gibt an, täglich hunderte Hassnachrichten mit Holocaust-Bezug zu erhalten. 8. Sie steht eigenen Angaben zufolge in Kontakt mit dem LKA. 9. Auf Berliner Free-Palestine-Demos riefen Teilnehmer arabischsprachig „Tod den Juden". 10. Auf der Sonnenallee in Berlin-Neukölln hängen Palästina-Flaggen. 11. Sander veröffentlichte im August 2025 ein kritisches Video über Teile der Schauspielbranche. 12. Die jüdische Gemeinde Halle organisierte Synagogenbesuche für Studierende.
+```
+
+Erwartung: `extract_claims_from_faktencheck(...)` liefert **genau 12** Behauptungen (1–12),
+Meinungen/Interpretationen tauchen NICHT auf. Zusätzlich ein **synthetischer** Test mit interner
+Datums-Zahl, z. B. inline `… 1. Sie reiste am 7. Oktober 2023 nach Israel. 2. Das Gesetz gilt
+seit 2021.` → muss **2** Claims liefern (nicht an „7." zerteilen).
+
+> **Clean-Handoff verifiziert (PO-Debug-Log):** Der reale Stufe-2-Request (Claude-Lauf) enthält
+> `Faktenprüfer` + `ZU PRÜFENDE BEHAUPTUNGEN`, aber KEINE Meinungs-/Interpretations-Inhalte und
+> nicht die Marker „Meinungen"/„Interpretationen". Das Design (nur Behauptungen in Stufe 2) ist
+> damit am echten Lauf bestätigt.
+
+**N2 — Format schärfen (Pflicht).** In `FAKTENCHECK_FORMAT` + den 2 beschreibenden Templates
+ergänzen: „Schreibe jeden nummerierten Punkt auf eine EIGENE Zeile (Zeilenumbruch nach jedem
+Punkt); keine Inline-Aufzählung." Belt-and-suspenders zum robusteren Parser (N1).
+
+**N3 — Prompt-Riegel gegen erfundene Quellen (Pflicht).** In `build_verification_prompt`
+ergänzen: „Gib nur Quellen an, die du tatsächlich abgerufen/verifiziert hast. Erfinde keine
+URLs. Kannst du eine Behauptung nicht mit einer belastbaren Quelle verifizieren, nutze Verdikt
+‚nicht überprüfbar' und Quelle ‚—'." Die bisherige Pflicht-Quelle-Regel entsprechend lockern
+(Quelle nur verpflichtend, wenn tatsächlich verifiziert).
+
+**N4 — Dialog mit Abbrechen / Trotzdem fortfahren.** `_verification_preflight`: bei
+No-Web-Modell statt `QMessageBox.information` ein `QMessageBox.question` mit Buttons
+**„Abbrechen"** (→ `return False`, Section bleibt offen zum Modellwechsel) und **„Trotzdem
+fortfahren"** (→ `return True`).
+
+**N5 — Web-Disclaimer im Output.** Wenn `_looks_web_capable(model)` False ist, `VerificationConfig`
+ein Flag mitgeben (z. B. `web_unverified: bool = False`); `somas_verification.txt` rendert dann
+eine sichtbare Zeile, z. B.: „⚠️ Verifikationsmodell ohne bestätigten Web-Zugriff — Quellen
+ungeprüft, können unzuverlässig oder erfunden sein." Bleibt dauerhaft im Dokument (anders als
+die Vorab-Warnung).
+
+**N6 — `:online`-Schalter für OpenRouter.** Eine Checkbox „Web-Suche (:online)" am
+Verifikations-Picker, die bei OpenRouter-Modellen das Suffix `:online` an die `model_id` anhängt
+(falls nicht schon vorhanden). Damit ist echter Web-Zugriff aktivierbar; `_looks_web_capable`
+greift dann automatisch (→ keine Warnung, kein Disclaimer). Hinweis: `ProviderModelPicker` wird
+auch 3× im Modellvergleich genutzt — die Checkbox so kapseln, dass sie die bestehende
+Vergleichs-Nutzung nicht stört (nur bei OpenRouter-Auswahl wirksam/sichtbar).
+
+**Nicht in dieser Runde:** breitere Web-Erkennungs-Heuristik (PO-Entscheidung — der
+`:online`-Schalter macht den Fall explizit; pauschale Modelllisten sind unzuverlässig und
+wartungsintensiv). Backlog.
+
+> **Reihenfolge:** Diese Nachbesserungen vor PR 6 (Doku/Version), damit die Doku den finalen
+> Stand abbildet. Danach erneuter PO-Test (idealerweise: ein web-fähiges Modell via `:online`
+> oder Perplexity → Stufe 2 liefert echte, klickbare Quellen).

--- a/specs/STARTPROMPT_v0.10.0_fuer_Kurt.md
+++ b/specs/STARTPROMPT_v0.10.0_fuer_Kurt.md
@@ -1,0 +1,70 @@
+# Startprompt für Kurt (Claude Code) — v0.10.0 Faktencheck-Verifikation
+
+> Diesen Text als ersten Auftrag in Claude Code (VS Code) einfügen. Die vollständige
+> Architektur steht in `specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md`.
+
+---
+
+Du bist der **Programmierer** im SOMAS-Team (Rollen: Architekt = Claude.ai, Programmierer =
+du/Claude Code, Supervisor/PO = Thorsten). Setze das Feature **v0.10.0 — Faktencheck-
+Verifikation (Hybrid)** um.
+
+## Zuerst lesen
+1. `specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md` — **vollständig**. Sie ist die
+   verbindliche Vorgabe (Architektur, PRs, Datenmodelle, Output-Formate, Tests, Nicht-Ziele).
+2. `CLAUDE.md` — Projektkontext, Code-Stil, GUI-Konventionen.
+3. Querverweise zur Orientierung: `src/core/comparison_worker.py`, `comparison_item.py`,
+   `src/core/prompt_builder.py`, `src/gui/provider_model_picker.py`, `src/core/rating_store.py`.
+
+## Auftrag
+Implementiere die PRs **in der in der Spec genannten Reihenfolge** (PR 1 → PR 6). PRs 1–4 sind
+ohne GUI testbar — baue und teste sie zuerst headless, GUI (PR 5) zuletzt gegen den fertigen
+Worker. Halte dich an die in der Spec definierten Funktionssignaturen und Datei-/Modulnamen.
+
+## Harte Constraints (nicht brechen)
+- **Modul-Header bleibt exakt `### FAKTENCHECK`** — sonst bricht die Modul-Statistik
+  (`rating_store.VALID_MODULES`, Regex `^###\s*FAKTENCHECK\b`, DB-Schema v3).
+- **Modul erzwingen** über den **bestehenden** `custom_module`-Mechanismus
+  (`_apply_custom_overrides`), keine neue Forcing-Logik.
+- `ALL_MODULES` / `VALID_MODULES` bleiben **6 Module** mit denselben Namen.
+- **Kappung app-seitig & deterministisch** (`cap_claims`), Default **N = 10**, konfigurierbar
+  (`0 = unbegrenzt`). Cap **nur auf Behauptungen**; Meinungen/Interpretationen ranken, **kein Cap**.
+- **Stufe-2-Prompt enthält ausschließlich die nackten Behauptungen** — keine Meinungen, kein
+  Transkript (der zentrale Qualitätspunkt).
+- **API-Keys** zur Laufzeit aus dem Keyring (`get_api_key`), niemals serialisieren.
+- **Sprache der Stufe-2-Ausgabe = `config.language`** (Default Deutsch); Parameter durchreichen,
+  nicht hartkodieren.
+- Stufe-2-Fehler ist **nicht fatal**: Analyse bleibt erhalten, Platzhalter-Abschnitt + Warnung.
+
+## Code-Konventionen (aus CLAUDE.md)
+- PEP 8, Type Hints, Google-Style-Docstrings. Deutsche Kommentare OK, Code/Variablen englisch.
+- `try/except` um alle externen API-Calls; Nutzerfehler über `QMessageBox`; Logging über
+  `debug_logger`.
+- Neue Tests anlegen (`tests/test_faktencheck_parser.py` lt. Spec) und **bestehende Tests grün
+  halten**.
+
+## Zeilenenden / Diffs (wichtig)
+Das Repo hat **CRLF-Churn und kein `.gitattributes`**. Bewahre die vorhandenen Zeilenenden der
+bearbeiteten Dateien; **keine Voll-Reformatierung** ganzer Dateien (z. B. kein globales
+Umstellen von Quotes/Einrückung), damit die Diffs klein und reviewbar bleiben. Ändere nur, was
+das Feature braucht.
+
+## Nicht-Ziele (NICHT umsetzen)
+Keine Verifikation in Batch/Modellvergleich, keine DB-Persistenz der Verdikte, kein
+strukturiertes Claim→Verdict-Datenmodell, keine erzwungene Web-Konfiguration, kein PDF-Export,
+**kein Englisch-/i18n-Umbau** (eigenes späteres Vorhaben).
+
+## Definition of Done
+- Alle PRs umgesetzt, Funktionssignaturen wie spezifiziert.
+- Versionsbump **v0.10.0** (zentrale Konstante / `debug_logger.APP_VERSION` / Titelleiste).
+- `CLAUDE.md` (neue Phase 12 + Modul-/Templateliste), `README.md` (Changelog), `docs/` aktualisiert.
+- Tests grün (neu + bestehend).
+- **Ein realer End-to-End-Lauf** auf einem Test-Video (siehe `CLAUDE.md` TEST_URLS): prüfen,
+  dass Stufe 1 saubere, einzelne, relevanz-sortierte Behauptungen liefert und Stufe 2 pro
+  Behauptung Verdikt + Quelle bringt. Im **Debug-Log des Stufe-2-Requests verifizieren, dass
+  keine Meinungen in den Prompt gelangt sind.**
+
+## Arbeitsweise
+Wenn etwas in der Spec unklar oder widersprüchlich ist, oder eine Annahme nötig wäre: **frag den
+PO (Thorsten), bevor du sie triffst.** Lieber einmal zu viel fragen als eine falsche Annahme
+einbauen. Arbeite PR für PR und halte nach jedem PR kurz inne, damit der PO testen/abnehmen kann.

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.9.1"
+APP_VERSION = "0.10.0"
 
 
 class DebugLogger:

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -608,6 +608,161 @@ def clean_synthesis_output(text: str) -> str:
     return "\n".join(lines).strip()
 
 
+# --- Faktencheck-Verifikation: Parser / Prompt / Cleaner (v0.10.0) ---
+
+# Verdikt-Skala (exakt) für die Stufe-2-Ausgabe.
+VERDICT_VALUES = (
+    "bestätigt", "teilweise bestätigt", "widerlegt", "nicht überprüfbar",
+)
+
+
+def extract_claims_from_faktencheck(analysis_text: str) -> list[str]:
+    """Extrahiert NUR die nummerierten Behauptungen aus dem FAKTENCHECK-Block.
+
+    Sucht den Stufe-1-Block ``### FAKTENCHECK`` (Dekonstruktion, NICHT
+    ``### FAKTENCHECK · VERIFIKATION``) bis zur nächsten ``### ``-Überschrift
+    bzw. EOF. Innerhalb des Blocks werden ab dem Sub-Header ``Behauptungen``
+    die nummerierten Zeilen (``1.`` oder ``1)``) bis zum nächsten
+    ``**…:**``-Sub-Header bzw. Blockende eingesammelt.
+
+    Die Reihenfolge bleibt erhalten (Stufe 1 ordnet bereits nach Relevanz
+    absteigend). Es findet KEINE Kappung statt — die Liste ist vollständig.
+
+    Args:
+        analysis_text: Der vollständige SOMAS-Analysetext.
+
+    Returns:
+        Liste aller Behauptungs-Strings in Relevanz-Reihenfolge (kann leer sein).
+    """
+    if not analysis_text:
+        return []
+
+    lines = analysis_text.splitlines()
+
+    # 1) FAKTENCHECK-Header der Dekonstruktion finden (nicht den VERIFIKATION-Header)
+    header_re = re.compile(r"^\s*###\s*FAKTENCHECK\b", re.IGNORECASE)
+    start = None
+    for i, line in enumerate(lines):
+        if header_re.match(line) and "VERIFIKATION" not in line.upper():
+            start = i
+            break
+    if start is None:
+        return []
+
+    # 2) Blockende = nächste '### '-Überschrift oder EOF
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if re.match(r"^\s*###\s", lines[j]):
+            end = j
+            break
+    block = lines[start + 1:end]
+
+    # 3) Sub-Header 'Behauptungen' finden (Zeilenanfang, optional fett)
+    behaupt_re = re.compile(r"^\s*\*{0,2}\s*Behauptungen", re.IGNORECASE)
+    claim_start = None
+    for k, line in enumerate(block):
+        if behaupt_re.match(line):
+            claim_start = k + 1
+            break
+    if claim_start is None:
+        return []
+
+    # 4) Nummerierte Zeilen bis zum nächsten '**…:**'-Sub-Header bzw. Blockende
+    num_re = re.compile(r"^\s*\d+[\.\)]\s+(.*\S)\s*$")
+    next_subheader_re = re.compile(r"^\s*\*\*[^*]+:\*\*")
+    claims: list[str] = []
+    for line in block[claim_start:]:
+        if next_subheader_re.match(line):
+            break
+        m = num_re.match(line)
+        if not m:
+            continue
+        text = m.group(1).strip().strip('*"„“”').strip()
+        if text:
+            claims.append(text)
+    return claims
+
+
+def cap_claims(claims: list[str], max_claims: int) -> tuple[list[str], int]:
+    """Wendet die konfigurierbare Obergrenze deterministisch an.
+
+    Args:
+        claims: Vollständige, relevanz-sortierte Behauptungsliste.
+        max_claims: Obergrenze (0 = unbegrenzt).
+
+    Returns:
+        Tupel ``(gekappte_liste, total_count)``. Bei ``max_claims == 0`` oder
+        ``len(claims) <= max_claims`` bleibt die Liste unverändert (Kopie). Die
+        App entscheidet anhand ``len(capped) < total``, ob gekappt wurde.
+    """
+    total = len(claims)
+    if max_claims and max_claims > 0 and total > max_claims:
+        return list(claims[:max_claims]), total
+    return list(claims), total
+
+
+def build_verification_prompt(
+    claims: list[str],
+    language: str = "Deutsch",
+    source_hint: str = "",
+) -> str:
+    """Baut den Stufe-2-Verifikations-Prompt.
+
+    Enthält AUSSCHLIESSLICH die Behauptungen (keine Meinungen, kein Transkript)
+    → sauberer Handoff an das web-fähige Modell.
+
+    Args:
+        claims: Die (bereits gekappte) Liste der zu prüfenden Behauptungen.
+        language: Sprache der Ausgabe (Default Deutsch).
+        source_hint: Optionaler Kontext (z.B. Titel/URL) — nur als Orientierung.
+
+    Returns:
+        Der fertige Prompt-String.
+    """
+    numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims, 1))
+    verdicts = " | ".join(VERDICT_VALUES)
+    hint = f"\nKONTEXT (nur zur Orientierung): {source_hint}\n" if source_hint else ""
+
+    return (
+        f"Du bist ein sorgfältiger Faktenprüfer. Prüfe die folgenden Behauptungen "
+        f"einzeln per Websuche bzw. aktuellem Wissen. Antworte in {language}.\n"
+        f"{hint}\n"
+        f"REGELN:\n"
+        f"- Prüfe AUSSCHLIESSLICH die vorgelegten Behauptungen, in gegebener "
+        f"Reihenfolge. Erfinde keine neuen Behauptungen.\n"
+        f"- Gib pro Behauptung EXAKT dieses Markdown-Format aus (kein Vorspann, "
+        f"keine Meta, keine Einleitung):\n"
+        f"\n"
+        f"**<Nr>. „<Behauptung>\"**\n"
+        f"- **Verdikt:** <eines von: {verdicts}>\n"
+        f"- **Begründung:** <1–2 Sätze>\n"
+        f"- **Quelle:** <URL oder Titel; bei 'nicht überprüfbar' ein Gedankenstrich: —>\n"
+        f"\n"
+        f"- Bei Verdikt 'bestätigt', 'teilweise bestätigt' oder 'widerlegt' ist "
+        f"mindestens EINE belastbare Quelle (URL/Titel) verpflichtend.\n"
+        f"- Verwende ausschließlich die vier genannten Verdikt-Werte, exakt geschrieben.\n"
+        f"\n"
+        f"ZU PRÜFENDE BEHAUPTUNGEN:\n"
+        f"{numbered}\n"
+    )
+
+
+def clean_verification_output(text: str) -> str:
+    """Bereinigt die Stufe-2-Ausgabe für das saubere Anhängen.
+
+    Analog zu :func:`clean_synthesis_output`: entfernt umschließende Code-Fences
+    sowie führende Leer-/Überschriftenzeilen, damit der Verifikationsabschnitt
+    sauber unter den deterministischen Header gerendert werden kann.
+
+    Args:
+        text: Roh-Ausgabe des Verifikationsmodells.
+
+    Returns:
+        Bereinigter Markdown-Text (kann leer sein).
+    """
+    return clean_synthesis_output(text)
+
+
 def get_preset_info_for_display(preset: PromptPreset) -> str:
     """Erstellt einen Info-String für die GUI-Anzeige.
     

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -637,6 +637,10 @@ def extract_claims_from_faktencheck(analysis_text: str) -> list[str]:
     if not analysis_text:
         return []
 
+    # Überschriften normalisieren ('###FAKTENCHECK' -> '### FAKTENCHECK'), damit die
+    # Block-Ende-Erkennung (^\s*###\s) auch bei fehlendem Leerzeichen greift.
+    analysis_text = normalize_markdown_headings(analysis_text)
+
     lines = analysis_text.splitlines()
 
     # 1) FAKTENCHECK-Header der Dekonstruktion finden (nicht den VERIFIKATION-Header)

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -231,6 +231,34 @@ def load_template(template_name: str = "somas_prompt.txt") -> str:
         return f.read()
 
 
+# --- Faktencheck-Verifikation (v0.10.0) ---
+
+# Single Source of Truth für das parsbare Stufe-1-Format. Enthält die exakten
+# Vertrags-Marker (**Meinungen:** / **Interpretationen:** / **Behauptungen
+# (überprüfbar):**), auf die der Claim-Parser (extract_claims_from_faktencheck)
+# angewiesen ist. Wird bei erzwungenem FAKTENCHECK injiziert (s. _apply_custom_overrides),
+# damit das Format in JEDEM Preset garantiert ist – auch in den namens-only-Templates.
+FAKTENCHECK_FORMAT = (
+    "FAKTENCHECK-FORMAT — gib den Abschnitt GENAU so aus (Header exakt '### FAKTENCHECK'):\n"
+    "**Meinungen:** subjektive Wertungen (nicht prüfbar), nummeriert.\n"
+    "**Interpretationen:** Deutungen/Schlussfolgerungen (nicht direkt prüfbar), nummeriert.\n"
+    "**Behauptungen (überprüfbar):** je eine einzelne, in sich abgeschlossene, falsifizierbare\n"
+    "Tatsachenaussage pro Punkt, nummeriert; neutral und kontextfrei formuliert (ohne\n"
+    "Meinungswörter); KEIN Urteil über Wahr/Falsch.\n"
+    "Ordne JEDEN Block nach Relevanz absteigend (wichtigste zuerst): zentral für Kernthese/\n"
+    "Hauptthema und/oder strittig bzw. folgenreich im Diskurs. Triviale Selbstverständlichkeiten\n"
+    "NICHT auflisten bzw. ans Ende stellen."
+)
+
+# Hebt das Antwort-Zeichenlimit NUR für den erzwungenen FAKTENCHECK-Lauf (Verifikation) auf,
+# damit die vollständige, relevanz-sortierte Behauptungsliste für das Top-N-Capping entsteht.
+# Steht vor dem (im Template späteren) GESAMTZEICHENLIMIT-Text und überschreibt es so.
+FAKTENCHECK_NO_LIMIT_HINT = (
+    "HINWEIS: Für diesen Lauf ist ein etwaiges Gesamtzeichenlimit AUFGEHOBEN. Die "
+    "Vollständigkeit der relevanz-sortierten Behauptungsliste hat Vorrang vor Kürze."
+)
+
+
 def _apply_custom_overrides(
     rendered: str,
     custom_system_prompt: Optional[str] = None,
@@ -256,6 +284,11 @@ def _apply_custom_overrides(
             f"PFLICHT-MODUL: Verwende ausschließlich das Modul '{custom_module}'. "
             f"Keine andere Wahl ist erlaubt."
         )
+        # v0.10.0: Bei erzwungenem FAKTENCHECK zusätzlich das parsbare 3-Block-Format
+        # und die Limit-Aufhebung injizieren (deckt alle Presets ab, auch namens-only).
+        if custom_module.strip().upper() == "FAKTENCHECK":
+            parts.append(FAKTENCHECK_NO_LIMIT_HINT)
+            parts.append(FAKTENCHECK_FORMAT)
 
     if parts:
         parts.append(rendered)

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -247,7 +247,9 @@ FAKTENCHECK_FORMAT = (
     "Meinungswörter); KEIN Urteil über Wahr/Falsch.\n"
     "Ordne JEDEN Block nach Relevanz absteigend (wichtigste zuerst): zentral für Kernthese/\n"
     "Hauptthema und/oder strittig bzw. folgenreich im Diskurs. Triviale Selbstverständlichkeiten\n"
-    "NICHT auflisten bzw. ans Ende stellen."
+    "NICHT auflisten bzw. ans Ende stellen.\n"
+    "Schreibe JEDEN nummerierten Punkt auf eine EIGENE Zeile (Zeilenumbruch nach jedem Punkt); "
+    "KEINE Inline-Aufzählung mehrerer Punkte in einer Zeile."
 )
 
 # Hebt das Antwort-Zeichenlimit NUR für den erzwungenen FAKTENCHECK-Lauf (Verifikation) auf,
@@ -616,14 +618,60 @@ VERDICT_VALUES = (
 )
 
 
+def _split_consecutive_claims(region: str) -> list[str]:
+    """Zerlegt eine Behauptungs-Region an FORTLAUFENDEN Nummern-Grenzen.
+
+    Funktioniert für zeilen- UND inline-nummerierte Listen. Getrennt wird nur an
+    der jeweils nächsten erwarteten Nummer (n → n+1), damit interne Zahlen wie
+    'am 7. Oktober 2023' einen Claim nicht zerreißen.
+
+    Args:
+        region: Der zusammengefügte Behauptungs-Text (eine oder mehrere Zeilen).
+
+    Returns:
+        Liste der Behauptungs-Strings in Reihenfolge.
+    """
+    # Eine Nummer ist nur dann eine echte Claim-Grenze, wenn sie (a) fortlaufend
+    # ist (n -> n+1) UND (b) am Zeilenanfang oder nach satzbeendender Interpunktion
+    # steht. So zerreißt eine interne Zahl wie 'am 3. März 2020' den Claim nicht,
+    # selbst wenn sie zufällig der nächsten erwarteten Nummer entspricht.
+    chosen: list[tuple[int, int]] = []
+    expected = None
+    for m in re.finditer(r"(\d+)[\.\)]\s+", region):
+        pos, num = m.start(), int(m.group(1))
+        before = region[:pos].rstrip()
+        boundary_ctx = (
+            pos == 0
+            or region[pos - 1] == "\n"
+            or (before != "" and before[-1] in ".!?:)")
+        )
+        if not boundary_ctx:
+            continue
+        if expected is None:
+            expected = num
+        if num == expected:
+            chosen.append((pos, m.end()))
+            expected += 1
+
+    claims: list[str] = []
+    for i, (_pos, end) in enumerate(chosen):
+        stop = chosen[i + 1][0] if i + 1 < len(chosen) else len(region)
+        text = region[end:stop].strip().strip('*"„“”').strip()
+        text = re.sub(r"\s+", " ", text).strip()
+        if text:
+            claims.append(text)
+    return claims
+
+
 def extract_claims_from_faktencheck(analysis_text: str) -> list[str]:
     """Extrahiert NUR die nummerierten Behauptungen aus dem FAKTENCHECK-Block.
 
     Sucht den Stufe-1-Block ``### FAKTENCHECK`` (Dekonstruktion, NICHT
     ``### FAKTENCHECK · VERIFIKATION``) bis zur nächsten ``### ``-Überschrift
-    bzw. EOF. Innerhalb des Blocks werden ab dem Sub-Header ``Behauptungen``
-    die nummerierten Zeilen (``1.`` oder ``1)``) bis zum nächsten
-    ``**…:**``-Sub-Header bzw. Blockende eingesammelt.
+    bzw. EOF. Ab dem Sub-Header ``Behauptungen`` wird die Claim-Region (Resttext
+    der Header-Zeile + Folgezeilen bis zum nächsten Sub-Header/Terminator)
+    eingesammelt und an fortlaufenden Nummern getrennt — robust gegen
+    zeilen- UND inline-nummerierte Listen.
 
     Die Reihenfolge bleibt erhalten (Stufe 1 ordnet bereits nach Relevanz
     absteigend). Es findet KEINE Kappung statt — die Liste ist vollständig.
@@ -661,30 +709,37 @@ def extract_claims_from_faktencheck(analysis_text: str) -> list[str]:
             break
     block = lines[start + 1:end]
 
-    # 3) Sub-Header 'Behauptungen' finden (Zeilenanfang, optional fett)
-    behaupt_re = re.compile(r"^\s*\*{0,2}\s*Behauptungen", re.IGNORECASE)
-    claim_start = None
+    # 3) Sub-Header 'Behauptungen' finden; er kann die Behauptungen bereits
+    #    inline enthalten (z.B. DeepSeek: '**Behauptungen (überprüfbar):** 1. … 2. …').
+    behaupt_re = re.compile(
+        r"^\s*\*{0,2}\s*Behauptungen[^:]*:\s*\*{0,2}\s*(.*)$", re.IGNORECASE
+    )
+    next_subheader_re = re.compile(r"^\s*\*\*[^*]+:\*\*")
+    stop_re = re.compile(
+        r'^\s*(QUELLE|ANSCHLUSSFRAGE|WICHTIG|HINWEIS|TRANSKRIPT|---|""")',
+        re.IGNORECASE,
+    )
+    header_idx = None
+    inline_rest = ""
     for k, line in enumerate(block):
-        if behaupt_re.match(line):
-            claim_start = k + 1
+        m = behaupt_re.match(line)
+        if m:
+            header_idx = k
+            inline_rest = m.group(1)
             break
-    if claim_start is None:
+    if header_idx is None:
         return []
 
-    # 4) Nummerierte Zeilen bis zum nächsten '**…:**'-Sub-Header bzw. Blockende
-    num_re = re.compile(r"^\s*\d+[\.\)]\s+(.*\S)\s*$")
-    next_subheader_re = re.compile(r"^\s*\*\*[^*]+:\*\*")
-    claims: list[str] = []
-    for line in block[claim_start:]:
-        if next_subheader_re.match(line):
+    # 4) Claim-Region = Resttext der Header-Zeile + Folgezeilen bis zum nächsten
+    #    Sub-Header / Abschnitts-Terminator / Blockende; dann an Nummern splitten.
+    region_parts = [inline_rest]
+    for line in block[header_idx + 1:]:
+        if next_subheader_re.match(line) or stop_re.match(line):
             break
-        m = num_re.match(line)
-        if not m:
-            continue
-        text = m.group(1).strip().strip('*"„“”').strip()
-        if text:
-            claims.append(text)
-    return claims
+        region_parts.append(line)
+    region = "\n".join(region_parts)
+
+    return _split_consecutive_claims(region)
 
 
 def cap_claims(claims: list[str], max_claims: int) -> tuple[list[str], int]:
@@ -742,8 +797,11 @@ def build_verification_prompt(
         f"- **Begründung:** <1–2 Sätze>\n"
         f"- **Quelle:** <URL oder Titel; bei 'nicht überprüfbar' ein Gedankenstrich: —>\n"
         f"\n"
-        f"- Bei Verdikt 'bestätigt', 'teilweise bestätigt' oder 'widerlegt' ist "
-        f"mindestens EINE belastbare Quelle (URL/Titel) verpflichtend.\n"
+        f"- Gib NUR Quellen an, die du tatsächlich abgerufen/verifiziert hast. "
+        f"Erfinde KEINE URLs. Kannst du eine Behauptung nicht mit einer belastbaren "
+        f"Quelle belegen, nutze Verdikt 'nicht überprüfbar' und Quelle '—'.\n"
+        f"- Eine Quelle ist nur dann verpflichtend, wenn die Behauptung tatsächlich "
+        f"verifiziert wurde (bestätigt / teilweise bestätigt / widerlegt).\n"
         f"- Verwende ausschließlich die vier genannten Verdikt-Werte, exakt geschrieben.\n"
         f"\n"
         f"ZU PRÜFENDE BEHAUPTUNGEN:\n"

--- a/src/core/verification_item.py
+++ b/src/core/verification_item.py
@@ -1,0 +1,56 @@
+"""Datenmodelle für die Faktencheck-Verifikation (Stufe 2, v0.10.0).
+
+VerificationConfig kapselt die (bereits gekappte) Behauptungsliste + das
+gewählte Verifikationsmodell; VerificationResult hält den Lauf-Zustand.
+Die Kappung passiert bewusst VOR dem Worker (in der GUI), damit der Worker
+frei von UI-/Settings-Wissen und headless testbar bleibt.
+"""
+
+from dataclasses import dataclass, field
+
+from .comparison_item import ModelChoice  # wiederverwenden
+
+
+@dataclass
+class VerificationConfig:
+    """Eingabe für einen Verifikationslauf.
+
+    Attributes:
+        claims: Bereits gekappte Liste (Top-N), die geprüft wird.
+        model: Das gewählte Verifikationsmodell.
+        language: Sprache der Ausgabe (Default Deutsch).
+        total_claims: Gesamtzahl der Behauptungen VOR der Kappung
+            (für die Transparenzzeile).
+        source_title: Optionaler Quellentitel (Anzeige/Debug).
+        source_url: Optionale Quellen-URL (Anzeige/Debug).
+    """
+
+    claims: list[str]
+    model: ModelChoice
+    language: str = "Deutsch"
+    total_claims: int = 0
+    source_title: str = ""
+    source_url: str = ""
+
+
+@dataclass
+class VerificationResult:
+    """Laufzeit-Zustand eines Verifikationslaufs.
+
+    Attributes:
+        config: Die zugrunde liegende VerificationConfig.
+        status: pending|running|done|error|skipped.
+        raw_output: Bereinigte Modell-Ausgabe (Pro-Behauptung-Blöcke).
+        rendered_section: Fertiger Markdown-Abschnitt inkl. Header.
+        citations: Deduplizierte Quellen-URLs (falls Provider welche liefert).
+        tokens_used: Token-Verbrauch.
+        error_message: Fehlermeldung bei status == "error".
+    """
+
+    config: VerificationConfig
+    status: str = "pending"
+    raw_output: str = ""
+    rendered_section: str = ""
+    citations: list[str] = field(default_factory=list)
+    tokens_used: int = 0
+    error_message: str = ""

--- a/src/core/verification_item.py
+++ b/src/core/verification_item.py
@@ -23,6 +23,8 @@ class VerificationConfig:
             (für die Transparenzzeile).
         source_title: Optionaler Quellentitel (Anzeige/Debug).
         source_url: Optionale Quellen-URL (Anzeige/Debug).
+        web_unverified: True, wenn das Modell keinen bestätigten Web-Zugriff hat
+            (rendert einen dauerhaften Disclaimer im Verifikationsabschnitt).
     """
 
     claims: list[str]
@@ -31,6 +33,7 @@ class VerificationConfig:
     total_claims: int = 0
     source_title: str = ""
     source_url: str = ""
+    web_unverified: bool = False
 
 
 @dataclass

--- a/src/core/verification_worker.py
+++ b/src/core/verification_worker.py
@@ -16,7 +16,7 @@ from PyQt6.QtCore import QThread, pyqtSignal
 
 from src.config.api_config import get_api_key
 
-from .api_client import APIStatus, create_client
+from .api_client import APIResponse, APIStatus, LLMClient, create_client
 from .debug_logger import APP_VERSION, DebugLogger
 from .prompt_builder import (
     build_verification_prompt,
@@ -139,7 +139,7 @@ class VerificationWorker(QThread):
         self.status_changed.emit("error")
         self.error_occurred.emit(message)
 
-    def _send(self, client, prompt: str, model_id: str):
+    def _send(self, client: LLMClient, prompt: str, model_id: str) -> APIResponse:
         """Sendet den Prompt, misst die Dauer und loggt optional (Debug)."""
         log_dir = None
         if self._debug_logger:
@@ -178,7 +178,7 @@ class VerificationWorker(QThread):
         return response
 
     @staticmethod
-    def _dedup(citations) -> list[str]:
+    def _dedup(citations: list[str] | None) -> list[str]:
         """Dedupliziert Quellen unter Erhalt der Reihenfolge."""
         seen: set[str] = set()
         result: list[str] = []

--- a/src/core/verification_worker.py
+++ b/src/core/verification_worker.py
@@ -205,6 +205,7 @@ class VerificationWorker(QThread):
             claims_capped=claims_capped,
             checked_count=len(cfg.claims),
             total_count=cfg.total_claims,
+            web_unverified=cfg.web_unverified,
             verification_body=body,
             citations=citations,
         )

--- a/src/core/verification_worker.py
+++ b/src/core/verification_worker.py
@@ -1,0 +1,215 @@
+"""QThread-Worker für die Faktencheck-Verifikation (Stufe 2, v0.10.0).
+
+Bewusst schlank: ein einzelner API-Call an das gewählte Verifikationsmodell,
+das ausschließlich die (bereits gekappten) Behauptungen prüft. Muster wie
+ComparisonWorker/APIWorker. Stufe 2 ist ein optionaler Anhang — Fehler sind
+NICHT fatal für die Analyse (die GUI hängt bei error_occurred einen
+Platzhalter an, statt die Analyse zu verlieren).
+"""
+
+import logging
+import time
+from datetime import datetime
+
+from jinja2 import Environment, FileSystemLoader
+from PyQt6.QtCore import QThread, pyqtSignal
+
+from src.config.api_config import get_api_key
+
+from .api_client import APIStatus, create_client
+from .debug_logger import APP_VERSION, DebugLogger
+from .prompt_builder import (
+    build_verification_prompt,
+    clean_verification_output,
+    get_template_dir,
+)
+from .verification_item import VerificationConfig, VerificationResult
+
+logger = logging.getLogger(__name__)
+
+NO_CLAIMS_SECTION = (
+    "---\n\n### FAKTENCHECK · VERIFIKATION\n"
+    "_Keine überprüfbaren Behauptungen gefunden._\n"
+)
+
+
+class VerificationWorker(QThread):
+    """Worker-Thread für einen Verifikationslauf (Stufe 2).
+
+    Signals:
+        status_changed(str): "running" | "done" | "error" | "skipped".
+        finished_ok(str, object): rendered_section, VerificationResult.
+        error_occurred(str): Fehlermeldung (nicht fatal für die Analyse).
+    """
+
+    status_changed = pyqtSignal(str)
+    finished_ok = pyqtSignal(str, object)
+    error_occurred = pyqtSignal(str)
+
+    def __init__(
+        self,
+        config: VerificationConfig,
+        debug_logger: DebugLogger | None = None,
+    ) -> None:
+        """Initialisiert den VerificationWorker.
+
+        Args:
+            config: Die Verifikations-Konfiguration (gekappte claims + Modell).
+            debug_logger: Optionaler DebugLogger für Request/Response-Logging.
+        """
+        super().__init__()
+        self._config = config
+        self._debug_logger = debug_logger
+        self._cancelled = False
+        self._result = VerificationResult(config=config)
+
+    @property
+    def result(self) -> VerificationResult:
+        """Gibt den aktuellen Lauf-Zustand zurück (GUI/Headless-Zugriff)."""
+        return self._result
+
+    def run(self) -> None:
+        """Führt den Verifikationslauf aus."""
+        cfg = self._config
+
+        # 0) Keine Behauptungen → übersprungen, aber sauberer Hinweis-Abschnitt.
+        if not cfg.claims:
+            self._result.status = "skipped"
+            self._result.rendered_section = NO_CLAIMS_SECTION
+            self.status_changed.emit("skipped")
+            self.finished_ok.emit(NO_CLAIMS_SECTION, self._result)
+            return
+
+        # 1) API-Key prüfen
+        key = get_api_key(cfg.model.provider_id)
+        if not key:
+            name = cfg.model.provider_name or cfg.model.provider_id
+            self._fail(f"Kein API-Key für Provider '{name}' konfiguriert.")
+            return
+
+        self._result.status = "running"
+        self.status_changed.emit("running")
+
+        try:
+            client = create_client(cfg.model.provider_id, key)
+
+            source_hint = ""
+            if cfg.source_title or cfg.source_url:
+                source_hint = " ".join(p for p in (cfg.source_title, cfg.source_url) if p)
+
+            prompt = build_verification_prompt(
+                cfg.claims, language=cfg.language, source_hint=source_hint
+            )
+
+            if self._cancelled:
+                return
+
+            resp = self._send(client, prompt, cfg.model.model_id)
+
+            if self._cancelled:
+                return
+
+            if resp.status != APIStatus.RECEIVED or not (resp.content or "").strip():
+                self._fail(resp.error_message or "Modell lieferte leeren Inhalt.")
+                return
+
+            body = clean_verification_output(resp.content)
+            citations = self._dedup(resp.citations)
+            self._result.raw_output = body
+            self._result.citations = citations
+            self._result.tokens_used = resp.tokens_used
+
+            rendered = self._render(body, citations)
+            self._result.rendered_section = rendered
+            self._result.status = "done"
+            self.status_changed.emit("done")
+            self.finished_ok.emit(rendered, self._result)
+
+        except Exception as e:  # noqa: BLE001 — Stufe-2-Fehler darf Analyse nicht verlieren
+            logger.exception("VerificationWorker: unerwarteter Fehler")
+            if not self._cancelled:
+                self._fail(str(e))
+
+    # --- Helfer ---
+
+    def _fail(self, message: str) -> None:
+        """Markiert den Lauf als fehlgeschlagen (nicht fatal) und meldet ihn."""
+        self._result.status = "error"
+        self._result.error_message = message
+        self.status_changed.emit("error")
+        self.error_occurred.emit(message)
+
+    def _send(self, client, prompt: str, model_id: str):
+        """Sendet den Prompt, misst die Dauer und loggt optional (Debug)."""
+        log_dir = None
+        if self._debug_logger:
+            endpoint = getattr(client, "BASE_URL", "") + getattr(client, "CHAT_ENDPOINT", "")
+            log_dir = self._debug_logger.log_request(
+                provider=getattr(client, "PROVIDER_ID", ""),
+                model=model_id,
+                endpoint=endpoint,
+                prompt=prompt,
+                meta={
+                    "app_version": APP_VERSION,
+                    "feature": "verification",
+                    "language": self._config.language,
+                    "claims_count": len(self._config.claims),
+                    "total_claims": self._config.total_claims,
+                },
+            )
+
+        start = time.time()
+        response = client.send_prompt(prompt, model_id)
+        duration = time.time() - start
+        response.duration_seconds = duration
+
+        if self._debug_logger:
+            ok = response.status == APIStatus.RECEIVED
+            self._debug_logger.log_response(
+                log_dir=log_dir,
+                status_code=200 if ok else 500,
+                content=response.content,
+                tokens={"total": response.tokens_used},
+                duration=duration,
+                model_used=response.model_used,
+                citations=response.citations,
+                error=None if ok else (response.error_message or "Fehler"),
+            )
+        return response
+
+    @staticmethod
+    def _dedup(citations) -> list[str]:
+        """Dedupliziert Quellen unter Erhalt der Reihenfolge."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for c in citations or []:
+            if c and c not in seen:
+                seen.add(c)
+                result.append(c)
+        return result
+
+    def _render(self, body: str, citations: list[str]) -> str:
+        """Rendert den Verifikationsabschnitt via Jinja2."""
+        cfg = self._config
+        env = Environment(
+            loader=FileSystemLoader(get_template_dir()),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+        template = env.get_template("somas_verification.txt")
+        claims_capped = len(cfg.claims) < cfg.total_claims
+        return template.render(
+            model_name=cfg.model.model_name or cfg.model.model_id,
+            provider_name=cfg.model.provider_name or cfg.model.provider_id,
+            date=datetime.now().strftime("%d.%m.%Y"),
+            claims_capped=claims_capped,
+            checked_count=len(cfg.claims),
+            total_count=cfg.total_claims,
+            verification_body=body,
+            citations=citations,
+        )
+
+    def cancel(self) -> None:
+        """Markiert den Worker als abgebrochen (Ergebnis wird ignoriert)."""
+        self._cancelled = True
+        logger.info("VerificationWorker Abbruch angefordert")

--- a/src/gui/collapsible_section.py
+++ b/src/gui/collapsible_section.py
@@ -94,10 +94,15 @@ class CollapsibleSection(QWidget):
         self._body.setSizePolicy(
             QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
         )
+        # ID-Selektor: begrenzt die Regel auf das Body-Widget selbst, damit sie
+        # NICHT auf Kind-Widgets kaskadiert. Sonst schaltet eine geerbte border-
+        # Regel QCheckBox/QSpinBox-Subcontrols von nativ auf QSS (unsichtbarer
+        # Checkbox-Haken, tote SpinBox-Taste).
+        self._body.setObjectName("collapsibleBody")
         self._body.setStyleSheet(
-            "background-color: white; "
+            "#collapsibleBody { background-color: white; "
             "border: 1px solid #C0C0C0; border-top: none; "
-            "border-bottom-left-radius: 4px; border-bottom-right-radius: 4px;"
+            "border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; }"
         )
         self._body_layout = QVBoxLayout(self._body)
         self._body_layout.setContentsMargins(10, 8, 10, 8)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -35,7 +35,7 @@ from src.gui.transcript_widget import TranscriptInputWidget
 from src.gui.provider_model_picker import ProviderModelPicker
 from src.core.comparison_item import ComparisonConfig, ModelChoice
 from src.core.comparison_worker import ComparisonWorker
-from src.core.verification_item import VerificationConfig
+from src.core.verification_item import VerificationConfig, VerificationResult
 from src.core.verification_worker import VerificationWorker
 from src.config.api_config import (
     load_providers, get_api_key, has_api_key,
@@ -957,6 +957,12 @@ class MainWindow(QMainWindow):
     @pyqtSlot()
     def _on_get_meta(self):
         """Handler für 'Get Meta' Button."""
+        # Defensiv: laufende Verifikation abbrechen, damit ihr Callback nicht
+        # in die neue Analyse hineinschreibt (Stale-State / Race-Condition).
+        if self._verification_worker and self._verification_worker.isRunning():
+            self._verification_worker.cancel()
+            self._verification_worker.wait(2000)
+
         url = self.url_input.text().strip()
         if not url:
             QMessageBox.warning(self, "Fehler", "Bitte eine YouTube-URL eingeben.")
@@ -2157,7 +2163,7 @@ class MainWindow(QMainWindow):
         save_preferences(prefs)
 
     @staticmethod
-    def _looks_web_capable(choice) -> bool:
+    def _looks_web_capable(choice: ModelChoice) -> bool:
         """Heuristik: Hat das gewählte Modell vermutlich Web-Zugriff?"""
         if choice.provider_id == "perplexity":
             return True
@@ -2231,6 +2237,10 @@ class MainWindow(QMainWindow):
         self.verify_picker.set_enabled(not running)
         self.verify_max_spin.setEnabled(not running)
         self.btn_batch.setEnabled(not running)
+        # Quelle sperren: verhindert, dass ein neues Video das Ergebnis leert,
+        # während die Stufe-2-Sektion noch angehängt wird (Stale-State / Race).
+        self.btn_get_meta.setEnabled(not running)
+        self.url_input.setEnabled(not running)
         self.btn_generate.setText("Verifikation läuft…" if running else "Generate Prompt")
 
     def _maybe_start_verification(self, response: APIResponse) -> None:
@@ -2277,7 +2287,7 @@ class MainWindow(QMainWindow):
         logger.info(f"Verifikation Status: {status}")
 
     @pyqtSlot(str, object)
-    def _on_verify_finished(self, section: str, result) -> None:
+    def _on_verify_finished(self, section: str, result: VerificationResult) -> None:
         """Hängt den Verifikationsabschnitt an die Analyse an."""
         self._append_to_result(section)
         if getattr(result, "status", "") == "skipped":

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -33,7 +33,7 @@ from src.gui.collapsible_section import CollapsibleSection
 from src.gui.model_selector import FilterableModelSelector, ModelData, extract_provider
 from src.gui.transcript_widget import TranscriptInputWidget
 from src.gui.provider_model_picker import ProviderModelPicker
-from src.core.comparison_item import ComparisonConfig
+from src.core.comparison_item import ComparisonConfig, ModelChoice
 from src.core.comparison_worker import ComparisonWorker
 from src.core.verification_item import VerificationConfig
 from src.core.verification_worker import VerificationWorker
@@ -567,6 +567,14 @@ class MainWindow(QMainWindow):
         verify_hint = QLabel("Empfohlen: web-fähiges Modell (z. B. Perplexity Sonar).")
         verify_hint.setStyleSheet("color: gray; font-style: italic; font-size: 11px;")
         verify_layout.addWidget(verify_hint)
+
+        # Web-Suche (:online) — nur für OpenRouter-Modelle wirksam
+        self.verify_online_checkbox = QCheckBox("Web-Suche aktivieren (:online, nur OpenRouter)")
+        self.verify_online_checkbox.setToolTip(
+            "Hängt bei OpenRouter-Modellen das Suffix ':online' an die Modell-ID an, "
+            "um echten Web-Zugriff zu aktivieren."
+        )
+        verify_layout.addWidget(self.verify_online_checkbox)
 
         verify_opts = QHBoxLayout()
         verify_opts.addWidget(QLabel("Max. zu prüfende Behauptungen:"))
@@ -2157,13 +2165,31 @@ class MainWindow(QMainWindow):
             return True
         return False
 
+    def _effective_verify_choice(self) -> ModelChoice | None:
+        """Liefert die Verifikations-Auswahl inkl. ':online'-Suffix (falls aktiv).
+
+        Der ':online'-Schalter wirkt nur bei OpenRouter-Modellen; so bleibt die
+        Wiederverwendung des ProviderModelPicker im Modellvergleich unberührt.
+        """
+        sel = self.verify_picker.get_selection()
+        if not sel:
+            return None
+        if (self.verify_online_checkbox.isChecked()
+                and sel.provider_id == "openrouter"
+                and not sel.model_id.endswith(":online")):
+            return ModelChoice(
+                sel.provider_id, f"{sel.model_id}:online",
+                sel.model_name, sel.provider_name,
+            )
+        return sel
+
     def _verification_preflight(self) -> bool:
         """Validiert das Verifikations-Setup vor dem Analysestart.
 
         Returns:
             True, wenn gestartet werden darf; False bricht den Lauf ab.
         """
-        sel = self.verify_picker.get_selection()
+        sel = self._effective_verify_choice()
         if not sel:
             QMessageBox.warning(
                 self, "Verifikationsmodell fehlt",
@@ -2179,13 +2205,22 @@ class MainWindow(QMainWindow):
         # Verifikation braucht die API-Automatik (Auto-Stufe-2 nach der Analyse)
         if not self.api_checkbox.isChecked():
             self.api_checkbox.setChecked(True)
-        # Soft-Warnung Web-Fähigkeit (nicht blockierend)
+        # Web-Fähigkeit: bei Unsicherheit Nachfrage mit Abbrechen / Trotzdem fortfahren
         if not self._looks_web_capable(sel):
-            QMessageBox.information(
-                self, "Hinweis: Web-Zugriff",
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Icon.Warning)
+            box.setWindowTitle("Kein bestätigter Web-Zugriff")
+            box.setText(
                 "Das gewählte Verifikationsmodell hat evtl. keinen Web-Zugriff; "
-                "die Verifikation kann ungenau sein.",
+                "Quellen können unzuverlässig oder erfunden sein."
             )
+            proceed_btn = box.addButton(
+                "Trotzdem fortfahren", QMessageBox.ButtonRole.AcceptRole
+            )
+            box.addButton("Abbrechen", QMessageBox.ButtonRole.RejectRole)
+            box.exec()
+            if box.clickedButton() is not proceed_btn:
+                return False
         return True
 
     def _set_verification_running(self, running: bool) -> None:
@@ -2202,7 +2237,7 @@ class MainWindow(QMainWindow):
         """Startet Stufe 2, wenn die Verifikation aktiv ist."""
         if not self.verify_checkbox.isChecked():
             return
-        sel = self.verify_picker.get_selection()
+        sel = self._effective_verify_choice()
         if not sel:
             return  # Preflight hätte das abgefangen — defensiv überspringen
 
@@ -2215,6 +2250,7 @@ class MainWindow(QMainWindow):
             total_claims=total,
             source_title=self.video_info.title if self.video_info else "",
             source_url=self.video_info.url if self.video_info else "",
+            web_unverified=not self._looks_web_capable(sel),
         )
 
         worker = VerificationWorker(config, debug_logger=self._debug_logger)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QLabel, QLineEdit, QPushButton, QTextEdit, QMessageBox,
     QFrame, QApplication, QComboBox, QCheckBox, QTabWidget,
-    QScrollArea, QMenu, QInputDialog,
+    QScrollArea, QMenu, QInputDialog, QSpinBox,
 )
 from PyQt6.QtCore import Qt, pyqtSlot, QEvent, QPoint
 from PyQt6.QtGui import QFont
@@ -17,6 +17,7 @@ from src.core.prompt_builder import (
     build_prompt, build_prompt_from_transcript,
     load_presets, get_preset_by_name, get_preset_by_id, PromptPreset,
     get_anti_monotony_hint,
+    extract_claims_from_faktencheck, cap_claims,
 )
 from src.core.linkedin_formatter import format_for_linkedin
 from src.core.export import export_to_markdown, get_suggested_filename, save_markdown
@@ -34,10 +35,12 @@ from src.gui.transcript_widget import TranscriptInputWidget
 from src.gui.provider_model_picker import ProviderModelPicker
 from src.core.comparison_item import ComparisonConfig
 from src.core.comparison_worker import ComparisonWorker
+from src.core.verification_item import VerificationConfig
+from src.core.verification_worker import VerificationWorker
 from src.config.api_config import (
     load_providers, get_api_key, has_api_key,
     get_last_provider, get_last_model, save_last_selection,
-    load_preferences,
+    load_preferences, save_preferences,
 )
 
 
@@ -155,6 +158,10 @@ class MainWindow(QMainWindow):
         # Debug-Logger (Preference-gesteuert)
         prefs = load_preferences()
         self._debug_logger = DebugLogger(enabled=prefs.get("debug_logging", False))
+
+        # Faktencheck-Verifikation-State (v0.10.0)
+        self._verification_worker: VerificationWorker | None = None
+        self._verification_max_claims: int = prefs.get("verification_max_claims", 10)
 
         # Lade Presets mit Fehlerbehandlung
         try:
@@ -540,6 +547,45 @@ class MainWindow(QMainWindow):
         self.compare_section.setVisible(False)
         layout.addWidget(self.compare_section)
 
+        # --- Faktencheck-Verifikation (v0.10.0) ---
+        self.verify_checkbox = QCheckBox("Behauptungen verifizieren (Faktencheck Stufe 2)")
+        self.verify_checkbox.setToolTip(
+            "Nach der Analyse die überprüfbaren Behauptungen automatisch von einem "
+            "web-fähigen Modell prüfen lassen (Verdikt + Quelle pro Behauptung)."
+        )
+        layout.addWidget(self.verify_checkbox)
+
+        self.verify_section = CollapsibleSection("Faktencheck-Verifikation")
+        verify_content = QWidget()
+        verify_layout = QVBoxLayout(verify_content)
+        verify_layout.setContentsMargins(0, 0, 0, 0)
+        verify_layout.setSpacing(6)
+
+        self.verify_picker = ProviderModelPicker("Verifikationsmodell:", self._api_providers)
+        verify_layout.addWidget(self.verify_picker)
+
+        verify_hint = QLabel("Empfohlen: web-fähiges Modell (z. B. Perplexity Sonar).")
+        verify_hint.setStyleSheet("color: gray; font-style: italic; font-size: 11px;")
+        verify_layout.addWidget(verify_hint)
+
+        verify_opts = QHBoxLayout()
+        verify_opts.addWidget(QLabel("Max. zu prüfende Behauptungen:"))
+        self.verify_max_spin = QSpinBox()
+        self.verify_max_spin.setRange(0, 100)
+        self.verify_max_spin.setValue(self._verification_max_claims)
+        self.verify_max_spin.setToolTip("0 = unbegrenzt (alle Behauptungen prüfen).")
+        verify_opts.addWidget(self.verify_max_spin)
+        verify_opts.addStretch()
+        self.btn_verify_cancel = QPushButton("Abbrechen")
+        self.btn_verify_cancel.setEnabled(False)
+        self.btn_verify_cancel.clicked.connect(self._on_verify_cancel)
+        verify_opts.addWidget(self.btn_verify_cancel)
+        verify_layout.addLayout(verify_opts)
+
+        self.verify_section.set_content_widget(verify_content)
+        self.verify_section.setVisible(False)
+        layout.addWidget(self.verify_section)
+
         # Initial: Controls deaktiviert bis Checkbox aktiv
         self._set_api_controls_enabled(False)
 
@@ -700,6 +746,8 @@ class MainWindow(QMainWindow):
         # API-Controls
         self.api_checkbox.toggled.connect(self._on_api_toggle)
         self.compare_checkbox.toggled.connect(self._on_compare_toggled)
+        self.verify_checkbox.toggled.connect(self._on_verify_toggled)
+        self.verify_max_spin.valueChanged.connect(self._on_verify_max_changed)
         self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
         self.model_combo.currentIndexChanged.connect(self._on_model_changed)
         self.model_selector.model_selected.connect(self._on_openrouter_model_selected)
@@ -1030,6 +1078,10 @@ class MainWindow(QMainWindow):
             self._start_comparison()
             return
 
+        # Verifikation aktiv → Vorab-Validierung (Modell/Key/Web-Hinweis)
+        if self.verify_checkbox.isChecked() and not self._verification_preflight():
+            return
+
         # Transcript-Tab aktiv → eigene Generierungslogik
         if self.input_tabs.currentIndex() == 1:
             self._generate_from_transcript()
@@ -1107,6 +1159,11 @@ class MainWindow(QMainWindow):
         recent_modules = self._rating_store.get_recent_modules(3)
         anti_monotony_hint = get_anti_monotony_hint(recent_modules)
 
+        # Verifikation erzwingt das FAKTENCHECK-Modul (liefert die Behauptungsliste)
+        effective_module = (
+            "FAKTENCHECK" if self.verify_checkbox.isChecked() else self._custom_module
+        )
+
         # Wenn Transkript vorhanden → transkript-aware Prompt bauen
         if self.video_info.transcript:
             # Transkript aus dem Transcript-Widget holen (könnte editiert worden sein)
@@ -1129,7 +1186,7 @@ class MainWindow(QMainWindow):
                 perspective=perspective,
                 anti_monotony_hint=anti_monotony_hint,
                 custom_system_prompt=self._custom_system_prompt,
-                custom_module=self._custom_module,
+                custom_module=effective_module,
             )
         else:
             # Kein Transkript → nur URL/Metadaten (bisheriges Verhalten)
@@ -1138,7 +1195,7 @@ class MainWindow(QMainWindow):
                 perspective=perspective,
                 anti_monotony_hint=anti_monotony_hint,
                 custom_system_prompt=self._custom_system_prompt,
-                custom_module=self._custom_module,
+                custom_module=effective_module,
             )
 
         self.prompt_text.setText(prompt)
@@ -1188,6 +1245,11 @@ class MainWindow(QMainWindow):
         recent_modules = self._rating_store.get_recent_modules(3)
         anti_monotony_hint = get_anti_monotony_hint(recent_modules)
 
+        # Verifikation erzwingt das FAKTENCHECK-Modul (liefert die Behauptungsliste)
+        effective_module = (
+            "FAKTENCHECK" if self.verify_checkbox.isChecked() else self._custom_module
+        )
+
         prompt = build_prompt_from_transcript(
             title=data["title"],
             author=data["author"],
@@ -1200,7 +1262,7 @@ class MainWindow(QMainWindow):
             perspective=perspective,
             anti_monotony_hint=anti_monotony_hint,
             custom_system_prompt=self._custom_system_prompt,
-            custom_module=self._custom_module,
+            custom_module=effective_module,
         )
         self.prompt_text.setText(prompt)
 
@@ -1806,11 +1868,16 @@ class MainWindow(QMainWindow):
         if has_custom and not self._is_rework:
             self._autosave_user_preset()
 
+        was_rework = self._is_rework
         self._is_rework = False
 
         # UI entsperren
         self._update_generate_enabled()
         self.btn_generate.setText("Generate Prompt")
+
+        # Faktencheck-Verifikation (Stufe 2): nach echter Analyse automatisch starten
+        if not was_rework:
+            self._maybe_start_verification(response)
 
         # Rework-Button zurücksetzen
         self.btn_rework.setText("\u2702 Kürzen lassen")
@@ -1845,9 +1912,14 @@ class MainWindow(QMainWindow):
             if self.api_checkbox.isChecked():
                 self.api_checkbox.setChecked(False)
             self.api_checkbox.setEnabled(False)
+            # Gegenseitiger Ausschluss mit der Faktencheck-Verifikation
+            if self.verify_checkbox.isChecked():
+                self.verify_checkbox.setChecked(False)
+            self.verify_checkbox.setEnabled(False)
             self.btn_generate.setText("Modellvergleich starten")
         else:
             self.api_checkbox.setEnabled(True)
+            self.verify_checkbox.setEnabled(True)
             self.btn_generate.setText("Generate Prompt")
 
     def _set_comparison_running(self, running: bool) -> None:
@@ -2050,6 +2122,155 @@ class MainWindow(QMainWindow):
             self._comparison_worker.cancel()
             self.compare_section.set_summary("Abgebrochen", color="#C62828")
             self.btn_compare_cancel.setEnabled(False)
+
+    # ── Faktencheck-Verifikation (v0.10.0) ────────────────────────────
+
+    @pyqtSlot(bool)
+    def _on_verify_toggled(self, checked: bool) -> None:
+        """Blendet die Verifikation ein/aus (Ausschluss mit Modellvergleich)."""
+        self.verify_section.setVisible(checked)
+        if checked:
+            self.verify_section.expand()
+            # Gegenseitiger Ausschluss mit dem Modellvergleich
+            if self.compare_checkbox.isChecked():
+                self.compare_checkbox.setChecked(False)
+            self.compare_checkbox.setEnabled(False)
+            # Verifikation braucht die API-Automatik (Auto-Stufe-2 nach der Analyse)
+            self.api_checkbox.setChecked(True)
+        else:
+            self.compare_checkbox.setEnabled(True)
+
+    @pyqtSlot(int)
+    def _on_verify_max_changed(self, value: int) -> None:
+        """Persistiert die Obergrenze der zu prüfenden Behauptungen."""
+        self._verification_max_claims = value
+        prefs = load_preferences()
+        prefs["verification_max_claims"] = value
+        save_preferences(prefs)
+
+    @staticmethod
+    def _looks_web_capable(choice) -> bool:
+        """Heuristik: Hat das gewählte Modell vermutlich Web-Zugriff?"""
+        if choice.provider_id == "perplexity":
+            return True
+        if choice.provider_id == "openrouter" and ":online" in (choice.model_id or ""):
+            return True
+        return False
+
+    def _verification_preflight(self) -> bool:
+        """Validiert das Verifikations-Setup vor dem Analysestart.
+
+        Returns:
+            True, wenn gestartet werden darf; False bricht den Lauf ab.
+        """
+        sel = self.verify_picker.get_selection()
+        if not sel:
+            QMessageBox.warning(
+                self, "Verifikationsmodell fehlt",
+                "Bitte ein Verifikationsmodell wählen (oder die Verifikation deaktivieren).",
+            )
+            return False
+        if not get_api_key(sel.provider_id):
+            QMessageBox.warning(
+                self, "API-Key fehlt",
+                f"Kein API-Key für {sel.provider_name or sel.provider_id} konfiguriert.",
+            )
+            return False
+        # Verifikation braucht die API-Automatik (Auto-Stufe-2 nach der Analyse)
+        if not self.api_checkbox.isChecked():
+            self.api_checkbox.setChecked(True)
+        # Soft-Warnung Web-Fähigkeit (nicht blockierend)
+        if not self._looks_web_capable(sel):
+            QMessageBox.information(
+                self, "Hinweis: Web-Zugriff",
+                "Das gewählte Verifikationsmodell hat evtl. keinen Web-Zugriff; "
+                "die Verifikation kann ungenau sein.",
+            )
+        return True
+
+    def _set_verification_running(self, running: bool) -> None:
+        """Sperrt/entsperrt Controls während eines Verifikationslaufs."""
+        self.btn_generate.setEnabled(not running)
+        self.btn_verify_cancel.setEnabled(running)
+        self.verify_checkbox.setEnabled(not running)
+        self.verify_picker.set_enabled(not running)
+        self.verify_max_spin.setEnabled(not running)
+        self.btn_batch.setEnabled(not running)
+        self.btn_generate.setText("Verifikation läuft…" if running else "Generate Prompt")
+
+    def _maybe_start_verification(self, response: APIResponse) -> None:
+        """Startet Stufe 2, wenn die Verifikation aktiv ist."""
+        if not self.verify_checkbox.isChecked():
+            return
+        sel = self.verify_picker.get_selection()
+        if not sel:
+            return  # Preflight hätte das abgefangen — defensiv überspringen
+
+        all_claims = extract_claims_from_faktencheck(response.content)
+        claims, total = cap_claims(all_claims, self._verification_max_claims)
+        config = VerificationConfig(
+            claims=claims,
+            model=sel,
+            language=self.config.language,
+            total_claims=total,
+            source_title=self.video_info.title if self.video_info else "",
+            source_url=self.video_info.url if self.video_info else "",
+        )
+
+        worker = VerificationWorker(config, debug_logger=self._debug_logger)
+        worker.status_changed.connect(self._on_verify_status)
+        worker.finished_ok.connect(self._on_verify_finished)
+        worker.error_occurred.connect(self._on_verify_error)
+        worker.finished.connect(lambda: self._set_verification_running(False))
+
+        self._verification_worker = worker
+        self._set_verification_running(True)
+        self.verify_section.set_summary(
+            f"Verifikation läuft … ({sel.model_name or sel.model_id})", color="#1565C0"
+        )
+        worker.start()
+
+    def _append_to_result(self, section: str) -> None:
+        """Hängt einen Markdown-Abschnitt an das bestehende Ergebnis an."""
+        current = self.result_text.toPlainText().rstrip()
+        self.result_text.setPlainText(f"{current}\n\n{section.strip()}\n")
+
+    @pyqtSlot(str)
+    def _on_verify_status(self, status: str) -> None:
+        """Loggt den Verifikations-Status."""
+        logger.info(f"Verifikation Status: {status}")
+
+    @pyqtSlot(str, object)
+    def _on_verify_finished(self, section: str, result) -> None:
+        """Hängt den Verifikationsabschnitt an die Analyse an."""
+        self._append_to_result(section)
+        if getattr(result, "status", "") == "skipped":
+            self.verify_section.set_summary(
+                "Keine überprüfbaren Behauptungen", color="#888888"
+            )
+        else:
+            self.verify_section.set_summary("Verifikation fertig ✓", color="#2E7D32")
+        logger.info("Verifikationsabschnitt angehängt")
+
+    @pyqtSlot(str)
+    def _on_verify_error(self, message: str) -> None:
+        """Hängt einen Platzhalter an (Analyse bleibt erhalten) + Warnung."""
+        placeholder = (
+            "---\n\n### FAKTENCHECK · VERIFIKATION\n"
+            f"_Verifikation fehlgeschlagen: {message}. "
+            "Behauptungen siehe FAKTENCHECK-Block oben._\n"
+        )
+        self._append_to_result(placeholder)
+        self.verify_section.set_summary("Verifikation fehlgeschlagen", color="#C62828")
+        QMessageBox.warning(self, "Verifikation fehlgeschlagen", message)
+
+    @pyqtSlot()
+    def _on_verify_cancel(self) -> None:
+        """Bricht einen laufenden Verifikationslauf ab."""
+        if self._verification_worker and self._verification_worker.isRunning():
+            self._verification_worker.cancel()
+            self.verify_section.set_summary("Abgebrochen", color="#C62828")
+            self.btn_verify_cancel.setEnabled(False)
 
     # ── Custom Prompt Editor ──────────────────────────────────────────
 

--- a/templates/somas_prompt.txt
+++ b/templates/somas_prompt.txt
@@ -16,7 +16,7 @@ Wähle genau eines der folgenden Module als 5. Abschnitt:
 - OFFENE_FRAGEN: Benenne, was ungeklärt bleibt oder bewusst ausgelassen wird.
 - VERBINDUNGEN: Ordne den Inhalt in einen größeren historischen oder gesellschaftlichen Kontext ein.
 - SUBTEXT: Dekodiere die impliziten Botschaften. Was wird zwischen den Zeilen gesagt? Welche Annahmen setzt der Sprecher als selbstverständlich voraus? Nicht bewerten – nur sichtbar machen. Verzichte auf wertende Adjektive.
-- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende.
+- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende. Schreibe jeden nummerierten Punkt auf eine eigene Zeile (keine Inline-Aufzählung).
 {% if anti_monotony_hint %}{{ anti_monotony_hint }}
 {% endif %}
 OUTPUT-FORMAT:

--- a/templates/somas_prompt.txt
+++ b/templates/somas_prompt.txt
@@ -16,7 +16,7 @@ Wähle genau eines der folgenden Module als 5. Abschnitt:
 - OFFENE_FRAGEN: Benenne, was ungeklärt bleibt oder bewusst ausgelassen wird.
 - VERBINDUNGEN: Ordne den Inhalt in einen größeren historischen oder gesellschaftlichen Kontext ein.
 - SUBTEXT: Dekodiere die impliziten Botschaften. Was wird zwischen den Zeilen gesagt? Welche Annahmen setzt der Sprecher als selbstverständlich voraus? Nicht bewerten – nur sichtbar machen. Verzichte auf wertende Adjektive.
-- FAKTENCHECK: Identifiziere die 3–4 überprüfungsbedürftigsten Aussagen. Nenne pro Aussage: Was wurde behauptet, warum prüfen, wonach suchen. Stelle keine eigenen Faktenbehauptungen auf und urteile nicht über Wahr oder Falsch.
+- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende.
 {% if anti_monotony_hint %}{{ anti_monotony_hint }}
 {% endif %}
 OUTPUT-FORMAT:

--- a/templates/somas_prompt_transcript.txt
+++ b/templates/somas_prompt_transcript.txt
@@ -21,7 +21,7 @@ Wähle genau eines der folgenden Module als 5. Abschnitt:
 - OFFENE_FRAGEN: Benenne, was ungeklärt bleibt oder bewusst ausgelassen wird.
 - VERBINDUNGEN: Ordne den Inhalt in einen größeren historischen oder gesellschaftlichen Kontext ein.
 - SUBTEXT: Dekodiere die impliziten Botschaften. Was wird zwischen den Zeilen gesagt? Welche Annahmen setzt der Sprecher als selbstverständlich voraus? Nicht bewerten – nur sichtbar machen. Verzichte auf wertende Adjektive.
-- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende.
+- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende. Schreibe jeden nummerierten Punkt auf eine eigene Zeile (keine Inline-Aufzählung).
 {% if anti_monotony_hint %}{{ anti_monotony_hint }}
 {% endif %}
 OUTPUT-FORMAT:

--- a/templates/somas_prompt_transcript.txt
+++ b/templates/somas_prompt_transcript.txt
@@ -21,7 +21,7 @@ Wähle genau eines der folgenden Module als 5. Abschnitt:
 - OFFENE_FRAGEN: Benenne, was ungeklärt bleibt oder bewusst ausgelassen wird.
 - VERBINDUNGEN: Ordne den Inhalt in einen größeren historischen oder gesellschaftlichen Kontext ein.
 - SUBTEXT: Dekodiere die impliziten Botschaften. Was wird zwischen den Zeilen gesagt? Welche Annahmen setzt der Sprecher als selbstverständlich voraus? Nicht bewerten – nur sichtbar machen. Verzichte auf wertende Adjektive.
-- FAKTENCHECK: Identifiziere die 3–4 überprüfungsbedürftigsten Aussagen. Nenne pro Aussage: Was wurde behauptet, warum prüfen, wonach suchen. Stelle keine eigenen Faktenbehauptungen auf und urteile nicht über Wahr oder Falsch.
+- FAKTENCHECK: Trenne die Aussagen strikt in drei nummerierte Blöcke mit EXAKT diesen Sub-Headern: **Meinungen:** (subjektive Wertungen, nicht prüfbar), **Interpretationen:** (Deutungen/Schlussfolgerungen, nicht direkt prüfbar), **Behauptungen (überprüfbar):** (je eine einzelne, in sich abgeschlossene, falsifizierbare Tatsachenaussage pro Punkt, neutral und kontextfrei formuliert, ohne Meinungswörter). Fälle KEIN Urteil über Wahr/Falsch. Ordne jeden Block nach Relevanz absteigend (wichtigste zuerst); triviale Selbstverständlichkeiten ans Ende.
 {% if anti_monotony_hint %}{{ anti_monotony_hint }}
 {% endif %}
 OUTPUT-FORMAT:

--- a/templates/somas_verification.txt
+++ b/templates/somas_verification.txt
@@ -5,6 +5,10 @@
 {% if claims_capped %}
 *Geprüft: die {{ checked_count }} von {{ total_count }} nach Relevanz priorisierten Behauptungen.*
 {% endif %}
+{% if web_unverified %}
+
+> ⚠️ Verifikationsmodell ohne bestätigten Web-Zugriff — Quellen ungeprüft, können unzuverlässig oder erfunden sein.
+{% endif %}
 
 {{ verification_body }}
 {% if citations %}

--- a/templates/somas_verification.txt
+++ b/templates/somas_verification.txt
@@ -1,0 +1,16 @@
+---
+
+### FAKTENCHECK · VERIFIKATION
+*Geprüft mit {{ model_name }} ({{ provider_name }}){% if date %} am {{ date }}{% endif %}*
+{% if claims_capped %}
+*Geprüft: die {{ checked_count }} von {{ total_count }} nach Relevanz priorisierten Behauptungen.*
+{% endif %}
+
+{{ verification_body }}
+{% if citations %}
+
+#### Quellen
+{% for c in citations %}
+{{ loop.index }}. {{ c }}
+{% endfor %}
+{% endif %}

--- a/tests/test_faktencheck_parser.py
+++ b/tests/test_faktencheck_parser.py
@@ -89,6 +89,56 @@ def test_extract_headings_without_space():
     print("  extract_headings_without_space: ###ohne-Space normalisiert, Block endet korrekt OK")
 
 
+# Reale Fixture aus dem PO-Debug-Log (DeepSeek V4 Pro): FAKTENCHECK komplett inline.
+ANALYSE_INLINE_DEEPSEEK = (
+    "### FAKTENCHECK\n"
+    "**Meinungen:** 1. Sanders pro-israelische Positionen sind nicht radikal. 2. Der Ausschluss aus dem Film ist eine himmelschreiende Ungerechtigkeit. 3. Die Branche war links, weil es in Mode war.\n"
+    "**Interpretationen:** 1. Sanders Ausschluss zeigt ein strukturelles Problem der Filmbranche. 2. Anti-israelische Propaganda hat breite Gesellschaftsschichten erfasst.\n"
+    "**Behauptungen (überprüfbar):** 1. Sander wurde wegen ihrer pro-israelischen Haltung aus dem Film „Die Todessehnsucht der Maria Om\" ausgeschlossen. 2. Sie verfasste das Drehbuch mit einem Co-Autor. 3. Sie führt seit Ende 2024 einen Rechtsstreit gegen die Produktionsfirma. 4. Das Kammergericht Berlin entschied in der Berufung zugunsten der Produktionsfirma. 5. Auf dem Campus der Burg Giebichenstein Kunsthochschule Halle wurden Flugblätter verteilt, die die jüdische Gemeinde als rassistisch und zionistisch bezeichnen und ihre Ausladung fordern. 6. Die Hochschulleitung entfernte diese Plakate. 7. Sander gibt an, täglich hunderte Hassnachrichten mit Holocaust-Bezug zu erhalten. 8. Sie steht eigenen Angaben zufolge in Kontakt mit dem LKA. 9. Auf Berliner Free-Palestine-Demos riefen Teilnehmer arabischsprachig „Tod den Juden\". 10. Auf der Sonnenallee in Berlin-Neukölln hängen Palästina-Flaggen. 11. Sander veröffentlichte im August 2025 ein kritisches Video über Teile der Schauspielbranche. 12. Die jüdische Gemeinde Halle organisierte Synagogenbesuche für Studierende.\n"
+)
+
+
+def test_extract_inline_deepseek():
+    claims = extract_claims_from_faktencheck(ANALYSE_INLINE_DEEPSEEK)
+    assert len(claims) == 12, f"erwartet 12, bekam {len(claims)}: {claims}"
+    assert claims[0].startswith("Sander wurde wegen ihrer pro-israelischen Haltung")
+    assert claims[11].startswith("Die jüdische Gemeinde Halle organisierte")
+    # Meinungen/Interpretationen tauchen NICHT auf
+    joined = " ".join(claims)
+    assert "himmelschreiende" not in joined and "strukturelles Problem" not in joined
+    print("  extract_inline_deepseek: 12 Behauptungen aus Inline-Block OK")
+
+
+def test_extract_internal_numbers():
+    # Interne Datums-/Jahreszahl darf einen Claim NICHT zerteilen.
+    inline = (
+        "### FAKTENCHECK\n"
+        "**Behauptungen (überprüfbar):** 1. Sie reiste am 7. Oktober 2023 nach Israel. "
+        "2. Das Gesetz gilt seit 2021.\n"
+    )
+    claims = extract_claims_from_faktencheck(inline)
+    assert claims == [
+        "Sie reiste am 7. Oktober 2023 nach Israel.",
+        "Das Gesetz gilt seit 2021.",
+    ], claims
+    print("  extract_internal_numbers: '7. Oktober' zerreißt Claim nicht -> 2 Claims OK")
+
+
+def test_extract_mixed_and_quelle_terminator():
+    # Mehrzeilig + abschließender QUELLE-Abschnitt darf nicht in den letzten Claim lecken.
+    txt = (
+        "### FAKTENCHECK\n"
+        "**Behauptungen (überprüfbar):**\n"
+        "1. Erste Behauptung.\n"
+        "2. Zweite Behauptung mit Datum am 3. März 2020.\n"
+        "QUELLE:\n"
+        'YouTube-Video: "Titel"\n'
+    )
+    claims = extract_claims_from_faktencheck(txt)
+    assert claims == ["Erste Behauptung.", "Zweite Behauptung mit Datum am 3. März 2020."], claims
+    print("  extract_mixed_and_quelle: mehrzeilig + QUELLE-Terminator OK")
+
+
 def test_extract_edge_cases():
     assert extract_claims_from_faktencheck("") == []
     assert extract_claims_from_faktencheck("### FRAMING\nKein Faktencheck hier.") == []
@@ -155,6 +205,9 @@ def main():
     test_extract_standard()
     test_extract_robust()
     test_extract_headings_without_space()
+    test_extract_inline_deepseek()
+    test_extract_internal_numbers()
+    test_extract_mixed_and_quelle_terminator()
     test_extract_edge_cases()
     test_cap_claims()
     test_build_verification_prompt()

--- a/tests/test_faktencheck_parser.py
+++ b/tests/test_faktencheck_parser.py
@@ -1,0 +1,149 @@
+"""Unit-Tests für den Faktencheck-Parser & Verifikations-Prompt (v0.10.0).
+
+Lauf (ohne pytest):  python tests/test_faktencheck_parser.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.prompt_builder import (
+    extract_claims_from_faktencheck,
+    cap_claims,
+    build_verification_prompt,
+    clean_verification_output,
+    VERDICT_VALUES,
+)
+
+
+# --- Beispiel-Analysen ----------------------------------------------------
+
+ANALYSE_STANDARD = """### FRAMING
+Sprecher X in einem Interview.
+
+### KERNTHESE
+Die zentrale Aussage.
+
+### FAKTENCHECK
+**Meinungen:**
+1. Der Sprecher findet die Politik übertrieben.
+2. Das sei eine Schande.
+
+**Interpretationen:**
+1. Daraus folgt vermutlich ein Strategiewechsel.
+
+**Behauptungen (überprüfbar):**
+1. Die Inflation lag 2023 bei 5,9 Prozent.
+2. Das Gesetz wurde 2021 verabschiedet.
+3. Die Stadt hat zwei Millionen Einwohner.
+
+QUELLE:
+YouTube-Video: "Titel" von Kanal
+URL: https://youtu.be/x
+"""
+
+# Robust: fehlende Meinungen/Interpretationen, 1)-Nummerierung, GROSS-Marker,
+# Folge-Überschrift beendet den Block.
+ANALYSE_ROBUST = """### FAKTENCHECK
+**BEHAUPTUNGEN (ÜBERPRÜFBAR):**
+1) Erste belegbare Behauptung.
+2) Zweite belegbare Behauptung.
+
+### IMPLIKATION
+Egal.
+"""
+
+
+def test_extract_standard():
+    claims = extract_claims_from_faktencheck(ANALYSE_STANDARD)
+    assert claims == [
+        "Die Inflation lag 2023 bei 5,9 Prozent.",
+        "Das Gesetz wurde 2021 verabschiedet.",
+        "Die Stadt hat zwei Millionen Einwohner.",
+    ], claims
+    # Meinungen/Interpretationen tauchen NICHT auf
+    joined = " ".join(claims)
+    assert "übertrieben" not in joined and "Strategiewechsel" not in joined
+    print("  extract_standard: 3 Behauptungen, Meinungen/Interpretationen ignoriert OK")
+
+
+def test_extract_robust():
+    claims = extract_claims_from_faktencheck(ANALYSE_ROBUST)
+    assert claims == ["Erste belegbare Behauptung.", "Zweite belegbare Behauptung."], claims
+    print("  extract_robust: fehlende Blöcke, 1)-Nummerierung, GROSS-Marker, Folge-### OK")
+
+
+def test_extract_edge_cases():
+    assert extract_claims_from_faktencheck("") == []
+    assert extract_claims_from_faktencheck("### FRAMING\nKein Faktencheck hier.") == []
+    # FAKTENCHECK-Block ohne Behauptungen-Marker -> []
+    no_claims = "### FAKTENCHECK\n**Meinungen:**\n1. Nur eine Meinung.\n"
+    assert extract_claims_from_faktencheck(no_claims) == []
+    # VERIFIKATION-Header darf NICHT als Dekonstruktionsblock gegriffen werden
+    only_verif = (
+        "### FAKTENCHECK · VERIFIKATION\n"
+        "**1. „X\"**\n- **Verdikt:** bestätigt\n"
+    )
+    assert extract_claims_from_faktencheck(only_verif) == []
+    print("  extract_edge: leer/kein-Block/nur-Meinungen/VERIFIKATION-Header -> [] OK")
+
+
+def test_cap_claims():
+    many = [f"Behauptung {i}" for i in range(1, 15)]  # 14 Stück
+    capped, total = cap_claims(many, 10)
+    assert total == 14 and len(capped) == 10 and capped[0] == "Behauptung 1" and capped[-1] == "Behauptung 10"
+    # N=0 -> unbegrenzt
+    capped0, total0 = cap_claims(many, 0)
+    assert capped0 == many and total0 == 14
+    # len <= N -> unverändert
+    few = ["A", "B"]
+    capped_few, total_few = cap_claims(few, 10)
+    assert capped_few == few and total_few == 2
+    # Reihenfolge bleibt erhalten
+    assert cap_claims(["c", "a", "b"], 2)[0] == ["c", "a"]
+    print("  cap_claims: 14+N10->10/total14, N0->alle, len<=N->unverändert, Reihenfolge OK")
+
+
+def test_build_verification_prompt():
+    claims = ["Die Inflation lag 2023 bei 5,9 Prozent.", "Das Gesetz wurde 2021 verabschiedet."]
+    prompt = build_verification_prompt(claims, language="Deutsch")
+    # alle Behauptungen enthalten, nummeriert
+    assert "1. Die Inflation lag 2023 bei 5,9 Prozent." in prompt
+    assert "2. Das Gesetz wurde 2021 verabschiedet." in prompt
+    # Verdikt-Skala vollständig & exakt
+    for v in VERDICT_VALUES:
+        assert v in prompt, f"Verdikt fehlt: {v}"
+    # Format-/Vertragsbestandteile
+    assert "**Verdikt:**" in prompt and "**Begründung:**" in prompt and "**Quelle:**" in prompt
+    assert "Deutsch" in prompt
+    # KEINE Meinungen (es wurden keine übergeben — Negativprobe)
+    assert "übertrieben" not in prompt and "Schande" not in prompt
+    # Sprache durchgereicht
+    assert "Antworte in Englisch" in build_verification_prompt(claims, language="Englisch")
+    # source_hint optional
+    assert "KONTEXT" in build_verification_prompt(claims, source_hint="Titel · URL")
+    assert "KONTEXT" not in build_verification_prompt(claims)
+    print("  build_verification_prompt: Behauptungen+Skala+Format+Sprache+Hint OK")
+
+
+def test_clean_verification_output():
+    fenced = "```markdown\n**1. „X\"**\n- **Verdikt:** bestätigt\n```"
+    assert clean_verification_output(fenced).startswith("**1.")
+    assert clean_verification_output("# Vorspann\n\n**1. „X\"**").startswith("**1.")
+    assert clean_verification_output("") == ""
+    print("  clean_verification_output: Fences/Vorspann entfernt OK")
+
+
+def main():
+    print("Faktencheck-Parser-Tests:")
+    test_extract_standard()
+    test_extract_robust()
+    test_extract_edge_cases()
+    test_cap_claims()
+    test_build_verification_prompt()
+    test_clean_verification_output()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_faktencheck_parser.py
+++ b/tests/test_faktencheck_parser.py
@@ -73,6 +73,22 @@ def test_extract_robust():
     print("  extract_robust: fehlende Blöcke, 1)-Nummerierung, GROSS-Marker, Folge-### OK")
 
 
+def test_extract_headings_without_space():
+    # Header/Folge-Überschrift OHNE Leerzeichen nach ### -> normalize greift,
+    # Block endet korrekt vor '###IMPLIKATION'.
+    txt = (
+        "###FAKTENCHECK\n"
+        "**Behauptungen (überprüfbar):**\n"
+        "1. Behauptung eins.\n"
+        "2. Behauptung zwei.\n"
+        "###IMPLIKATION\n"
+        "3. Das ist KEINE Behauptung mehr.\n"
+    )
+    claims = extract_claims_from_faktencheck(txt)
+    assert claims == ["Behauptung eins.", "Behauptung zwei."], claims
+    print("  extract_headings_without_space: ###ohne-Space normalisiert, Block endet korrekt OK")
+
+
 def test_extract_edge_cases():
     assert extract_claims_from_faktencheck("") == []
     assert extract_claims_from_faktencheck("### FRAMING\nKein Faktencheck hier.") == []
@@ -138,6 +154,7 @@ def main():
     print("Faktencheck-Parser-Tests:")
     test_extract_standard()
     test_extract_robust()
+    test_extract_headings_without_space()
     test_extract_edge_cases()
     test_cap_claims()
     test_build_verification_prompt()


### PR DESCRIPTION
## Überblick

Zweistufige Faktenprüfung gemäß `specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md`:

- **Stufe 1 (Dekonstruktion):** Das FAKTENCHECK-Modul trennt strikt **Meinungen / Interpretationen / überprüfbare Behauptungen** (relevanz-sortiert).
- **Stufe 2 (Verifikation, optional):** Ein web-fähiges Modell prüft **ausschließlich die nackten Behauptungen** und liefert pro Behauptung **Verdikt + Quelle**. Der zentrale Qualitätsgewinn: keine Meinungen im Stufe-2-Prompt.

## PRs

| PR | Inhalt |
|----|--------|
| 1 | `FAKTENCHECK_FORMAT`-Konstante + Injektion via `_apply_custom_overrides` (deckt alle Presets ab) + Limit-Aufhebung bei erzwungenem Modul; 2 beschreibende Templates aktualisiert |
| 2 | Parser (`extract_claims_from_faktencheck`), `cap_claims` (Top-N), `build_verification_prompt`, `clean_verification_output` + Unit-Tests |
| 3 | `verification_item.py` (VerificationConfig/Result) + `somas_verification.txt` |
| 4 | `VerificationWorker(QThread)` (schlank, nicht-fatale Fehler) |
| 5 | GUI: Toggle + Verifikationsmodell-Picker + Max-Behauptungen-SpinBox + Auto-Anhang + Ausschluss mit Modellvergleich |

## Nachbesserungen nach PO-Test (Runde 2)

- **N1 (kritisch):** Parser erkennt jetzt **inline-** wie zeilen-nummerierte Behauptungen (reale DeepSeek-Inline-Fixture → 12 Claims); interne Zahlen wie „am 3. März 2020" zerreißen Claims nicht (Grenze nur an Zeilenanfang/Satzende + fortlaufende Nummer).
- **N2:** Format fordert einen Punkt pro Zeile (Belt-and-suspenders zu N1).
- **N3:** Prompt-Riegel gegen **erfundene Quellen**; Quelle nur bei echter Verifikation verpflichtend.
- **N4:** Preflight-Dialog bei No-Web-Modell („Abbrechen" / „Trotzdem fortfahren").
- **N5:** Dauerhafter **Web-Disclaimer** im Dokument bei Modell ohne bestätigten Web-Zugriff.
- **N6:** **`:online`-Schalter** für OpenRouter (echter Web-Zugriff aktivierbar; ProviderModelPicker für den Modellvergleich unberührt).

## Harte Constraints eingehalten
- Modul-Header bleibt exakt `### FAKTENCHECK` (Modul-Statistik/DB-Schema v3 intakt).
- Modul-Erzwingung über den bestehenden `custom_module`-Mechanismus.
- API-Keys zur Laufzeit aus dem Keyring, nie serialisiert.

## Tests
`tests/test_faktencheck_parser.py` (Standard/Robustheit/Inline/interne Zahlen/Edge/Cap/Prompt/Cleaner) grün; bestehende Tests (`test_empty_content.py`) grün; GUI offscreen-smoke grün.

## Noch offen (nicht in diesem PR)
PR 6 (Doku & Version v0.10.0) folgt nach dem erneuten PO-Test, damit die Doku den finalen Stand abbildet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Faktencheck-Verifikation (Stufe 2) in den Analyse-Workflow integriert
  * Neue Verifikations-Einstellungen: Aktivierung, Modellwahl, optionaler Online-Modus, Claim-Limit und Abbruch
  * Vorabprüfung vor dem Start sowie automatische Einbindung der Verifikations-Section in die Ergebnisanzeige
  * Läuft eine Verifikation während neuer Aufgaben (z. B. YouTube-Metadaten), wird sie defensiv abgebrochen; Modellvergleich wird gegenseitig ausgeschlossen
* **Tests**
  * Neue Tests für Claim-Extraktion, Prompt-Erstellung, Ausgabe-Reinigung sowie Edge-Cases hinzugefügt
* **Style**
  * Verbesserte Stylescope-Logik für ausklappbare Bereiche
<!-- end of auto-generated comment: release notes by coderabbit.ai -->