### PR TITLE
Feature: WordPress-Export – Analyse als Beitrag senden (Variante A, D…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ yt-dlp>=2024.1.0                 # Metadaten-Extraktion (Titel, Kanal, Dauer)
 # Template Engine (für Prompt-Generierung)
 Jinja2>=3.1.0
 
+# WordPress-Export (Markdown -> HTML)
+markdown>=3.4.0
+
 # API Integration
 requests>=2.31.0
 keyring>=24.0.0

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -1,0 +1,423 @@
+"""WordPress-Integration: Sendet SOMAS-Analysen als Beitrag an die selbstgehostete
+WordPress-Seite via REST-API (`/wp-json/wp/v2/posts`).
+
+Da SOMAS eine Desktop-App ist, entfällt CORS – ein direkter HTTPS-Request mit
+HTTP Basic Auth (Benutzername + Application Password) genügt.
+
+Credentials:
+- URL, Benutzername, Default-Status, Default-Kategorie -> user_preferences.json
+  (nicht sensibel)
+- Application Password -> OS Credential Manager (keyring), analog zu den API-Keys.
+
+Markdown -> HTML wird clientseitig konvertiert, da WordPress Beiträge als HTML
+speichert.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import keyring
+import requests
+from requests.auth import HTTPBasicAuth
+
+from src.config.api_config import (
+    SERVICE_NAME,
+    load_preferences,
+    save_preferences,
+)
+
+logger = logging.getLogger(__name__)
+
+# Keyring-Schlüssel für das Application Password (analog zu "<provider>_api_key").
+_WP_PASSWORD_KEY = "wordpress_app_password"
+
+# Preferences-Schlüssel (nicht-sensible Config).
+_PREF_URL = "wordpress_url"
+_PREF_USER = "wordpress_user"
+_PREF_STATUS = "wordpress_default_status"
+_PREF_CATEGORY = "wordpress_default_category"
+
+#: Erlaubte Beitragsstatus laut WordPress-REST-API.
+WP_STATUSES = ("draft", "private", "publish", "pending")
+
+#: Standard-Status, wenn nichts konfiguriert ist (sicherste Variante: Entwurf).
+DEFAULT_STATUS = "draft"
+
+_REQUEST_TIMEOUT = 30
+
+
+# --------------------------------------------------------------------------- #
+# Datenmodell + Credential-Verwaltung
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class WordPressConfig:
+    """Konfiguration für die WordPress-Verbindung.
+
+    Attributes:
+        url: Basis-URL der WordPress-Seite (ohne abschließenden Slash),
+            z.B. ``https://diggi.torja.de``.
+        username: WordPress-Benutzername mit Veröffentlichungsrecht.
+        default_status: Vorausgewählter Beitragsstatus im Sende-Dialog.
+        default_category: Optionale Default-Kategorie (Name), die beim Senden
+            automatisch angelegt/zugewiesen wird.
+    """
+
+    url: str = ""
+    username: str = ""
+    default_status: str = DEFAULT_STATUS
+    default_category: str = ""
+
+    @property
+    def is_complete(self) -> bool:
+        """True, wenn URL und Benutzername gesetzt sind (Passwort separat)."""
+        return bool(self.url.strip() and self.username.strip())
+
+
+def get_wp_config() -> WordPressConfig:
+    """Lädt die WordPress-Konfiguration aus den User-Preferences.
+
+    Returns:
+        Befülltes :class:`WordPressConfig` (leer, wenn nichts konfiguriert).
+    """
+    prefs = load_preferences()
+    status = prefs.get(_PREF_STATUS, DEFAULT_STATUS)
+    if status not in WP_STATUSES:
+        status = DEFAULT_STATUS
+    return WordPressConfig(
+        url=prefs.get(_PREF_URL, "").rstrip("/"),
+        username=prefs.get(_PREF_USER, ""),
+        default_status=status,
+        default_category=prefs.get(_PREF_CATEGORY, ""),
+    )
+
+
+def save_wp_config(
+    url: str,
+    username: str,
+    default_status: str = DEFAULT_STATUS,
+    default_category: str = "",
+) -> None:
+    """Speichert die nicht-sensible WordPress-Config in den User-Preferences.
+
+    Args:
+        url: Basis-URL der WordPress-Seite.
+        username: WordPress-Benutzername.
+        default_status: Default-Beitragsstatus.
+        default_category: Optionale Default-Kategorie.
+    """
+    prefs = load_preferences()
+    prefs[_PREF_URL] = url.strip().rstrip("/")
+    prefs[_PREF_USER] = username.strip()
+    prefs[_PREF_STATUS] = (
+        default_status if default_status in WP_STATUSES else DEFAULT_STATUS
+    )
+    prefs[_PREF_CATEGORY] = default_category.strip()
+    save_preferences(prefs)
+    logger.info("WordPress-Konfiguration gespeichert")
+
+
+def get_wp_app_password() -> Optional[str]:
+    """Holt das Application Password aus dem OS Credential Manager.
+
+    Returns:
+        Das Passwort oder ``None``, wenn keines hinterlegt ist.
+    """
+    return keyring.get_password(SERVICE_NAME, _WP_PASSWORD_KEY)
+
+
+def save_wp_app_password(app_password: str) -> None:
+    """Speichert das Application Password sicher im Credential Manager.
+
+    Leerzeichen im WordPress-Passwort werden beibehalten – WordPress akzeptiert
+    es mit oder ohne, das Entfernen ist nicht nötig.
+
+    Args:
+        app_password: Das von WordPress generierte Application Password.
+    """
+    keyring.set_password(SERVICE_NAME, _WP_PASSWORD_KEY, app_password)
+    logger.info("WordPress Application Password gespeichert")
+
+
+def delete_wp_app_password() -> None:
+    """Löscht das Application Password aus dem Credential Manager."""
+    try:
+        keyring.delete_password(SERVICE_NAME, _WP_PASSWORD_KEY)
+        logger.info("WordPress Application Password gelöscht")
+    except keyring.errors.PasswordDeleteError:
+        pass  # Passwort existierte nicht
+
+
+def has_wp_credentials() -> bool:
+    """Prüft, ob URL, Benutzername und Application Password vollständig sind.
+
+    Returns:
+        True, wenn alle drei Bestandteile vorhanden sind.
+    """
+    config = get_wp_config()
+    return config.is_complete and bool(get_wp_app_password())
+
+
+# --------------------------------------------------------------------------- #
+# Markdown -> HTML + Inhalts-Helfer
+# --------------------------------------------------------------------------- #
+
+
+def markdown_to_html(md_text: str) -> str:
+    """Konvertiert Markdown nach HTML für den WordPress-Block-Editor.
+
+    WordPress speichert Beiträge als HTML; roher Markdown würde wörtlich im Post
+    landen. Emojis und Unicode bleiben dabei unverändert erhalten.
+
+    Args:
+        md_text: Markdown-Quelltext.
+
+    Returns:
+        Gerendertes HTML.
+
+    Raises:
+        RuntimeError: Wenn das ``markdown``-Paket nicht installiert ist.
+    """
+    try:
+        import markdown
+    except ImportError as exc:  # pragma: no cover - reine Abhängigkeitsprüfung
+        raise RuntimeError(
+            "Das Paket 'markdown' wird benötigt. "
+            "Installiere es mit: pip install markdown"
+        ) from exc
+
+    return markdown.markdown(
+        md_text,
+        extensions=["extra", "fenced_code", "tables", "sane_lists"],
+    )
+
+
+def assemble_content(intro_md: str, analysis_md: str, outro_md: str) -> str:
+    """Fügt Intro, Analyse und Outro zu einem Markdown-Block zusammen.
+
+    Leere Felder werden ausgelassen, sodass bei leerem Intro/Outro nur die
+    Analyse gesendet wird (Variante A: getrennte Felder).
+
+    Args:
+        intro_md: Optionaler Einleitungstext (Markdown).
+        analysis_md: Die SOMAS-Analyse (Markdown).
+        outro_md: Optionaler Ausleitungstext (Markdown).
+
+    Returns:
+        Zusammengesetzter Markdown-String (Teile durch Leerzeile getrennt).
+    """
+    parts = [
+        part.strip()
+        for part in (intro_md, analysis_md, outro_md)
+        if part and part.strip()
+    ]
+    return "\n\n".join(parts)
+
+
+def split_title_and_body(md_text: str, fallback_title: str = "Analyse") -> tuple[str, str]:
+    """Zieht eine führende H1-Überschrift als Titel heraus, falls vorhanden.
+
+    Vermeidet eine Dopplung, wenn die Analyse mit ``# Titel`` beginnt.
+
+    Args:
+        md_text: Markdown-Quelltext.
+        fallback_title: Titel, falls keine H1 am Anfang steht.
+
+    Returns:
+        Tupel ``(title, body)``.
+    """
+    lines = md_text.lstrip().splitlines()
+    if lines and lines[0].startswith("# "):
+        title = lines[0][2:].strip()
+        body = "\n".join(lines[1:]).lstrip()
+        return title, body
+    return fallback_title, md_text
+
+
+# --------------------------------------------------------------------------- #
+# REST-Client
+# --------------------------------------------------------------------------- #
+
+
+class WordPressError(Exception):
+    """Fehler bei der Kommunikation mit der WordPress-REST-API."""
+
+
+class WordPressClient:
+    """Schlanker Client für die WordPress-REST-API (Beiträge + Taxonomien).
+
+    Authentifizierung via HTTP Basic Auth mit Benutzername + Application
+    Password.
+    """
+
+    def __init__(self, config: WordPressConfig, app_password: str) -> None:
+        """Initialisiert den Client.
+
+        Args:
+            config: WordPress-Konfiguration (URL, Benutzer, Defaults).
+            app_password: Das Application Password.
+        """
+        self.url = config.url.rstrip("/")
+        self.username = config.username
+        self._auth = HTTPBasicAuth(config.username, app_password)
+
+    # -- intern -------------------------------------------------------------- #
+
+    def _endpoint(self, path: str) -> str:
+        return f"{self.url}/wp-json/wp/v2/{path.lstrip('/')}"
+
+    # -- öffentlich ---------------------------------------------------------- #
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Testet die Verbindung und die Anmeldedaten.
+
+        Ruft den ``/users/me``-Endpunkt auf, der gültige Credentials verlangt.
+
+        Returns:
+            Tupel ``(success, message)`` mit einer benutzerfreundlichen Meldung.
+        """
+        try:
+            resp = requests.get(
+                self._endpoint("users/me"),
+                auth=self._auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            return False, f"Verbindung fehlgeschlagen: {exc}"
+
+        if resp.status_code == 200:
+            try:
+                name = resp.json().get("name", self.username)
+            except ValueError:
+                name = self.username
+            return True, f"Verbunden als '{name}'."
+        if resp.status_code in (401, 403):
+            return False, "Anmeldung fehlgeschlagen – Benutzer/Passwort prüfen."
+        return False, f"Unerwartete Antwort (HTTP {resp.status_code})."
+
+    def get_or_create_term(self, name: str, taxonomy: str = "tags") -> int:
+        """Schlägt eine Kategorie/einen Tag nach und legt sie bei Bedarf an.
+
+        Die REST-API erwartet numerische IDs, keine Namen.
+
+        Args:
+            name: Anzeigename der Kategorie/des Tags.
+            taxonomy: ``"tags"`` oder ``"categories"``.
+
+        Returns:
+            Die numerische Term-ID.
+
+        Raises:
+            WordPressError: Bei API-Fehlern.
+        """
+        base = self._endpoint(taxonomy)
+        try:
+            # 1. Suchen
+            resp = requests.get(
+                base, params={"search": name}, auth=self._auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            for term in resp.json():
+                if term.get("name", "").lower() == name.lower():
+                    return int(term["id"])
+
+            # 2. Nicht gefunden -> anlegen
+            resp = requests.post(
+                base, json={"name": name}, auth=self._auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return int(resp.json()["id"])
+        except requests.RequestException as exc:
+            raise WordPressError(
+                f"Taxonomie '{taxonomy}' konnte nicht verarbeitet werden: {exc}"
+            ) from exc
+        except (KeyError, ValueError) as exc:
+            raise WordPressError(
+                f"Unerwartete Antwort beim Anlegen von '{name}': {exc}"
+            ) from exc
+
+    def resolve_terms(self, names: list[str], taxonomy: str = "tags") -> list[int]:
+        """Wandelt eine Liste von Namen in Term-IDs um (leere werden ignoriert).
+
+        Args:
+            names: Namen der Kategorien/Tags.
+            taxonomy: ``"tags"`` oder ``"categories"``.
+
+        Returns:
+            Liste numerischer IDs.
+        """
+        ids: list[int] = []
+        for name in names:
+            cleaned = name.strip()
+            if cleaned:
+                ids.append(self.get_or_create_term(cleaned, taxonomy))
+        return ids
+
+    def post(
+        self,
+        title: str,
+        html_content: str,
+        status: str = DEFAULT_STATUS,
+        category_ids: Optional[list[int]] = None,
+        tag_ids: Optional[list[int]] = None,
+    ) -> tuple[int, str]:
+        """Erstellt einen Beitrag in WordPress.
+
+        Args:
+            title: Beitragstitel.
+            html_content: Bereits nach HTML konvertierter Inhalt.
+            status: Beitragsstatus (``draft`` | ``publish`` | ``private`` |
+                ``pending``).
+            category_ids: Optionale Kategorie-IDs.
+            tag_ids: Optionale Tag-IDs.
+
+        Returns:
+            Tupel ``(post_id, link)``.
+
+        Raises:
+            WordPressError: Bei API-/Netzwerkfehlern.
+        """
+        if status not in WP_STATUSES:
+            status = DEFAULT_STATUS
+
+        payload: dict = {
+            "title": title,
+            "content": html_content,
+            "status": status,
+        }
+        if category_ids:
+            payload["categories"] = category_ids
+        if tag_ids:
+            payload["tags"] = tag_ids
+
+        try:
+            resp = requests.post(
+                self._endpoint("posts"),
+                json=payload,
+                auth=self._auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return int(data["id"]), data.get("link", "")
+        except requests.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.response.json().get("message", "")
+            except (ValueError, AttributeError):
+                detail = exc.response.text[:200] if exc.response is not None else ""
+            raise WordPressError(
+                f"Beitrag konnte nicht gesendet werden (HTTP "
+                f"{exc.response.status_code if exc.response is not None else '?'})"
+                f"{': ' + detail if detail else ''}"
+            ) from exc
+        except requests.RequestException as exc:
+            raise WordPressError(f"Netzwerkfehler beim Senden: {exc}") from exc
+        except (KeyError, ValueError) as exc:
+            raise WordPressError(
+                f"Unerwartete Antwort von WordPress: {exc}"
+            ) from exc

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -421,3 +421,64 @@ class WordPressClient:
             raise WordPressError(
                 f"Unerwartete Antwort von WordPress: {exc}"
             ) from exc
+
+
+# --------------------------------------------------------------------------- #
+# High-Level-Operationen (für den asynchronen Worker, blockierend ausgeführt)
+# --------------------------------------------------------------------------- #
+
+
+def run_connection_test(config: WordPressConfig, app_password: str) -> tuple[bool, str]:
+    """Führt einen Verbindungstest aus (blockierend – im Worker-Thread nutzen).
+
+    Args:
+        config: WordPress-Konfiguration.
+        app_password: Application Password.
+
+    Returns:
+        Tupel ``(success, message)``.
+    """
+    return WordPressClient(config, app_password).test_connection()
+
+
+def publish_post(
+    config: WordPressConfig,
+    app_password: str,
+    title: str,
+    markdown_content: str,
+    status: str = DEFAULT_STATUS,
+    category_names: Optional[list[str]] = None,
+    tag_names: Optional[list[str]] = None,
+) -> tuple[int, str]:
+    """Konvertiert Markdown, löst Taxonomien auf und postet (blockierend).
+
+    Diese Funktion bündelt alle Netzwerk-Operationen, damit sie als Einheit im
+    Worker-Thread laufen kann.
+
+    Args:
+        config: WordPress-Konfiguration.
+        app_password: Application Password.
+        title: Beitragstitel.
+        markdown_content: Beitragsinhalt als Markdown.
+        status: Beitragsstatus.
+        category_names: Optionale Kategorie-Namen.
+        tag_names: Optionale Tag-Namen.
+
+    Returns:
+        Tupel ``(post_id, link)``.
+
+    Raises:
+        WordPressError: Bei API-/Netzwerkfehlern.
+        RuntimeError: Wenn das ``markdown``-Paket fehlt.
+    """
+    client = WordPressClient(config, app_password)
+    html = markdown_to_html(markdown_content)
+    category_ids = client.resolve_terms(category_names or [], "categories")
+    tag_ids = client.resolve_terms(tag_names or [], "tags")
+    return client.post(
+        title=title,
+        html_content=html,
+        status=status,
+        category_ids=category_ids or None,
+        tag_ids=tag_ids or None,
+    )

--- a/src/core/wordpress_worker.py
+++ b/src/core/wordpress_worker.py
@@ -1,0 +1,55 @@
+"""Wiederverwendbarer QThread-Worker für blockierende WordPress-Operationen.
+
+Sowohl der Verbindungstest (Einstellungen) als auch das Senden eines Beitrags
+(Sende-Dialog) sind Netzwerk-Operationen, die den GUI-Thread einfrieren würden.
+Dieser Worker führt eine beliebige Funktion im Hintergrund aus und meldet das
+Ergebnis bzw. einen Fehler per Signal zurück.
+
+Wichtig (PyQt-Konventionen):
+- Im ``run()`` werden **keine** Widgets angefasst – ausschließlich Signals
+  emittiert. Das UI-Update erfolgt in den verbundenen Slots im Main-Thread.
+- Der Aufrufer muss eine Referenz auf die Worker-Instanz halten, sonst wird der
+  QThread vorzeitig vom Garbage Collector eingesammelt.
+"""
+
+import logging
+from typing import Any, Callable
+
+from PyQt6.QtCore import QThread, pyqtSignal
+
+logger = logging.getLogger(__name__)
+
+
+class WordPressWorker(QThread):
+    """Führt eine blockierende Funktion im Hintergrund aus.
+
+    Signals:
+        succeeded: Emittiert das Rückgabeobjekt der Funktion bei Erfolg.
+        failed: Emittiert eine Fehlermeldung (str) bei einer Exception.
+    """
+
+    succeeded = pyqtSignal(object)
+    failed = pyqtSignal(str)
+
+    def __init__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Initialisiert den Worker.
+
+        Args:
+            fn: Die im Hintergrund auszuführende (blockierende) Funktion.
+            *args: Positionsargumente für ``fn``.
+            **kwargs: Schlüsselwortargumente für ``fn``.
+        """
+        super().__init__()
+        self._fn = fn
+        self._args = args
+        self._kwargs = kwargs
+
+    def run(self) -> None:
+        """Führt die Funktion aus und meldet Ergebnis oder Fehler per Signal."""
+        try:
+            result = self._fn(*self._args, **self._kwargs)
+        except Exception as exc:  # noqa: BLE001 – bewusst alles abfangen, Thread darf nicht crashen
+            logger.error("WordPress-Worker fehlgeschlagen: %s", exc)
+            self.failed.emit(str(exc))
+        else:
+            self.succeeded.emit(result)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -710,6 +710,10 @@ class MainWindow(QMainWindow):
         self.btn_export_linkedin = QPushButton("Export: LinkedIn")
         self.btn_export_markdown = QPushButton("Export: Markdown")
         self.btn_export_pdf = QPushButton("Export: PDF")
+        self.btn_send_blog = QPushButton("An Blog senden")
+        self.btn_send_blog.setToolTip(
+            "Analyse als WordPress-Beitrag senden (Konfiguration unter Settings)"
+        )
 
         # Quellen-Detail-Button (erscheint nach LinkedIn-Export)
         self.btn_sources_detail = QPushButton("Quellen (Details)")
@@ -722,6 +726,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.btn_export_linkedin)
         layout.addWidget(self.btn_export_markdown)
         layout.addWidget(self.btn_export_pdf)
+        layout.addWidget(self.btn_send_blog)
         layout.addWidget(self.btn_sources_detail)
         layout.addStretch()
 
@@ -745,6 +750,7 @@ class MainWindow(QMainWindow):
         # Export-Buttons
         self.btn_export_linkedin.clicked.connect(self._on_export_linkedin)
         self.btn_export_markdown.clicked.connect(self._on_export_markdown)
+        self.btn_send_blog.clicked.connect(self._on_send_to_wordpress)
         self.btn_sources_detail.clicked.connect(self._on_copy_sources_detail)
         # Input-Tabs (YouTube / Transkript)
         self.input_tabs.currentChanged.connect(self._on_input_tab_changed)
@@ -1439,6 +1445,19 @@ class MainWindow(QMainWindow):
             except Exception as e:
                 QMessageBox.critical(self, "Fehler", f"Export fehlgeschlagen: {e}")
                 logger.error(f"Markdown-Export fehlgeschlagen: {e}")
+
+    def _on_send_to_wordpress(self) -> None:
+        """Öffnet den WordPress-Sende-Dialog mit der aktuellen Analyse."""
+        result = self.result_text.toPlainText().strip()
+        if not result:
+            QMessageBox.warning(self, "An Blog senden", "Kein Analyse-Ergebnis vorhanden.")
+            return
+
+        from src.gui.wordpress_dialog import WordPressSendDialog
+
+        suggested_title = self.video_info.title if self.video_info else ""
+        dialog = WordPressSendDialog(result, suggested_title, parent=self)
+        dialog.exec()
 
     def _export_comparison_markdown(self, content: str) -> None:
         """Speichert das fertige Vergleichs-Markdown ohne zusätzlichen Header."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1446,6 +1446,7 @@ class MainWindow(QMainWindow):
                 QMessageBox.critical(self, "Fehler", f"Export fehlgeschlagen: {e}")
                 logger.error(f"Markdown-Export fehlgeschlagen: {e}")
 
+    @pyqtSlot()
     def _on_send_to_wordpress(self) -> None:
         """Öffnet den WordPress-Sende-Dialog mit der aktuellen Analyse."""
         result = self.result_text.toPlainText().strip()

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -10,7 +10,7 @@ from typing import Optional
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
     QPushButton, QGroupBox, QFormLayout, QMessageBox, QComboBox, QWidget,
-    QCheckBox, QFileDialog,
+    QCheckBox, QFileDialog, QScrollArea, QFrame, QApplication,
 )
 from PyQt6.QtCore import pyqtSlot
 from PyQt6.QtGui import QFont
@@ -24,6 +24,19 @@ from src.core.perplexity_client import PerplexityClient
 from src.core.openrouter_client import OpenRouterClient
 from src.core.debug_logger import DebugLogger
 from src.core.rating_store import RatingStore
+from src.core.wordpress_client import (
+    WP_STATUSES, WordPressClient,
+    get_wp_config, save_wp_config,
+    get_wp_app_password, save_wp_app_password, delete_wp_app_password,
+)
+
+# Benutzerfreundliche Beschriftungen für die WordPress-Status-Auswahl.
+_WP_STATUS_LABELS = {
+    "draft": "Entwurf (draft)",
+    "private": "Privat (private)",
+    "publish": "Veröffentlichen (publish)",
+    "pending": "Ausstehend (pending)",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +64,22 @@ class SettingsDialog(QDialog):
         self._load_current_keys()
 
     def _setup_ui(self) -> None:
-        """Erstellt das Dialog-Layout."""
-        layout = QVBoxLayout(self)
+        """Erstellt das Dialog-Layout.
+
+        Der Inhalt liegt in einem scrollbaren Bereich, damit der Dialog auch auf
+        kleinen Displays (z.B. Notebook) passt und die Buttons unten stets
+        erreichbar bleiben.
+        """
+        outer_layout = QVBoxLayout(self)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Scrollbarer Inhaltsbereich
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+
+        container = QWidget()
+        layout = QVBoxLayout(container)
         layout.setSpacing(15)
 
         # Provider-Gruppen
@@ -63,14 +90,22 @@ class SettingsDialog(QDialog):
         # Default-Einstellungen
         layout.addWidget(self._create_defaults_group())
 
+        # WordPress-Blog
+        layout.addWidget(self._create_wordpress_group())
+
         # Debug-Einstellungen
         layout.addWidget(self._create_debug_group())
 
         # Bewertungsdaten
         layout.addWidget(self._create_ratings_group())
 
-        # Buttons
+        layout.addStretch()
+        scroll.setWidget(container)
+        outer_layout.addWidget(scroll, stretch=1)
+
+        # Buttons (außerhalb des Scrollbereichs -> immer sichtbar)
         btn_layout = QHBoxLayout()
+        btn_layout.setContentsMargins(15, 10, 15, 10)
         btn_layout.addStretch()
 
         self.btn_save = QPushButton("Speichern")
@@ -83,7 +118,12 @@ class SettingsDialog(QDialog):
         self.btn_cancel.clicked.connect(self.reject)
         btn_layout.addWidget(self.btn_cancel)
 
-        layout.addLayout(btn_layout)
+        outer_layout.addLayout(btn_layout)
+
+        # Anfangsgröße an verfügbare Bildschirmhöhe anpassen (mit Rand)
+        screen = QApplication.primaryScreen()
+        avail_h = screen.availableGeometry().height() if screen else 900
+        self.resize(580, min(860, max(420, avail_h - 120)))
 
     def _create_provider_group(self, provider_id: str, provider_name: str) -> QGroupBox:
         """Erstellt eine Provider-Gruppe mit Key-Eingabe und Test-Button."""
@@ -163,6 +203,129 @@ class SettingsDialog(QDialog):
         group_layout.addRow(self.channel_meta_checkbox)
 
         return group
+
+    def _create_wordpress_group(self) -> QGroupBox:
+        """Erstellt die WordPress-Blog-Gruppe (URL, Benutzer, App-Passwort)."""
+        group = QGroupBox("WordPress-Blog")
+        group_layout = QFormLayout(group)
+
+        wp = get_wp_config()
+
+        # URL
+        self.wp_url_input = QLineEdit(wp.url)
+        self.wp_url_input.setPlaceholderText("https://diggi.torja.de")
+        group_layout.addRow("URL:", self.wp_url_input)
+
+        # Benutzername
+        self.wp_user_input = QLineEdit(wp.username)
+        self.wp_user_input.setPlaceholderText("WordPress-Benutzername")
+        group_layout.addRow("Benutzer:", self.wp_user_input)
+
+        # Application Password (+ Sichtbarkeit, Test, Löschen)
+        pw_layout = QHBoxLayout()
+        self.wp_pw_input = QLineEdit()
+        self.wp_pw_input.setEchoMode(QLineEdit.EchoMode.Password)
+        self.wp_pw_input.setPlaceholderText("Application Password…")
+        self.wp_pw_input.setMinimumWidth(280)
+        existing_pw = get_wp_app_password()
+        if existing_pw:
+            self.wp_pw_input.setText(existing_pw)
+        pw_layout.addWidget(self.wp_pw_input)
+
+        self.wp_pw_toggle = QPushButton("Zeigen")
+        self.wp_pw_toggle.setMaximumWidth(70)
+        self.wp_pw_toggle.setCheckable(True)
+        self.wp_pw_toggle.toggled.connect(self._toggle_wp_pw_visibility)
+        pw_layout.addWidget(self.wp_pw_toggle)
+
+        btn_wp_test = QPushButton("Test")
+        btn_wp_test.setMaximumWidth(60)
+        btn_wp_test.clicked.connect(self._on_wp_test)
+        pw_layout.addWidget(btn_wp_test)
+
+        btn_wp_delete = QPushButton("X")
+        btn_wp_delete.setMaximumWidth(30)
+        btn_wp_delete.setToolTip("Application Password löschen")
+        btn_wp_delete.clicked.connect(self._on_wp_delete_password)
+        pw_layout.addWidget(btn_wp_delete)
+
+        group_layout.addRow("App-Passwort:", pw_layout)
+
+        # Default-Status
+        self.wp_status_combo = QComboBox()
+        for status in WP_STATUSES:
+            self.wp_status_combo.addItem(
+                _WP_STATUS_LABELS.get(status, status), status
+            )
+        idx = self.wp_status_combo.findData(wp.default_status)
+        if idx >= 0:
+            self.wp_status_combo.setCurrentIndex(idx)
+        group_layout.addRow("Default-Status:", self.wp_status_combo)
+
+        # Default-Kategorie
+        self.wp_category_input = QLineEdit(wp.default_category)
+        self.wp_category_input.setPlaceholderText("z.B. YouTube-Analysen (optional)")
+        group_layout.addRow("Default-Kategorie:", self.wp_category_input)
+
+        # Status-Label
+        self.wp_status_label = QLabel("")
+        self.wp_status_label.setStyleSheet("color: gray; font-style: italic;")
+        self.wp_status_label.setWordWrap(True)
+        group_layout.addRow("Status:", self.wp_status_label)
+
+        return group
+
+    def _toggle_wp_pw_visibility(self, visible: bool) -> None:
+        """Zeigt/versteckt das WordPress-App-Passwort."""
+        if visible:
+            self.wp_pw_input.setEchoMode(QLineEdit.EchoMode.Normal)
+            self.wp_pw_toggle.setText("Verbergen")
+        else:
+            self.wp_pw_input.setEchoMode(QLineEdit.EchoMode.Password)
+            self.wp_pw_toggle.setText("Zeigen")
+
+    @pyqtSlot()
+    def _on_wp_test(self) -> None:
+        """Testet die WordPress-Verbindung mit den eingegebenen Daten."""
+        from src.core.wordpress_client import WordPressConfig
+
+        url = self.wp_url_input.text().strip()
+        user = self.wp_user_input.text().strip()
+        password = self.wp_pw_input.text().strip()
+        if not (url and user and password):
+            QMessageBox.warning(
+                self, "WordPress-Test",
+                "Bitte URL, Benutzer und Application Password eingeben."
+            )
+            return
+
+        self.wp_status_label.setText("Teste…")
+        self.wp_status_label.setStyleSheet("color: #2196F3; font-style: italic;")
+        self.wp_status_label.repaint()
+
+        config = WordPressConfig(url=url, username=user)
+        client = WordPressClient(config, password)
+        success, message = client.test_connection()
+        if success:
+            self.wp_status_label.setText(message)
+            self.wp_status_label.setStyleSheet("color: #4CAF50; font-weight: bold;")
+        else:
+            self.wp_status_label.setText(message)
+            self.wp_status_label.setStyleSheet("color: #F44336; font-weight: bold;")
+
+    @pyqtSlot()
+    def _on_wp_delete_password(self) -> None:
+        """Löscht das gespeicherte WordPress-App-Passwort."""
+        reply = QMessageBox.question(
+            self, "App-Passwort löschen",
+            "WordPress Application Password wirklich löschen?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            delete_wp_app_password()
+            self.wp_pw_input.clear()
+            self.wp_status_label.setText("App-Passwort gelöscht")
+            self.wp_status_label.setStyleSheet("color: #808080; font-style: italic;")
 
     def _create_debug_group(self) -> QGroupBox:
         """Erstellt die Debug-Logging-Gruppe."""
@@ -457,6 +620,17 @@ class SettingsDialog(QDialog):
         prefs["debug_logging"] = self.debug_checkbox.isChecked()
         prefs["show_channel_meta"] = self.channel_meta_checkbox.isChecked()
         save_preferences(prefs)
+
+        # WordPress-Konfiguration speichern (nicht-sensibel + Passwort via keyring)
+        save_wp_config(
+            url=self.wp_url_input.text(),
+            username=self.wp_user_input.text(),
+            default_status=self.wp_status_combo.currentData(),
+            default_category=self.wp_category_input.text(),
+        )
+        wp_password = self.wp_pw_input.text().strip()
+        if wp_password:
+            save_wp_app_password(wp_password)
 
         logger.info(f"{saved_count} API-Key(s) gespeichert")
         self.accept()

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -25,7 +25,7 @@ from src.core.openrouter_client import OpenRouterClient
 from src.core.debug_logger import DebugLogger
 from src.core.rating_store import RatingStore
 from src.core.wordpress_client import (
-    WP_STATUSES, WordPressClient,
+    WP_STATUSES,
     get_wp_config, save_wp_config,
     get_wp_app_password, save_wp_app_password, delete_wp_app_password,
 )
@@ -238,10 +238,10 @@ class SettingsDialog(QDialog):
         self.wp_pw_toggle.toggled.connect(self._toggle_wp_pw_visibility)
         pw_layout.addWidget(self.wp_pw_toggle)
 
-        btn_wp_test = QPushButton("Test")
-        btn_wp_test.setMaximumWidth(60)
-        btn_wp_test.clicked.connect(self._on_wp_test)
-        pw_layout.addWidget(btn_wp_test)
+        self._btn_wp_test = QPushButton("Test")
+        self._btn_wp_test.setMaximumWidth(60)
+        self._btn_wp_test.clicked.connect(self._on_wp_test)
+        pw_layout.addWidget(self._btn_wp_test)
 
         btn_wp_delete = QPushButton("X")
         btn_wp_delete.setMaximumWidth(30)
@@ -286,8 +286,9 @@ class SettingsDialog(QDialog):
 
     @pyqtSlot()
     def _on_wp_test(self) -> None:
-        """Testet die WordPress-Verbindung mit den eingegebenen Daten."""
-        from src.core.wordpress_client import WordPressConfig
+        """Testet die WordPress-Verbindung asynchron (kein GUI-Freeze)."""
+        from src.core.wordpress_client import WordPressConfig, run_connection_test
+        from src.core.wordpress_worker import WordPressWorker
 
         url = self.wp_url_input.text().strip()
         user = self.wp_user_input.text().strip()
@@ -301,17 +302,31 @@ class SettingsDialog(QDialog):
 
         self.wp_status_label.setText("Teste…")
         self.wp_status_label.setStyleSheet("color: #2196F3; font-style: italic;")
-        self.wp_status_label.repaint()
+        self._btn_wp_test.setEnabled(False)
 
         config = WordPressConfig(url=url, username=user)
-        client = WordPressClient(config, password)
-        success, message = client.test_connection()
-        if success:
-            self.wp_status_label.setText(message)
-            self.wp_status_label.setStyleSheet("color: #4CAF50; font-weight: bold;")
-        else:
-            self.wp_status_label.setText(message)
-            self.wp_status_label.setStyleSheet("color: #F44336; font-weight: bold;")
+        # Referenz auf den Worker halten (sonst GC), läuft im Hintergrund.
+        self._wp_test_worker = WordPressWorker(run_connection_test, config, password)
+        self._wp_test_worker.succeeded.connect(self._on_wp_test_result)
+        self._wp_test_worker.failed.connect(self._on_wp_test_failed)
+        self._wp_test_worker.finished.connect(
+            lambda: self._btn_wp_test.setEnabled(True)
+        )
+        self._wp_test_worker.start()
+
+    @pyqtSlot(object)
+    def _on_wp_test_result(self, result: tuple) -> None:
+        """Verarbeitet das Ergebnis des Verbindungstests (Main-Thread)."""
+        success, message = result
+        self.wp_status_label.setText(message)
+        color = "#4CAF50" if success else "#F44336"
+        self.wp_status_label.setStyleSheet(f"color: {color}; font-weight: bold;")
+
+    @pyqtSlot(str)
+    def _on_wp_test_failed(self, message: str) -> None:
+        """Zeigt einen unerwarteten Fehler des Verbindungstests an."""
+        self.wp_status_label.setText(f"Fehler: {message}")
+        self.wp_status_label.setStyleSheet("color: #F44336; font-weight: bold;")
 
     @pyqtSlot()
     def _on_wp_delete_password(self) -> None:

--- a/src/gui/wordpress_dialog.py
+++ b/src/gui/wordpress_dialog.py
@@ -18,10 +18,11 @@ from PyQt6.QtWidgets import (
 )
 
 from src.core.wordpress_client import (
-    WordPressClient, WordPressError, WP_STATUSES,
-    assemble_content, markdown_to_html,
+    WP_STATUSES,
+    assemble_content, markdown_to_html, publish_post,
     get_wp_config, get_wp_app_password, has_wp_credentials,
 )
+from src.core.wordpress_worker import WordPressWorker
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,8 @@ class WordPressSendDialog(QDialog):
 
         self._config = get_wp_config()
         self._last_link: str = ""
+        self._pending_status: str = ""
+        self._send_worker: Optional[WordPressWorker] = None
 
         self._setup_ui(analysis_md, suggested_title)
 
@@ -229,44 +232,46 @@ class WordPressSendDialog(QDialog):
 
         status = self.status_combo.currentData()
         category_names = [self.category_input.text()] if self.category_input.text().strip() else []
-        tag_names = [t for t in self.tags_input.text().split(",") if t.strip()]
+        tag_names = [t.strip() for t in self.tags_input.text().split(",") if t.strip()]
 
+        self._pending_status = status
         self.btn_send.setEnabled(False)
         self._set_status("Sende an WordPress…", error=False)
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        try:
-            client = WordPressClient(self._config, app_password)
-            html = markdown_to_html(self._assembled_markdown())
 
-            category_ids = client.resolve_terms(category_names, "categories")
-            tag_ids = client.resolve_terms(tag_names, "tags")
+        # Netzwerk-Operationen im Hintergrund (Referenz halten -> kein GC).
+        self._send_worker = WordPressWorker(
+            publish_post,
+            self._config, app_password, title, self._assembled_markdown(),
+            status, category_names, tag_names,
+        )
+        self._send_worker.succeeded.connect(self._on_send_result)
+        self._send_worker.failed.connect(self._on_send_failed)
+        self._send_worker.start()
 
-            post_id, link = client.post(
-                title=title,
-                html_content=html,
-                status=status,
-                category_ids=category_ids or None,
-                tag_ids=tag_ids or None,
-            )
-        except (WordPressError, RuntimeError) as exc:
-            QApplication.restoreOverrideCursor()
-            logger.error("WordPress-Senden fehlgeschlagen: %s", exc)
-            self._set_status(str(exc), error=True)
-            QMessageBox.critical(self, "Senden fehlgeschlagen", str(exc))
-            self.btn_send.setEnabled(True)
-            return
-        else:
-            QApplication.restoreOverrideCursor()
-
+    @pyqtSlot(object)
+    def _on_send_result(self, result: tuple) -> None:
+        """Verarbeitet das erfolgreiche Senden (Main-Thread)."""
+        QApplication.restoreOverrideCursor()
+        post_id, link = result
         self._last_link = link
         self.btn_open.setEnabled(bool(link))
-        status_word = _STATUS_LABELS.get(status, status)
+        status_word = _STATUS_LABELS.get(self._pending_status, self._pending_status)
         self._set_status(
             f"Gesendet ✓ (Beitrag #{post_id}, Status: {status_word}).",
             error=False,
         )
         self.btn_send.setEnabled(True)
-        logger.info("WordPress-Beitrag #%s erstellt (%s)", post_id, status)
+        logger.info("WordPress-Beitrag #%s erstellt (%s)", post_id, self._pending_status)
+
+    @pyqtSlot(str)
+    def _on_send_failed(self, message: str) -> None:
+        """Behandelt einen Fehler beim Senden (Main-Thread)."""
+        QApplication.restoreOverrideCursor()
+        logger.error("WordPress-Senden fehlgeschlagen: %s", message)
+        self._set_status(message, error=True)
+        QMessageBox.critical(self, "Senden fehlgeschlagen", message)
+        self.btn_send.setEnabled(True)
 
     @pyqtSlot()
     def _on_open_link(self) -> None:

--- a/src/gui/wordpress_dialog.py
+++ b/src/gui/wordpress_dialog.py
@@ -1,0 +1,279 @@
+"""Sende-Dialog: SOMAS-Analyse als WordPress-Beitrag (Variante A).
+
+Getrennte Felder für Intro / Analyse / Outro. Das Intro-/Outro-Feld ist optional
+– bleibt es leer, wird nur die Analyse gesendet. Status, Kategorie und Tags sind
+einstellbar; Default-Status kommt aus den Einstellungen (üblicherweise „Entwurf").
+"""
+
+import logging
+from typing import Optional
+
+from PyQt6.QtCore import Qt, pyqtSlot
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtCore import QUrl
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QLineEdit,
+    QTextEdit, QComboBox, QPushButton, QGroupBox, QMessageBox, QWidget,
+    QApplication,
+)
+
+from src.core.wordpress_client import (
+    WordPressClient, WordPressError, WP_STATUSES,
+    assemble_content, markdown_to_html,
+    get_wp_config, get_wp_app_password, has_wp_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Benutzerfreundliche Beschriftungen für die Status-Auswahl.
+_STATUS_LABELS = {
+    "draft": "Entwurf (draft)",
+    "private": "Privat (private)",
+    "publish": "Veröffentlichen (publish)",
+    "pending": "Ausstehend (pending)",
+}
+
+
+class WordPressSendDialog(QDialog):
+    """Dialog zum Senden einer Analyse an WordPress (Intro/Analyse/Outro)."""
+
+    def __init__(
+        self,
+        analysis_md: str,
+        suggested_title: str = "",
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        """Initialisiert den Sende-Dialog.
+
+        Args:
+            analysis_md: Die Analyse als Markdown (vorbefüllt, editierbar).
+            suggested_title: Vorschlag für den Beitragstitel (z.B. Videotitel).
+            parent: Optionales Parent-Widget.
+        """
+        super().__init__(parent)
+        self.setWindowTitle("An Blog senden (WordPress)")
+        self.setMinimumSize(640, 640)
+
+        self._config = get_wp_config()
+        self._last_link: str = ""
+
+        self._setup_ui(analysis_md, suggested_title)
+
+    # ------------------------------------------------------------------ UI -- #
+
+    def _setup_ui(self, analysis_md: str, suggested_title: str) -> None:
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        # Ziel-Hinweis
+        target = self._config.url or "(keine WordPress-URL konfiguriert)"
+        info = QLabel(f"Ziel: <b>{target}</b>")
+        info.setTextFormat(Qt.TextFormat.RichText)
+        layout.addWidget(info)
+
+        # Titel
+        form = QFormLayout()
+        self.title_input = QLineEdit(suggested_title)
+        self.title_input.setPlaceholderText("Beitragstitel…")
+        form.addRow("Titel:", self.title_input)
+        layout.addLayout(form)
+
+        # Intro (optional)
+        layout.addWidget(self._field_label(
+            "Intro (optional, Markdown – z.B. Kommentar/Emoji-Einleitung 😉)"
+        ))
+        self.intro_edit = QTextEdit()
+        self.intro_edit.setPlaceholderText("Optionaler Einleitungstext…")
+        self.intro_edit.setMaximumHeight(90)
+        layout.addWidget(self.intro_edit)
+
+        # Analyse (vorbefüllt, editierbar)
+        layout.addWidget(self._field_label("Analyse (Markdown):"))
+        self.analysis_edit = QTextEdit()
+        self.analysis_edit.setPlainText(analysis_md)
+        self.analysis_edit.setMinimumHeight(220)
+        layout.addWidget(self.analysis_edit, stretch=1)
+
+        # Outro (optional)
+        layout.addWidget(self._field_label("Outro (optional, Markdown):"))
+        self.outro_edit = QTextEdit()
+        self.outro_edit.setPlaceholderText("Optionaler Ausleitungstext…")
+        self.outro_edit.setMaximumHeight(90)
+        layout.addWidget(self.outro_edit)
+
+        # Publikations-Optionen
+        layout.addWidget(self._build_options_group())
+
+        # Status-Zeile
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: gray; font-style: italic;")
+        layout.addWidget(self.status_label)
+
+        # Buttons
+        btn_row = QHBoxLayout()
+        self.btn_preview = QPushButton("HTML-Vorschau")
+        self.btn_preview.clicked.connect(self._on_preview)
+        btn_row.addWidget(self.btn_preview)
+        btn_row.addStretch()
+
+        self.btn_open = QPushButton("Im Browser öffnen")
+        self.btn_open.setEnabled(False)
+        self.btn_open.clicked.connect(self._on_open_link)
+        btn_row.addWidget(self.btn_open)
+
+        self.btn_send = QPushButton("An Blog senden")
+        self.btn_send.setDefault(True)
+        self.btn_send.clicked.connect(self._on_send)
+        btn_row.addWidget(self.btn_send)
+
+        self.btn_close = QPushButton("Schließen")
+        self.btn_close.clicked.connect(self.reject)
+        btn_row.addWidget(self.btn_close)
+
+        layout.addLayout(btn_row)
+
+        if not has_wp_credentials():
+            self._set_status(
+                "WordPress ist noch nicht vollständig konfiguriert. "
+                "Bitte URL, Benutzer und Application Password unter 'Settings' "
+                "hinterlegen.",
+                error=True,
+            )
+            self.btn_send.setEnabled(False)
+
+    def _build_options_group(self) -> QGroupBox:
+        group = QGroupBox("Veröffentlichung")
+        grid = QFormLayout(group)
+
+        # Status
+        self.status_combo = QComboBox()
+        for status in WP_STATUSES:
+            self.status_combo.addItem(_STATUS_LABELS.get(status, status), status)
+        # Default-Status vorwählen
+        idx = self.status_combo.findData(self._config.default_status)
+        if idx >= 0:
+            self.status_combo.setCurrentIndex(idx)
+        grid.addRow("Status:", self.status_combo)
+
+        # Kategorie (Default aus Config)
+        self.category_input = QLineEdit(self._config.default_category)
+        self.category_input.setPlaceholderText("z.B. YouTube-Analysen (optional)")
+        grid.addRow("Kategorie:", self.category_input)
+
+        # Tags
+        self.tags_input = QLineEdit()
+        self.tags_input.setPlaceholderText("Tag1, Tag2, … (optional)")
+        grid.addRow("Tags:", self.tags_input)
+
+        return group
+
+    @staticmethod
+    def _field_label(text: str) -> QLabel:
+        label = QLabel(text)
+        label.setStyleSheet("font-weight: bold;")
+        return label
+
+    # --------------------------------------------------------------- Logik -- #
+
+    def _assembled_markdown(self) -> str:
+        return assemble_content(
+            self.intro_edit.toPlainText(),
+            self.analysis_edit.toPlainText(),
+            self.outro_edit.toPlainText(),
+        )
+
+    @pyqtSlot()
+    def _on_preview(self) -> None:
+        """Zeigt das konvertierte HTML in einem Vorschau-Dialog."""
+        try:
+            html = markdown_to_html(self._assembled_markdown())
+        except RuntimeError as exc:
+            QMessageBox.critical(self, "Vorschau", str(exc))
+            return
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle("HTML-Vorschau")
+        dlg.setMinimumSize(560, 480)
+        v = QVBoxLayout(dlg)
+        view = QTextEdit()
+        view.setReadOnly(True)
+        view.setHtml(html)
+        v.addWidget(view)
+        btn = QPushButton("Schließen")
+        btn.clicked.connect(dlg.accept)
+        v.addWidget(btn)
+        dlg.exec()
+
+    @pyqtSlot()
+    def _on_send(self) -> None:
+        """Konvertiert, löst Kategorie/Tags auf und postet den Beitrag."""
+        title = self.title_input.text().strip()
+        if not title:
+            QMessageBox.warning(self, "Senden", "Bitte einen Titel eingeben.")
+            return
+
+        analysis = self.analysis_edit.toPlainText().strip()
+        if not analysis:
+            QMessageBox.warning(self, "Senden", "Die Analyse ist leer.")
+            return
+
+        app_password = get_wp_app_password()
+        if not self._config.is_complete or not app_password:
+            QMessageBox.warning(
+                self, "Senden",
+                "WordPress ist nicht vollständig konfiguriert (URL, Benutzer, "
+                "Application Password). Bitte unter 'Settings' hinterlegen.",
+            )
+            return
+
+        status = self.status_combo.currentData()
+        category_names = [self.category_input.text()] if self.category_input.text().strip() else []
+        tag_names = [t for t in self.tags_input.text().split(",") if t.strip()]
+
+        self.btn_send.setEnabled(False)
+        self._set_status("Sende an WordPress…", error=False)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            client = WordPressClient(self._config, app_password)
+            html = markdown_to_html(self._assembled_markdown())
+
+            category_ids = client.resolve_terms(category_names, "categories")
+            tag_ids = client.resolve_terms(tag_names, "tags")
+
+            post_id, link = client.post(
+                title=title,
+                html_content=html,
+                status=status,
+                category_ids=category_ids or None,
+                tag_ids=tag_ids or None,
+            )
+        except (WordPressError, RuntimeError) as exc:
+            QApplication.restoreOverrideCursor()
+            logger.error("WordPress-Senden fehlgeschlagen: %s", exc)
+            self._set_status(str(exc), error=True)
+            QMessageBox.critical(self, "Senden fehlgeschlagen", str(exc))
+            self.btn_send.setEnabled(True)
+            return
+        else:
+            QApplication.restoreOverrideCursor()
+
+        self._last_link = link
+        self.btn_open.setEnabled(bool(link))
+        status_word = _STATUS_LABELS.get(status, status)
+        self._set_status(
+            f"Gesendet ✓ (Beitrag #{post_id}, Status: {status_word}).",
+            error=False,
+        )
+        self.btn_send.setEnabled(True)
+        logger.info("WordPress-Beitrag #%s erstellt (%s)", post_id, status)
+
+    @pyqtSlot()
+    def _on_open_link(self) -> None:
+        if self._last_link:
+            QDesktopServices.openUrl(QUrl(self._last_link))
+
+    def _set_status(self, message: str, error: bool) -> None:
+        self.status_label.setText(message)
+        color = "#C62828" if error else "#2E7D32"
+        self.status_label.setStyleSheet(f"color: {color};")

--- a/src/gui/wordpress_dialog.py
+++ b/src/gui/wordpress_dialog.py
@@ -231,7 +231,7 @@ class WordPressSendDialog(QDialog):
             return
 
         status = self.status_combo.currentData()
-        category_names = [self.category_input.text()] if self.category_input.text().strip() else []
+        category_names = [self.category_input.text().strip()] if self.category_input.text().strip() else []
         tag_names = [t.strip() for t in self.tags_input.text().split(",") if t.strip()]
 
         self._pending_status = status


### PR DESCRIPTION
Analyse als Beitrag senden (Variante A, Default draft, scrollbarer Settings-Dialog)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WordPress-Integration: Analysen direkt als Blog-Beiträge veröffentlichen – mit neuem „An Blog senden“-Button im Exportbereich und einem Sende-Dialog (Intro/Analyse/Outro, Status, Kategorie/Tags) inkl. HTML-Vorschau.
  * WordPress-Konfiguration in den Einstellungen: URL, Benutzername, Application Password, Default-Status/Default-Kategorie; Verbindungstest sowie Passwort löschen.
  * Beim Veröffentlichen werden Kategorien und Tags automatisch aufgelöst bzw. bei Bedarf erstellt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->