### PR TITLE
v0.10.1 PR 5: Verifikation erneut versuchen (Retry mit Modellwechsel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.10.0
+**Version:** 0.10.1
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -332,10 +332,21 @@ TEST_URLS = [
 - [x] Tests `tests/test_faktencheck_parser.py`; headless + real-web getestet
 - [x] Spec dokumentiert (SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md)
 
+### Phase 12b: Faktencheck-Härtung & Fixes ✅ (v0.10.1)
+
+- [x] Unabhängigkeits-Riegel im Verifikations-Prompt: das geprüfte Video zählt nicht als
+  Beleg (nur externe Quellen); `source_hint` als verbotene Eigenquelle + gegen Prompt-
+  Injection saniert
+- [x] Perplexity-Modelle aktualisiert (`sonar-reasoning-pro`, `sonar-deep-research`)
+- [x] `DEFAULT_MAX_TOKENS = 8192` zentral in allen 4 Clients (behebt OpenRouter-HTTP-402)
+- [x] Zeichenlimit-Zeilen bei erzwungenem FAKTENCHECK entfernt (Regex), `:online`-Tooltip präzisiert
+- [x] Einheitlicher Export-Kopf für Einzelanalyse (Titel + „Kanal, YT" + Thumbnail)
+- [x] „Verifikation erneut versuchen"-Button: nur Stufe 2, Modellwechsel möglich, ersetzt Abschnitt
+- [x] Tests `tests/test_export_header.py` + erweiterte Parser-Tests
+
 ### Backlog
 
-- [ ] „Verifikation erneut versuchen"-Button (nur Stufe 2 wiederholen) — v0.10.1, hohe Priorität
-- [ ] Einheitlicher Export-Kopf (Einzelanalyse wie Modellvergleich: Titel-Block + Thumbnail) — v0.10.1
+- [ ] Docstring-Coverage auf ≥80 % (Test-Funktionen) — CodeRabbit-Gate, niedrige Priorität
 - [ ] Wochentags-basierte Perspektive-Defaults (nach Recherche)
 - [ ] Englisch-Support
 - [ ] PDF-Export (auch für Modellvergleich)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.10.0) — Faktencheck-Verifikation
+### Aktuell (v0.10.1) — Faktencheck-Verifikation (gehärtet)
 
 - **Zweistufige Faktenprüfung** – Das FAKTENCHECK-Modul trennt jetzt strikt **Meinungen**, **Interpretationen** und **überprüfbare Behauptungen** (relevanz-sortiert). Optional prüft danach ein web-fähiges Modell **nur die nackten Behauptungen** und liefert pro Behauptung **Verdikt + Quelle**
 - **Halluzinations-Schutz** – In der Verifikation stehen **keine Meinungen** im Prompt – das Modell kann nicht durch rhetorische Sprache „verführt" werden. Zusätzlicher Riegel gegen erfundene Quellen (kann nicht belegt werden → Verdikt „nicht überprüfbar", Quelle „—")
@@ -22,6 +22,7 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 - **Frei wählbares Verifikationsmodell** – ProviderModelPicker über alle 4 Provider; `:online`-Schalter für echten Web-Zugriff (OpenRouter); Web-Disclaimer, wenn kein bestätigter Web-Zugriff
 - **Konfigurierbare Obergrenze** – Default 10 zu prüfende Behauptungen (app-seitig, deterministisch gekappt; `0 = unbegrenzt`); Meinungen/Interpretationen werden vollständig angezeigt
 - **Sauberer Anhang** – Der Verifikationsabschnitt wird an die Analyse angehängt (Export enthält beide Teile); Stufe-2-Fehler ist nicht fatal (Analyse bleibt erhalten)
+- **Unabhängigkeits-Riegel (v0.10.1)** – Das geprüfte Video selbst zählt nicht als Beleg; nur unabhängige externe Quellen bestätigen/widerlegen. „Verifikation erneut versuchen"-Button wiederholt **nur Stufe 2** (z. B. nach Modellwechsel auf ein stärkeres Web-Modell)
 
 ### Seit v0.9.0 — Modellvergleich
 
@@ -320,6 +321,7 @@ Die App implementiert das SOMAS-Framework mit Content-Type-spezifischen Analyse-
 
 | Version | Datum | Änderungen |
 | --------- | ------- | ------------ |
+| 0.10.1 | 2026-06-16 | Faktencheck-Härtung: Unabhängigkeits-Riegel (kein Eigenbeleg durchs Video, `source_hint` injection-sicher), „Verifikation erneut versuchen"-Button (nur Stufe 2, Modellwechsel), Perplexity-Modelle aktualisiert (`sonar-reasoning-pro`/`sonar-deep-research`), `DEFAULT_MAX_TOKENS=8192` (HTTP-402-Fix), einheitlicher Export-Kopf (Titel + Thumbnail), Zeichenlimit-Fix bei FAKTENCHECK |
 | 0.10.0 | 2026-06-14 | Faktencheck-Verifikation (Hybrid): Stufe 1 trennt Meinungen/Interpretationen/Behauptungen; optionale Stufe 2 verifiziert Behauptungen per web-fähigem Modell (Verdikt + Quelle, 4-stufige Skala), Halluzinations-Schutz + Riegel gegen erfundene Quellen, `:online`-Schalter, Top-N-Kappung, Auto-Anhang |
 | 0.9.1 | 2026-05-30 | Fix: leeren/None-Content der Provider (z.B. OpenRouter `tencent/hy3-preview`) sauber als Fehler behandeln statt Crash; `reasoning`-Fallback + `finish_reason`-Diagnose; alle 4 Clients abgesichert; Regressionstest |
 | 0.9.0 | 2026-05-29 | Modellvergleich: zwei SOMAS-Analysen eines Videos + automatische Synthese-Kurzbeschreibung, deterministisches Markdown-Layout (Thumbnail), ProviderModelPicker, Export nach exports/ |

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.10.0"
+APP_VERSION = "0.10.1"
 
 
 class DebugLogger:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -2279,7 +2279,7 @@ class MainWindow(QMainWindow):
         self._verification_base_text = response.content.rstrip()
         self._start_verification(sel)
 
-    def _start_verification(self, sel) -> None:
+    def _start_verification(self, sel: ModelChoice) -> None:
         """Baut Config aus dem Basis-Text + Modellauswahl und startet den Worker."""
         all_claims = extract_claims_from_faktencheck(self._verification_base_text)
         claims, total = cap_claims(all_claims, self._verification_max_claims)
@@ -2310,6 +2310,10 @@ class MainWindow(QMainWindow):
     def _on_verify_retry(self) -> None:
         """Wiederholt NUR Stufe 2 auf den vorhandenen Behauptungen (Modellwechsel ok)."""
         if self._verification_worker and self._verification_worker.isRunning():
+            return
+        if self._api_worker and self._api_worker.isRunning():
+            # Analyse läuft noch (Auto-Anhang folgt) — kein paralleler Retry,
+            # sonst konkurrieren beide Pfade um result_text/Verifikationsstatus.
             return
         if not self._verification_base_text:
             # Fallback: aktuellen Ergebnistext als Basis nehmen (z. B. eingefügte Analyse)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -162,6 +162,8 @@ class MainWindow(QMainWindow):
         # Faktencheck-Verifikation-State (v0.10.0)
         self._verification_worker: VerificationWorker | None = None
         self._verification_max_claims: int = prefs.get("verification_max_claims", 10)
+        # Analyse-Text OHNE Verifikationsabschnitt (Basis für Retry, v0.10.1)
+        self._verification_base_text: str = ""
 
         # Lade Presets mit Fehlerbehandlung
         try:
@@ -586,6 +588,16 @@ class MainWindow(QMainWindow):
         self.verify_max_spin.setToolTip("0 = unbegrenzt (alle Behauptungen prüfen).")
         verify_opts.addWidget(self.verify_max_spin)
         verify_opts.addStretch()
+        # Nur Stufe 2 auf den vorhandenen Behauptungen wiederholen (z. B. nach
+        # Modellwechsel) — ohne erneuten Analyse-Lauf. Aktiv erst nach einem Lauf.
+        self.btn_verify_retry = QPushButton("Verifikation erneut versuchen")
+        self.btn_verify_retry.setEnabled(False)
+        self.btn_verify_retry.setToolTip(
+            "Prüft nur die bereits ermittelten Behauptungen erneut (mit dem aktuell "
+            "gewählten Verifikationsmodell) — die Analyse wird nicht neu erstellt."
+        )
+        self.btn_verify_retry.clicked.connect(self._on_verify_retry)
+        verify_opts.addWidget(self.btn_verify_retry)
         self.btn_verify_cancel = QPushButton("Abbrechen")
         self.btn_verify_cancel.setEnabled(False)
         self.btn_verify_cancel.clicked.connect(self._on_verify_cancel)
@@ -998,6 +1010,9 @@ class MainWindow(QMainWindow):
             self.rating_widget.setVisible(False)
             self.btn_channel_rating.setVisible(False)
             self._current_analysis_id = None
+            # Verifikations-Retry für das alte Video verfällt.
+            self._verification_base_text = ""
+            self.btn_verify_retry.setEnabled(False)
         except ValueError as e:
             QMessageBox.critical(self, "Fehler", str(e))
             logger.error(f"Fehler beim Abrufen der Metadaten: {e}")
@@ -1863,6 +1878,9 @@ class MainWindow(QMainWindow):
         """Handler für erfolgreiche API-Antwort."""
         self._last_api_response = response
         self._is_comparison_result = False
+        # Neues Analyse-Ergebnis → alter Retry-Stand ungültig (wird neu gesetzt,
+        # falls die Verifikation für diesen Lauf läuft).
+        self.btn_verify_retry.setEnabled(False)
         self._clear_stale_sources()
         self.result_text.setText(response.content)
         logger.info(
@@ -2243,17 +2261,27 @@ class MainWindow(QMainWindow):
         # während die Stufe-2-Sektion noch angehängt wird (Stale-State / Race).
         self.btn_get_meta.setEnabled(not running)
         self.url_input.setEnabled(not running)
+        # Retry während eines Laufs sperren; das Wieder-Aktivieren übernehmen die
+        # finished/error-Slots (nur wenn ein Basis-Text vorliegt).
+        if running:
+            self.btn_verify_retry.setEnabled(False)
         self.btn_generate.setText("Verifikation läuft…" if running else "Generate Prompt")
 
     def _maybe_start_verification(self, response: APIResponse) -> None:
-        """Startet Stufe 2, wenn die Verifikation aktiv ist."""
+        """Startet Stufe 2 nach einer frischen Analyse, wenn die Verifikation aktiv ist."""
         if not self.verify_checkbox.isChecked():
             return
         sel = self._effective_verify_choice()
         if not sel:
             return  # Preflight hätte das abgefangen — defensiv überspringen
+        # Analyse-Text als Basis merken (ohne Verifikationsabschnitt) — Grundlage
+        # für ein späteres "erneut versuchen".
+        self._verification_base_text = response.content.rstrip()
+        self._start_verification(sel)
 
-        all_claims = extract_claims_from_faktencheck(response.content)
+    def _start_verification(self, sel) -> None:
+        """Baut Config aus dem Basis-Text + Modellauswahl und startet den Worker."""
+        all_claims = extract_claims_from_faktencheck(self._verification_base_text)
         claims, total = cap_claims(all_claims, self._verification_max_claims)
         config = VerificationConfig(
             claims=claims,
@@ -2278,10 +2306,42 @@ class MainWindow(QMainWindow):
         )
         worker.start()
 
-    def _append_to_result(self, section: str) -> None:
-        """Hängt einen Markdown-Abschnitt an das bestehende Ergebnis an."""
-        current = self.result_text.toPlainText().rstrip()
-        self.result_text.setPlainText(f"{current}\n\n{section.strip()}\n")
+    @pyqtSlot()
+    def _on_verify_retry(self) -> None:
+        """Wiederholt NUR Stufe 2 auf den vorhandenen Behauptungen (Modellwechsel ok)."""
+        if self._verification_worker and self._verification_worker.isRunning():
+            return
+        if not self._verification_base_text:
+            # Fallback: aktuellen Ergebnistext als Basis nehmen (z. B. eingefügte Analyse)
+            self._verification_base_text = self.result_text.toPlainText().rstrip()
+        if not extract_claims_from_faktencheck(self._verification_base_text):
+            QMessageBox.information(
+                self, "Keine Behauptungen",
+                "Im Ergebnis sind keine überprüfbaren Behauptungen (FAKTENCHECK-Block) "
+                "vorhanden, die erneut geprüft werden könnten.",
+            )
+            return
+        sel = self._effective_verify_choice()
+        if not sel:
+            QMessageBox.warning(
+                self, "Verifikationsmodell fehlt", "Bitte ein Verifikationsmodell wählen.",
+            )
+            return
+        if not get_api_key(sel.provider_id):
+            QMessageBox.warning(
+                self, "API-Key fehlt",
+                f"Kein API-Key für {sel.provider_name or sel.provider_id} konfiguriert.",
+            )
+            return
+        self._start_verification(sel)
+
+    def _set_result_with_verification(self, section: str) -> None:
+        """Setzt das Ergebnis = Analyse-Basis + Verifikationsabschnitt.
+
+        Ersetzt einen evtl. vorhandenen früheren Abschnitt (Retry hängt nicht an).
+        """
+        base = self._verification_base_text or self.result_text.toPlainText().rstrip()
+        self.result_text.setPlainText(f"{base}\n\n{section.strip()}\n")
 
     @pyqtSlot(str)
     def _on_verify_status(self, status: str) -> None:
@@ -2290,26 +2350,28 @@ class MainWindow(QMainWindow):
 
     @pyqtSlot(str, object)
     def _on_verify_finished(self, section: str, result: VerificationResult) -> None:
-        """Hängt den Verifikationsabschnitt an die Analyse an."""
-        self._append_to_result(section)
+        """Setzt den Verifikationsabschnitt unter die Analyse (ersetzend)."""
+        self._set_result_with_verification(section)
         if getattr(result, "status", "") == "skipped":
             self.verify_section.set_summary(
                 "Keine überprüfbaren Behauptungen", color="#888888"
             )
         else:
             self.verify_section.set_summary("Verifikation fertig ✓", color="#2E7D32")
-        logger.info("Verifikationsabschnitt angehängt")
+        self.btn_verify_retry.setEnabled(True)
+        logger.info("Verifikationsabschnitt gesetzt")
 
     @pyqtSlot(str)
     def _on_verify_error(self, message: str) -> None:
-        """Hängt einen Platzhalter an (Analyse bleibt erhalten) + Warnung."""
+        """Setzt einen Platzhalter (Analyse bleibt erhalten) + Warnung + Retry aktiv."""
         placeholder = (
             "---\n\n### FAKTENCHECK · VERIFIKATION\n"
             f"_Verifikation fehlgeschlagen: {message}. "
             "Behauptungen siehe FAKTENCHECK-Block oben._\n"
         )
-        self._append_to_result(placeholder)
+        self._set_result_with_verification(placeholder)
         self.verify_section.set_summary("Verifikation fehlgeschlagen", color="#C62828")
+        self.btn_verify_retry.setEnabled(True)
         QMessageBox.warning(self, "Verifikation fehlgeschlagen", message)
 
     @pyqtSlot()
@@ -2319,6 +2381,9 @@ class MainWindow(QMainWindow):
             self._verification_worker.cancel()
             self.verify_section.set_summary("Abgebrochen", color="#C62828")
             self.btn_verify_cancel.setEnabled(False)
+            # Retry erlauben, falls bereits Behauptungen vorliegen.
+            if self._verification_base_text:
+                self.btn_verify_retry.setEnabled(True)
 
     # ── Custom Prompt Editor ──────────────────────────────────────────
 


### PR DESCRIPTION
## PR 5 — „Verifikation erneut versuchen"-Button (HOCH)

Wiederholt **nur Stufe 2** auf den bereits isolierten Behauptungen — **ohne** erneuten ~80-s-Stufe-1-Lauf und ohne Doppelkosten. Genau der ausfallanfällige/variable Teil.

**Kernszenario:** Ein schwaches Web-Modell (z. B. DeepSeek:online) liefert 5/7 „nicht überprüfbar" → Verifikationsmodell im Picker auf **Perplexity `sonar-pro`/`sonar-reasoning-pro`** umstellen (oder `:online` setzen) → **„Verifikation erneut versuchen"** → nur Stufe 2 läuft neu.

### Umsetzung (`main_window.py`)
- Neuer Button in der Verifikations-Section: aktiv **nach** einem Lauf, gesperrt **während** eines Laufs, zurückgesetzt bei **neuer Analyse / neuem Video**.
- `_verification_base_text` hält die Analyse **ohne** Verifikationsabschnitt → der Retry **ersetzt** den Abschnitt (kein doppeltes `### FAKTENCHECK · VERIFIKATION`).
- Modellwechsel: Retry liest die aktuelle Picker-Auswahl inkl. `:online` neu (`_effective_verify_choice`).
- `_start_verification()` aus `_maybe_start_verification` extrahiert (gemeinsamer Pfad).
- Race-Beachtung wie v0.10.0: Quelle/Controls während des Laufs gesperrt.

### Tests
Offscreen verifiziert: Enable/Disable-Logik, Wiederverwendung der vorhandenen Claims (kein neuer Stufe-1-Lauf), Modellwechsel (`:online`-Suffix), Replace-statt-Append, Reset bei neuer Analyse. Bestehende Test-Suites grün.

### Offen
- **PO-In-App-Test**: Retry nach Modellwechsel ersetzt die Sektion sauber.
- **DoD** (Versionsbump 0.10.0 → 0.10.1 + Changelog/Doku) ziehe ich nach deiner Abnahme auf diesem Branch nach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Wiederholungsmechanismus für die Faktencheck-Verifikation (Stufe 2): Neuer Button „Verifikation erneut versuchen“ startet die Verifikation erneut, ohne die gesamte Analyse neu durchzuführen.
  * Die Verifikationsausgabe wird dabei konsistent aktualisiert, statt frühere Abschnitte anzuhängen; der Retry-Zustand wird bei neuen Analysen/Antworten zurückgesetzt.
* **Chores**
  * Version auf **0.10.1** aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->