### PR TITLE
Hotfix v0.10.1: max_tokens (A1, HTTP 402) + Zeichenlimit bei FAKTENCHECK (A2)

### DIFF
--- a/specs/MERKZETTEL_v0.10.1_offene_punkte.md
+++ b/specs/MERKZETTEL_v0.10.1_offene_punkte.md
@@ -1,0 +1,61 @@
+# Merkzettel — offene Punkte nach v0.10.0
+
+> Stand: Abend 14.06.2026 (nach v0.10.0-Merge). Für die nächste Sitzung / v0.10.1.
+> Quelle: Abend-Beobachtungen Thorsten + Perplexity-Review. Noch nicht in die Haupt-Spec eingearbeitet.
+
+## A — Code-Bugs (für Kurt)
+
+**A1 · `max_tokens` fehlt im OpenRouter-Request (HOCH, verifiziert).**
+`openrouter_client.py` (Payload ~Z. 142) sendet kein `max_tokens`. Folge: OpenRouter reserviert
+das volle Context-Window (z. B. 65.536 Token) als Worst-Case und blockt mit **HTTP 402** bei
+moderatem Guthaben („requires more credits, or fewer max_tokens"). Das war die wahre Ursache des
+402 — nicht zu wenig Guthaben.
+→ Fix: expliziten `max_tokens` mitsenden. Wert groß genug, dass lange Verifikations-/
+Analyse-Antworten **nicht abgeschnitten** werden (Vorschlag 4096–8192), aber nicht das ganze
+Window. Perplexity-Client (`perplexity_client.py`) hat ebenfalls kein `max_tokens` → gleich
+mitziehen. Anthropic/OpenAI setzen es bereits (4096).
+
+**A2 · Prompt-Widerspruch beim Zeichenlimit bei aktiver Verifikation (MITTEL–HOCH).**
+Bei erzwungenem FAKTENCHECK stellt N2b den Hinweis „Gesamtzeichenlimit AUFGEHOBEN" voran —
+**aber** die Template-Zeile „⚠ ZEICHENLIMIT: … unter 2800 Zeichen" bleibt im Prompt (im echten
+Request nachgewiesen). Das Modell folgt dann evtl. der 2800-Grenze und **kürzt die
+Behauptungsliste** → genau das, was wir bei Verifikation NICHT wollen.
+→ Robuster Fix: bei erzwungenem FAKTENCHECK die `GESAMTZEICHENLIMIT`-Zeile im Template wirklich
+**unterdrücken** (Jinja-Conditional bzw. per Variable steuerbar), statt nur einen
+widersprechenden Hinweis voranzustellen. Revidiert PR 1.2b.
+
+## B — Konto-Sache (für Thorsten, kein Code)
+
+**B1 · Perplexity-API nicht erreichbar = Account, nicht Code.**
+Perplexity hat das monatliche 5-$-Gratis-API-Guthaben (~Feb 2026) abgeschafft → reines Prepaid.
+Account stand auf 0 $ → 401/402. 500 Credits (5 $) sind jetzt geladen und reichen für **hunderte**
+Läufe (ein 7-Claim-Lauf kostet < 0,05 $). Falls weiter Fehler:
+1. 10–15 Min Aktivierungsverzögerung nach erster Aufladung abwarten.
+2. Model-ID prüfen (aktuell: `sonar`, `sonar-pro`, `sonar-reasoning-pro`). Im fehlgeschlagenen
+   Request lief `sonar-reasoning` → **api_providers.json auf aktuelle Perplexity-IDs prüfen.**
+3. API-Key korrekt im Keyring (`get_api_key`)?
+Die gelbe „Guthaben wird knapp"-Warnung ist nur ein Default-Hinweis bei ≤ 5 $ — ignorierbar.
+
+## C — Backlog v0.10.1 (verfeinert durch Perplexity-Review)
+
+**C1 · „Verifikation erneut versuchen"-Button (HOCH) — mit Modellwechsel.**
+Wie geplant, aber Verfeinerung: vor dem Retry das **Verifikationsmodell wechseln** können
+(Picker + `:online` neu lesen) und nur Stufe 2 auf den bereits isolierten Claims neu fahren.
+Kernszenario: DeepSeek:online liefert 5/7 „nicht überprüfbar" → auf Perplexity Sonar umstellen
+und nur Stufe 2 wiederholen (kein 80-s-Stufe-1 erneut, keine Doppelkosten).
+
+**C2 · `:online`-Checkbox-Tooltip präzisieren (NIEDRIG).**
+Ergänzen: „Das ':online'-Suffix aktiviert die modellspezifische Internetsuche; die
+Recherche-Qualität hängt stark vom Modell ab." Lernpunkt aus dem Test: **Webzugriff ≠ Webzugriff**
+— DeepSeek:online fand top-aktuelle, real verifizierbare News nicht; dedizierte Such-Modelle
+(Perplexity Sonar) finden sie mühelos. Ggf. als Empfehlung auch in README/Docs.
+
+**C3 · Einheitlicher Export-Kopf** (Titel + „Kanal, YT" + Thumbnail) — bereits in der Spec geparkt.
+
+## Notiz
+Perplexity (Ideengeber) hat v0.10.0 begutachtet und ausdrücklich gelobt/abgesegnet: saubere
+Claim-Trennung, ehrliches „nicht überprüfbar" statt Halluzination. Architektur bestätigt.
+
+---
+Nächster Schritt morgen: A1 + A2 zu Kurt (kleine, klar umrissene Fixes), B1 selbst prüfen,
+C1–C3 in die Spec-Backlog-Sektion übernehmen.

--- a/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
+++ b/specs/SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md
@@ -707,14 +707,96 @@ hoch/runter beide funktionsfähig, in der Verifikations- UND der Vergleichs-Sect
 
 ---
 
+## Bugfix-Runde 4 (v0.10.1) — A1/A2 aus PO-Beobachtungen
+
+> Zwei nach dem v0.10.0-Merge gefundene Bugs. Beide klein und klar umrissen. Quelle:
+> PO-Test-Beobachtungen + externes Review. Verifiziert am Code.
+
+**A1 — `max_tokens` fehlt im Request → HTTP 402 bei OpenRouter (HOCH, verifiziert).**
+`openrouter_client.py` (Payload bei ~Z. 142) sendet nur `model` + `messages`, **kein**
+`max_tokens`. Folge: OpenRouter rechnet mit dem vollen Context-Window (z. B. 65.536 Output-Token)
+als Worst-Case und blockt bei moderatem Guthaben mit **HTTP 402** („requires more credits, or
+fewer max_tokens"). Das war die wahre Ursache des 402 — nicht zu wenig Guthaben.
+Fix:
+
+```python
+json={
+    "model": model,
+    "messages": [{"role": "user", "content": prompt}],
+    "max_tokens": 4096,
+},
+```
+
+- Wert **4096** (konsistent mit `anthropic_client.py`/`openai_client.py`, die ihn bereits setzen).
+  Reicht für die kurzen Analyse- und Verifikations-Antworten locker; verhindert das Worst-Case-
+  Pre-Auth. **`perplexity_client.py`** hat ebenfalls kein `max_tokens` → gleich mitziehen.
+- Hinweis: Reasoning-Modelle verbrauchen zusätzlich „Denk-Token". Falls dort später Abschneiden
+  auffällt, Wert erhöhen oder konfigurierbar machen (Backlog) — für jetzt genügt 4096.
+- **Verify:** OpenRouter-Lauf mit knappem Guthaben kein 402 mehr; Verifikation mit vielen Claims
+  wird nicht abgeschnitten.
+
+**A2 — Prompt-Widerspruch beim Zeichenlimit bei erzwungenem FAKTENCHECK (MITTEL–HOCH, verifiziert).**
+N2b stellt „Limit AUFGEHOBEN" voran, aber die Template-Zeilen zum Zeichenlimit bleiben im Prompt
+→ das Modell folgt evtl. der Grenze und **kürzt die Behauptungsliste**. Das Limit steht pro
+Template an bis zu **drei** Stellen (verifiziert):
+1. Kopf: `⚠ ZEICHENLIMIT: Deine GESAMTE Antwort MUSS unter … Zeichen bleiben. Zähle mit.`
+2. Regeln: `N. GESAMTZEICHENLIMIT: Deine GESAMTE Antwort MUSS unter … Zeichen bleiben.`
+3. (Transkript/Musik) `⚠ ERINNERUNG: Maximale Ausgabelänge = … Zeichen. …`
+
+Ein Gegen-Hinweis reicht also nicht. Fix **zentral in `_apply_custom_overrides`** (gleiche Stelle
+wie die FAKTENCHECK-Injektion): wenn `custom_module == "FAKTENCHECK"`, die Zeichenlimit-Zeilen aus
+dem gerenderten Prompt **entfernen**, bevor er zurückgegeben wird:
+
+```python
+if custom_module and custom_module.strip().upper() == "FAKTENCHECK":
+    rendered = re.sub(
+        r"(?im)^.*(?:ZEICHENLIMIT|Maximale Ausgabelänge).*\n?", "", rendered
+    )
+```
+
+- Damit verschwindet der Widerspruch komplett (alle drei Varianten). `FAKTENCHECK_NO_LIMIT_HINT`
+  kann dann entfallen **oder** zu einer rein positiven Zeile vereinfacht werden
+  („Liste die Behauptungen vollständig; Vollständigkeit vor Kürze.") — kein „aufgehoben"-Framing
+  mehr nötig, da real entfernt.
+- Greift nur bei erzwungenem FAKTENCHECK (Verifikation an bzw. manuell erzwungen). **Normale
+  Analysen (Verifikation aus) behalten ihr Preset-Limit unverändert** — konsistent mit
+  Entscheidung #9.
+- **Tests** (`tests/test_faktencheck_parser.py` o. ä.): `build_prompt(..., custom_module="FAKTENCHECK")`
+  enthält **kein** `ZEICHENLIMIT`/`Maximale Ausgabelänge` mehr (für ein Limit-Preset wie Standard);
+  ohne `custom_module` ist die Limit-Zeile weiterhin vorhanden.
+
+> **Reihenfolge:** A1 zuerst (entblockt OpenRouter), dann A2. Beide vor den C-Backlog-Punkten.
+> Können zusammen als v0.10.1-Hotfix laufen.
+
+---
+
 ## Backlog / Folge-Version (v0.10.1+)
 
-- **„Verifikation erneut versuchen"-Button (hohe Priorität, PO-Wunsch).** Bei
-  fehlgeschlagener/abgebrochener Stufe 2 nur die Verifikation wiederholen — Claims via
-  `extract_claims_from_faktencheck(result_text)` aus dem vorhandenen Ergebnis ziehen und einen
-  neuen `VerificationWorker` starten, **ohne** die komplette Analyse erneut zu fahren. Spart
-  Kosten/Zeit und ist genau der ausfallanfällige Teil. Naheliegend kombiniert mit der
-  Fehler-Anzeige (`_on_verify_error` setzt einen Retry-Button aktiv).
+- **„Verifikation erneut versuchen"-Button (HOCH, PO-Wunsch; vom Review ausdrücklich bestätigt).**
+  Nach jedem Verifikationslauf (Erfolg, „skipped", Fehler/Abbruch) im `verify_section` einen Button
+  „Verifikation erneut versuchen" aktivieren. Klick:
+  1. **Verifikationsmodell darf vorher gewechselt werden** — Auswahl frisch über
+     `_effective_verify_choice()` lesen (Picker + `:online`). Kernnutzen (Review-Szenario):
+     DeepSeek:online liefert viele „nicht überprüfbar" → Nutzer stellt auf Perplexity Sonar um und
+     fährt **nur Stufe 2** neu.
+  2. Claims via `extract_claims_from_faktencheck(result_text)` aus dem **vorhandenen** Ergebnis
+     ziehen (Stufe 1 bleibt unberührt — kein ~80-s-Re-Run, keine Doppelkosten), `cap_claims` mit
+     aktuellem SpinBox-Wert; neuen `VerificationWorker` starten (bestehendes
+     `_set_verification_running`/Abbrechen wiederverwenden).
+  3. **Vorhandenen Verifikationsabschnitt ERSETZEN, nicht stapeln:** vor dem Anhängen den alten
+     Block ab `### FAKTENCHECK · VERIFIKATION` (inkl. vorangehendem `---`) bis Ende abschneiden,
+     dann neu anhängen — sonst sammeln sich Duplikate bei mehrfachem Retry.
+  Button während eines laufenden Verifikationslaufs deaktivieren.
+- **`:online`-Checkbox-Tooltip präzisieren (NIEDRIG, Review-Anregung).** Tooltip ergänzen/ersetzen:
+  „Das ':online'-Suffix aktiviert die modellspezifische Internetsuche; die Recherche-Qualität hängt
+  stark vom Modell ab." Lernpunkt **„Webzugriff ≠ Webzugriff"**: DeepSeek:online fand real
+  verifizierbare, top-aktuelle News nicht, dedizierte Such-Modelle (Perplexity Sonar) mühelos.
+  Kurz auch in README/Docs als Empfehlung „für Stufe 2 ein dediziertes Such-Modell (z. B. Perplexity
+  Sonar) wählen".
+- **Optional: Perplexity-Modellliste ergänzen (NIEDRIG).** `api_providers.json` führt aktuell
+  `sonar`, `sonar-pro`, `sonar-reasoning` — alle gültig (Stand Juni 2026, offizielle Doku). Nice-to-have:
+  `sonar-reasoning-pro` (DeepSeek-R1-basiert, zeigt Reasoning) und `sonar-deep-research` aufnehmen.
+  Kein Stale-ID-Problem vorhanden.
 - **Debug-Logging nach Schritt/Feature benennen** (= Backlog #8, präzisiert): Logs trennen pro
   Call bereits in eigene Ordner (kein Datenverlust); sie sind nur nach Modell+Zeitstempel
   benannt. Nice-to-have: zusätzlich `feature`/`step` im Ordnernamen für leichtere Zuordnung.

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -142,6 +142,10 @@ class OpenRouterClient(LLMClient):
                 json={
                     "model": model,
                     "messages": [{"role": "user", "content": prompt}],
+                    # max_tokens setzen, sonst rechnet OpenRouter mit dem vollen
+                    # Context-Window als Worst-Case und blockt bei moderatem
+                    # Guthaben mit HTTP 402. 4096 reicht für Analyse/Verifikation.
+                    "max_tokens": 4096,
                 },
                 timeout=120,
             )

--- a/src/core/perplexity_client.py
+++ b/src/core/perplexity_client.py
@@ -78,6 +78,9 @@ class PerplexityClient(LLMClient):
                 json={
                     "model": model,
                     "messages": [{"role": "user", "content": prompt}],
+                    # max_tokens explizit setzen (analog OpenRouter/Anthropic/OpenAI),
+                    # um Worst-Case-Pre-Auth zu vermeiden. 4096 genügt.
+                    "max_tokens": 4096,
                 },
                 timeout=120,
             )

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -252,12 +252,18 @@ FAKTENCHECK_FORMAT = (
     "KEINE Inline-Aufzählung mehrerer Punkte in einer Zeile."
 )
 
-# Hebt das Antwort-Zeichenlimit NUR für den erzwungenen FAKTENCHECK-Lauf (Verifikation) auf,
-# damit die vollständige, relevanz-sortierte Behauptungsliste für das Top-N-Capping entsteht.
-# Steht vor dem (im Template späteren) GESAMTZEICHENLIMIT-Text und überschreibt es so.
+# Positiver Vollständigkeits-Hinweis für den erzwungenen FAKTENCHECK-Lauf. Die
+# eigentlichen Zeichenlimit-Zeilen werden bei FAKTENCHECK aus dem Prompt ENTFERNT
+# (s. _apply_custom_overrides), daher kein "aufgehoben"-Framing mehr nötig.
 FAKTENCHECK_NO_LIMIT_HINT = (
-    "HINWEIS: Für diesen Lauf ist ein etwaiges Gesamtzeichenlimit AUFGEHOBEN. Die "
-    "Vollständigkeit der relevanz-sortierten Behauptungsliste hat Vorrang vor Kürze."
+    "Liste die Behauptungen VOLLSTÄNDIG auf — Vollständigkeit hat Vorrang vor Kürze."
+)
+
+# Entfernt alle Zeichenlimit-Zeilen aus einem gerenderten Prompt (Kopf-Warnung,
+# Regel-Zeile, Erinnerung). Verhindert den Widerspruch zur vollständigen
+# Behauptungsliste bei erzwungenem FAKTENCHECK.
+_CHARLIMIT_LINE_RE = re.compile(
+    r"(?im)^.*(?:ZEICHENLIMIT|Maximale Ausgabelänge).*\n?"
 )
 
 
@@ -286,11 +292,14 @@ def _apply_custom_overrides(
             f"PFLICHT-MODUL: Verwende ausschließlich das Modul '{custom_module}'. "
             f"Keine andere Wahl ist erlaubt."
         )
-        # v0.10.0: Bei erzwungenem FAKTENCHECK zusätzlich das parsbare 3-Block-Format
-        # und die Limit-Aufhebung injizieren (deckt alle Presets ab, auch namens-only).
+        # v0.10.0/v0.10.1: Bei erzwungenem FAKTENCHECK das parsbare 3-Block-Format
+        # injizieren (deckt alle Presets ab, auch namens-only) UND die
+        # Zeichenlimit-Zeilen aus dem Template entfernen, damit kein Widerspruch
+        # zur vollständigen Behauptungsliste entsteht (A2).
         if custom_module.strip().upper() == "FAKTENCHECK":
             parts.append(FAKTENCHECK_NO_LIMIT_HINT)
             parts.append(FAKTENCHECK_FORMAT)
+            rendered = _CHARLIMIT_LINE_RE.sub("", rendered)
 
     if parts:
         parts.append(rendered)

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -259,11 +259,14 @@ FAKTENCHECK_NO_LIMIT_HINT = (
     "Liste die Behauptungen VOLLSTÄNDIG auf — Vollständigkeit hat Vorrang vor Kürze."
 )
 
-# Entfernt alle Zeichenlimit-Zeilen aus einem gerenderten Prompt (Kopf-Warnung,
-# Regel-Zeile, Erinnerung). Verhindert den Widerspruch zur vollständigen
-# Behauptungsliste bei erzwungenem FAKTENCHECK.
+# Entfernt die Zeichenlimit-Kontrollzeilen aus einem gerenderten Prompt (Kopf-
+# Warnung, Regel-Zeile, Erinnerung). An den tatsächlichen Template-Wortlaut
+# angeankert, damit eingebettete Transkript-Zeilen mit "Zeichenlimit"/"maximale
+# Ausgabelänge" NICHT versehentlich entfernt werden (der Prompt enthält im
+# Transkript-Modus das volle Transkript).
 _CHARLIMIT_LINE_RE = re.compile(
-    r"(?im)^.*(?:ZEICHENLIMIT|Maximale Ausgabelänge).*\n?"
+    r"(?im)^.*(?:ZEICHENLIMIT:\s*Deine GESAMTE Antwort MUSS unter"
+    r"|Maximale Ausgabelänge\s*=).*\n?"
 )
 
 

--- a/tests/test_faktencheck_parser.py
+++ b/tests/test_faktencheck_parser.py
@@ -12,8 +12,10 @@ from src.core.prompt_builder import (
     cap_claims,
     build_verification_prompt,
     clean_verification_output,
+    build_prompt,
     VERDICT_VALUES,
 )
+from src.config.defaults import VideoInfo, SomasConfig
 
 
 # --- Beispiel-Analysen ----------------------------------------------------
@@ -200,6 +202,19 @@ def test_clean_verification_output():
     print("  clean_verification_output: Fences/Vorspann entfernt OK")
 
 
+def test_charlimit_removed_for_faktencheck():
+    # A2: Bei erzwungenem FAKTENCHECK dürfen KEINE Zeichenlimit-Zeilen mehr im
+    # Prompt stehen (Widerspruch zur vollständigen Behauptungsliste).
+    vi = VideoInfo(title="T", channel="C", duration=600, url="https://youtu.be/x")
+    cfg = SomasConfig(depth=2, language="Deutsch")
+    forced = build_prompt(vi, cfg, preset_name="Standard", custom_module="FAKTENCHECK")
+    assert "ZEICHENLIMIT" not in forced and "Maximale Ausgabelänge" not in forced, forced
+    # Ohne Erzwingung bleibt das Preset-Limit erhalten.
+    normal = build_prompt(vi, cfg, preset_name="Standard")
+    assert "ZEICHENLIMIT" in normal
+    print("  charlimit_removed_for_faktencheck: Limit weg bei FAKTENCHECK, sonst da OK")
+
+
 def main():
     print("Faktencheck-Parser-Tests:")
     test_extract_standard()
@@ -212,6 +227,7 @@ def main():
     test_cap_claims()
     test_build_verification_prompt()
     test_clean_verification_output()
+    test_charlimit_removed_for_faktencheck()
     print("ALLE TESTS OK")
 
 

--- a/tests/test_faktencheck_parser.py
+++ b/tests/test_faktencheck_parser.py
@@ -13,6 +13,7 @@ from src.core.prompt_builder import (
     build_verification_prompt,
     clean_verification_output,
     build_prompt,
+    build_prompt_from_transcript,
     VERDICT_VALUES,
 )
 from src.config.defaults import VideoInfo, SomasConfig
@@ -202,9 +203,9 @@ def test_clean_verification_output():
     print("  clean_verification_output: Fences/Vorspann entfernt OK")
 
 
-def test_charlimit_removed_for_faktencheck():
-    # A2: Bei erzwungenem FAKTENCHECK dürfen KEINE Zeichenlimit-Zeilen mehr im
-    # Prompt stehen (Widerspruch zur vollständigen Behauptungsliste).
+def test_charlimit_removed_for_faktencheck() -> None:
+    """A2: Zeichenlimit-Kontrollzeilen werden bei erzwungenem FAKTENCHECK aus dem
+    Prompt entfernt, bleiben aber bei normaler Analyse (Standard-Preset) erhalten."""
     vi = VideoInfo(title="T", channel="C", duration=600, url="https://youtu.be/x")
     cfg = SomasConfig(depth=2, language="Deutsch")
     forced = build_prompt(vi, cfg, preset_name="Standard", custom_module="FAKTENCHECK")
@@ -213,6 +214,23 @@ def test_charlimit_removed_for_faktencheck():
     normal = build_prompt(vi, cfg, preset_name="Standard")
     assert "ZEICHENLIMIT" in normal
     print("  charlimit_removed_for_faktencheck: Limit weg bei FAKTENCHECK, sonst da OK")
+
+
+def test_charlimit_strip_preserves_transcript() -> None:
+    """Die Limit-Entfernung darf eingebettete Transkript-Zeilen mit 'Zeichenlimit'/
+    'maximale Ausgabelänge' NICHT löschen — nur die echten Kontrollzeilen."""
+    trap = "Sie sprach über das Zeichenlimit und die maximale Ausgabelänge der KI."
+    cfg = SomasConfig(depth=2, language="Deutsch")
+    prompt = build_prompt_from_transcript(
+        title="T", author="A", transcript=trap, config=cfg,
+        preset_name="Standard", custom_module="FAKTENCHECK",
+    )
+    # Trap-Zeile (Transkript) bleibt erhalten ...
+    assert trap in prompt, "Transkript-Zeile wurde fälschlich entfernt"
+    # ... die echte Kontroll-Zeile ist weg.
+    assert "Deine GESAMTE Antwort MUSS unter" not in prompt
+    assert "Maximale Ausgabelänge =" not in prompt
+    print("  charlimit_strip_preserves_transcript: Transkript-Zeile bleibt, Kontrollzeilen weg OK")
 
 
 def main():
@@ -228,6 +246,7 @@ def main():
     test_build_verification_prompt()
     test_clean_verification_output()
     test_charlimit_removed_for_faktencheck()
+    test_charlimit_strip_preserves_transcript()
     print("ALLE TESTS OK")
 
 


### PR DESCRIPTION
## Bugfix-Runde 4 (A1/A2 aus PO-Beobachtungen, am Code verifiziert)

### A1 — HTTP 402 bei OpenRouter (HOCH)
`openrouter_client` sendete **kein `max_tokens`** → OpenRouter rechnet mit dem vollen Context-Window als Worst-Case und blockt bei moderatem Guthaben mit HTTP 402 („requires more credits, or fewer max_tokens"). Das war die wahre Ursache des 402, nicht zu wenig Guthaben.

**Fix:** `max_tokens: 4096` im Payload von `openrouter_client` **und** `perplexity_client` (konsistent mit `anthropic_client`/`openai_client`, die ihn bereits setzen). Reicht für die kurzen Analyse-/Verifikations-Antworten.

### A2 — Prompt-Widerspruch beim Zeichenlimit bei erzwungenem FAKTENCHECK (MITTEL–HOCH)
Der „Limit aufgehoben"-Hinweis stand voran, aber die Template-Zeichenlimit-Zeilen (Kopf-Warnung, Regel-Zeile, Erinnerung) blieben im Prompt → das Modell kürzte ggf. die Behauptungsliste.

**Fix:** `_apply_custom_overrides` entfernt bei `custom_module == "FAKTENCHECK"` alle Zeichenlimit-Zeilen via Regex aus dem gerenderten Prompt (alle drei Varianten). Der Hinweis ist jetzt rein positiv („Vollständigkeit vor Kürze"), kein „aufgehoben"-Framing mehr. **Normale Analysen** (Verifikation aus) behalten ihr Preset-Limit unverändert (Entscheidung #9).

## Tests
`tests/test_faktencheck_parser.py`: neuer Fall — `build_prompt(..., custom_module="FAKTENCHECK")` enthält kein `ZEICHENLIMIT`/`Maximale Ausgabelänge` mehr (Standard-Preset), ohne Erzwingung weiterhin vorhanden. Alle bestehenden Tests grün; `test_empty_content.py` grün.

## Noch offen
- **PO-Verifikation A1** (real): OpenRouter-Lauf mit knappem Guthaben → kein 402 mehr; Verifikation mit vielen Claims wird nicht abgeschnitten.
- **Versionsbump 0.10.1 + Changelog** halte ich bis zur PO-Bestätigung zurück (real-world-abhängig) — sage Bescheid, dann ziehe ich ihn nach.
- v0.10.1-Backlog (Retry-Button, Export-Kopf) bleibt separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Entfernt widersprüchliche Zeichenlimit-Hinweise aus Faktencheck-Prompts für konsistentere Vollständigkeitsanforderungen.

* **Tests**
  * Neue Testabdeckung für Zeichenlimit-Entfernung bei Faktencheck-Modus hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->