### PR TITLE
fix: natuerliche Sprecher-Bezeichnung, Downloads-Default & Reasoning-…

### DIFF
--- a/src/core/export.py
+++ b/src/core/export.py
@@ -27,6 +27,23 @@ def get_exports_dir() -> Path:
     return exports_dir
 
 
+def get_default_save_dir() -> Path:
+    """Gibt das Standard-Verzeichnis für interaktive Speichern-Dialoge zurück.
+
+    Bevorzugt den Downloads-Ordner des Benutzers, fällt auf das Home-Verzeichnis
+    (~) zurück. Damit landen exportierte Markdowns nicht mehr versehentlich im
+    Arbeits-/Projektverzeichnis (das beim App-Start die Vorgabe war).
+
+    Returns:
+        Pfad zum Downloads-Ordner, sonst zum Home-Verzeichnis.
+    """
+    home = Path.home()
+    downloads = home / "Downloads"
+    if downloads.is_dir():
+        return downloads
+    return home
+
+
 # Mapping von problematischen Unicode-Zeichen zu sicheren Alternativen
 UNICODE_REPLACEMENTS = {
     '\u02BC': "'",      # Modifier Letter Apostrophe → normales Apostroph

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -587,6 +587,77 @@ def normalize_markdown_headings(text: str) -> str:
     return re.sub(r'(?m)^(\s*#{1,6})(?=[^#\s])', r'\1 ', text)
 
 
+# --- Reasoning-Leak-Schutz (v0.11+) ---
+
+# Erstes kanonisches SOMAS-Abschnitts-Header (Analyse beginnt regulär hiermit).
+_FRAMING_HEADER_RE = re.compile(r"(?m)^\s*#{1,6}\s*FRAMING\b", re.IGNORECASE)
+
+# Typische englische/deutsche Reasoning-Floskeln, mit denen Modelle ihren
+# Denkprozess einleiten, statt direkt das Ergebnis auszugeben.
+_REASONING_TELLS_RE = re.compile(
+    r"(?im)\b("
+    r"let me|i need to|i should|i'?ll|i will|first,? let me|now let me|"
+    r"let'?s analyze|let me analyze|let me think|okay,? let me|"
+    r"lass mich|ich muss zun|ich werde zun|zuerst muss ich|"
+    r"analysieren wir|gehen wir"
+    r")\b"
+)
+
+
+def strip_reasoning_preamble(text: str) -> tuple[str, bool]:
+    """Entfernt einen vorangestellten Reasoning-Block vor der eigentlichen Analyse.
+
+    Manche (Reasoning-)Modelle kippen ihren Denkprozess direkt in den Content,
+    bevor die Analyse beginnt. Eine reguläre SOMAS-Analyse startet mit
+    ``### FRAMING``. Steht davor substanzieller Text, der nach Reasoning aussieht
+    (Floskeln wie „Let me…" oder schlicht sehr lang), wird dieser Vorspann
+    entfernt. Kurze, harmlose Einleitungen bleiben unangetastet.
+
+    Args:
+        text: Roh-Content der Modellantwort.
+
+    Returns:
+        Tupel ``(bereinigter_text, wurde_gekürzt)``. Wird nichts entfernt, ist
+        der erste Wert der Originaltext (bzw. normalisiert) und der zweite False.
+    """
+    if not text:
+        return text, False
+
+    normalized = normalize_markdown_headings(text)
+    match = _FRAMING_HEADER_RE.search(normalized)
+    if not match or match.start() == 0:
+        return text, False
+
+    preamble = normalized[:match.start()]
+    looks_like_reasoning = bool(_REASONING_TELLS_RE.search(preamble))
+    is_long = len(preamble.strip()) > 400
+    if looks_like_reasoning or is_long:
+        return normalized[match.start():].lstrip(), True
+
+    return text, False
+
+
+def looks_like_reasoning_leak(text: str) -> bool:
+    """Heuristik: Sieht der Text nach durchgesickertem Reasoning aus?
+
+    Greift, wenn der Anfang NICHT mit einer Markdown-Überschrift beginnt UND
+    Reasoning-Floskeln im Kopf enthält. Bewusst konservativ – dient nur als
+    nicht-fataler Hinweis an den Benutzer, nicht als hartes Filterkriterium.
+
+    Args:
+        text: (Idealerweise bereits preamble-bereinigter) Analysetext.
+
+    Returns:
+        True, wenn der Text verdächtig nach rohem Reasoning aussieht.
+    """
+    if not text:
+        return False
+    head = text.lstrip()
+    if head.startswith("#"):
+        return False
+    return bool(_REASONING_TELLS_RE.search(head[:600]))
+
+
 def clean_synthesis_output(text: str) -> str:
     """Bereinigt die Synthese-Ausgabe für die saubere Einbettung ins Layout.
 

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -594,10 +594,15 @@ _FRAMING_HEADER_RE = re.compile(r"(?m)^\s*#{1,6}\s*FRAMING\b", re.IGNORECASE)
 
 # Typische englische/deutsche Reasoning-Floskeln, mit denen Modelle ihren
 # Denkprozess einleiten, statt direkt das Ergebnis auszugeben.
+# Apostroph-Klasse: ASCII (') UND typografisch (’, ʼ) – Modelle schreiben
+# Kontraktionen oft mit geschwungenem Apostroph (z.B. "I’ll", "let’s"). Der
+# Apostroph ist PFLICHT (kein '?'), damit bare Wörter wie "ill"/"lets" nicht
+# fälschlich als Reasoning-Floskel matchen.
+_APO = r"['’ʼ]"
 _REASONING_TELLS_RE = re.compile(
     r"(?im)\b("
-    r"let me|i need to|i should|i'?ll|i will|first,? let me|now let me|"
-    r"let'?s analyze|let me analyze|let me think|okay,? let me|"
+    r"let me|i need to|i should|i" + _APO + r"ll|i will|first,? let me|now let me|"
+    r"let" + _APO + r"s analyze|let me analyze|let me think|okay,? let me|"
     r"lass mich|ich muss zun|ich werde zun|zuerst muss ich|"
     r"analysieren wir|gehen wir"
     r")\b"

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -20,7 +20,9 @@ from src.core.prompt_builder import (
     extract_claims_from_faktencheck, cap_claims,
 )
 from src.core.linkedin_formatter import format_for_linkedin
-from src.core.export import export_to_markdown, get_suggested_filename, save_markdown
+from src.core.export import (
+    export_to_markdown, get_suggested_filename, save_markdown, get_default_save_dir,
+)
 from src.core.api_client import APIResponse, APIStatus
 from src.core.api_worker import APIWorker
 from src.core.debug_logger import DebugLogger, APP_VERSION
@@ -1413,7 +1415,7 @@ class MainWindow(QMainWindow):
         # Dateiname vorschlagen (sanitized für sichere Dateinamen)
         preset_name = self.current_preset.name if self.current_preset else ""
         suggested = get_suggested_filename(self.video_info, preset_name)
-        default_name = f"{suggested}.md"
+        default_name = str(get_default_save_dir() / f"{suggested}.md")
 
         # Datei-Dialog
         file_path, _ = QFileDialog.getSaveFileName(
@@ -1463,11 +1465,11 @@ class MainWindow(QMainWindow):
     def _export_comparison_markdown(self, content: str) -> None:
         """Speichert das fertige Vergleichs-Markdown ohne zusätzlichen Header."""
         from PyQt6.QtWidgets import QFileDialog
-        from src.core.export import get_exports_dir, sanitize_filename
+        from src.core.export import sanitize_filename
 
         title = self.video_info.title if self.video_info else "SOMAS"
         base = sanitize_filename(title) if title else "SOMAS"
-        default_path = str(get_exports_dir() / f"{base}_Modellvergleich.md")
+        default_path = str(get_default_save_dir() / f"{base}_Modellvergleich.md")
 
         file_path, _ = QFileDialog.getSaveFileName(
             self, "Modellvergleich exportieren", default_path,
@@ -1902,7 +1904,19 @@ class MainWindow(QMainWindow):
         # falls die Verifikation für diesen Lauf läuft).
         self.btn_verify_retry.setEnabled(False)
         self._clear_stale_sources()
-        self.result_text.setText(response.content)
+
+        # Reasoning-Leak-Schutz: manche Modelle kippen ihren Denkprozess in den
+        # Content. Für Anzeige/Export den Vorspann abschneiden; der ROH-Content
+        # in `response` bleibt für DB-Speicherung und Faktencheck-Verifikation
+        # unverändert (dort hilft die vollständige Behauptungsliste).
+        from src.core.prompt_builder import (
+            strip_reasoning_preamble, looks_like_reasoning_leak,
+        )
+        display_content, was_stripped = strip_reasoning_preamble(response.content)
+        self.result_text.setText(display_content)
+        if was_stripped or looks_like_reasoning_leak(display_content):
+            self._warn_reasoning_leak()
+
         logger.info(
             f"API-Antwort: {len(response.content)} Zeichen, "
             f"{response.tokens_used} Tokens ({response.model_used})"
@@ -1936,6 +1950,25 @@ class MainWindow(QMainWindow):
         # Rework-Button zurücksetzen
         self.btn_rework.setText("\u2702 Kürzen lassen")
         self.btn_rework.setEnabled(True)
+
+    def _warn_reasoning_leak(self) -> None:
+        """Weist nicht-fatal darauf hin, dass der Output rohes Reasoning enthielt.
+
+        Manche Modelle (z.B. einzelne Reasoning-Varianten) schreiben ihren
+        Denkprozess statt der reinen Analyse in den Content. Der angezeigte Text
+        wurde, soweit möglich, bereits bereinigt – die Analyse kann aber
+        weiterhin Reste enthalten. Ein anderes Modell liefert i.d.R. ein
+        saubereres Ergebnis.
+        """
+        QMessageBox.warning(
+            self,
+            "Hinweis: Modell-Reasoning erkannt",
+            "Das gewählte Modell hat vermutlich Teile seines Denkprozesses "
+            "(„Reasoning“) in die Antwort geschrieben. Der angezeigte "
+            "Text wurde automatisch bereinigt, kann aber noch Reste enthalten.\n\n"
+            "Tipp: Ein anderes Modell liefert für diese Analyse meist ein "
+            "saubereres Ergebnis.",
+        )
 
     @pyqtSlot(str)
     def _on_api_error(self, error_message: str) -> None:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1915,7 +1915,7 @@ class MainWindow(QMainWindow):
         display_content, was_stripped = strip_reasoning_preamble(response.content)
         self.result_text.setText(display_content)
         if was_stripped or looks_like_reasoning_leak(display_content):
-            self._warn_reasoning_leak()
+            self._warn_reasoning_leak(was_stripped)
 
         logger.info(
             f"API-Antwort: {len(response.content)} Zeichen, "
@@ -1951,23 +1951,41 @@ class MainWindow(QMainWindow):
         self.btn_rework.setText("\u2702 Kürzen lassen")
         self.btn_rework.setEnabled(True)
 
-    def _warn_reasoning_leak(self) -> None:
+    def _warn_reasoning_leak(self, was_stripped: bool) -> None:
         """Weist nicht-fatal darauf hin, dass der Output rohes Reasoning enthielt.
 
         Manche Modelle (z.B. einzelne Reasoning-Varianten) schreiben ihren
-        Denkprozess statt der reinen Analyse in den Content. Der angezeigte Text
-        wurde, soweit möglich, bereits bereinigt – die Analyse kann aber
-        weiterhin Reste enthalten. Ein anderes Modell liefert i.d.R. ein
-        saubereres Ergebnis.
+        Denkprozess statt der reinen Analyse in den Content. Der Hinweistext
+        unterscheidet, ob tatsächlich ein Vorspann entfernt wurde
+        (``was_stripped=True``) oder der Text nur heuristisch verdächtig wirkt,
+        aber UNVERÄNDERT angezeigt wird.
+
+        Args:
+            was_stripped: True, wenn strip_reasoning_preamble() einen Vorspann
+                entfernt hat; False, wenn nur die Heuristik angeschlagen hat.
         """
+        intro = (
+            "Das gewählte Modell hat vermutlich Teile seines Denkprozesses "
+            "(„Reasoning“) in die Antwort geschrieben. "
+        )
+        if was_stripped:
+            detail = (
+                "Ein vorangestellter Reasoning-Block wurde automatisch entfernt; "
+                "der angezeigte Text kann aber noch Reste enthalten."
+            )
+        else:
+            detail = (
+                "Der angezeigte Text wurde NICHT automatisch verändert – bitte "
+                "prüfe ihn auf eingestreute Denkschritte."
+            )
+        tip = (
+            "\n\nTipp: Ein anderes Modell liefert für diese Analyse meist ein "
+            "saubereres Ergebnis."
+        )
         QMessageBox.warning(
             self,
             "Hinweis: Modell-Reasoning erkannt",
-            "Das gewählte Modell hat vermutlich Teile seines Denkprozesses "
-            "(„Reasoning“) in die Antwort geschrieben. Der angezeigte "
-            "Text wurde automatisch bereinigt, kann aber noch Reste enthalten.\n\n"
-            "Tipp: Ein anderes Modell liefert für diese Analyse meist ein "
-            "saubereres Ergebnis.",
+            intro + detail + tip,
         )
 
     @pyqtSlot(str)

--- a/templates/somas_prompt.txt
+++ b/templates/somas_prompt.txt
@@ -1,5 +1,7 @@
 Analysiere das folgende YouTube-Video nach dem SOMAS-Schema (Source Overview Mapping And extraction Schema).
 
+BEZEICHNUNG DER SPRECHENDEN: Verwende natürliche Bezeichnungen – den Namen der Person (sofern aus Titel, Kanal oder Metadaten ersichtlich), sonst Rolle/Format wie „Host", „Creator", „Moderatorin"/„Moderator" oder den Kanalnamen. Vermeide künstliche Hilfskonstruktionen wie „die sprechende Person". Ist das Geschlecht nicht erkennbar, weiche auf Name, Rolle oder Kanal aus statt auf umständliche Platzhalter; erfinde kein Geschlecht.
+
 KONFIGURATION:
 - Tiefe: {{ depth }} ({{ depth_description }})
 - Abschnitte: FRAMING, KERNTHESE, ELABORATION, IMPLIKATION + 1 passendes Erweiterungsmodul

--- a/templates/somas_prompt_transcript.txt
+++ b/templates/somas_prompt_transcript.txt
@@ -2,7 +2,7 @@
 
 {% endif %}Analysiere das folgende Transkript nach dem SOMAS-Schema (Source Overview Mapping And extraction Schema).
 WICHTIG: "SOMAS" ist nur der Name dieses Analyse-Frameworks. Verwende den Begriff NICHT in deiner Analyse.
-Triff keine Annahmen über das Geschlecht sprechender Personen, sofern es nicht eindeutig aus dem Text oder den Metadaten hervorgeht.
+BEZEICHNUNG DER SPRECHENDEN: Verwende natürliche Bezeichnungen – den Namen der Person (sofern aus Titel, Autor/Kanal oder Metadaten ersichtlich), sonst Rolle/Format wie „Host", „Creator", „Moderatorin"/„Moderator", „Gast" oder den Kanalnamen. Vermeide künstliche Hilfskonstruktionen wie „die sprechende Person". Triff keine Annahmen über das Geschlecht, sofern es nicht eindeutig aus Text oder Metadaten hervorgeht; weiche dann auf Name, Rolle oder Kanal aus statt auf umständliche Platzhalter.
 
 KONFIGURATION:
 - Tiefe: {{ depth }} ({{ depth_description }})

--- a/tests/test_empty_content.py
+++ b/tests/test_empty_content.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 # Projekt-Root auf den Importpfad legen (Lauf ohne Installation/pytest)
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -31,6 +33,13 @@ def _run_requests_client(cls, module_path, payload):
         return cls("dummy-key").send_prompt("prompt", "some/model")
 
 
+@pytest.mark.parametrize(
+    "name,cls,module_path",
+    [
+        ("OpenRouter", OpenRouterClient, "src.core.openrouter_client"),
+        ("Perplexity", PerplexityClient, "src.core.perplexity_client"),
+    ],
+)
 def test_requests_based(name, cls, module_path):
     # 1) content == None -> ERROR (kein Crash), finish_reason in Meldung
     r = _run_requests_client(cls, module_path,


### PR DESCRIPTION
…Leak-Schutz

Templates nutzen Name/Host/Creator statt 'die sprechende Person'.

export: get_default_save_dir() (Downloads, Fallback ~) fuer Markdown-Exporte.

prompt_builder: strip_reasoning_preamble()+looks_like_reasoning_leak(); Anzeige/Export bereinigt, Roh-Content fuer DB/Verifikation unberuehrt.

test_empty_content: parametrize-Fix (Collection-Error unter pytest behoben).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Der Export-Dialog wählt jetzt automatisch einen passenden Standard-Speicherort, bevorzugt den Downloads-Ordner im Home-Verzeichnis.
  * Nach API-Antworten wird der angezeigte Text bereinigt, wenn ein ungewöhnlicher Vorspann erkannt wird; zusätzlich erscheint ein Hinweis.

* **Bug Fixes**
  * Verbesserte Erkennung und Behandlung leerer oder unvollständiger Antworten, einschließlich Fallback-Verhalten bei vorhandenem Reasoning-Inhalt.

* **Tests**
  * Die Tests für provider-basierte leere Inhalte wurden erweitert und auf mehrere Anbieter angewendet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->