### PR TITLE
feat: youtube-intake-service Core in-process integrieren (opt-in, Fal…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/youtube-intake-service"]
+	path = external/youtube-intake-service
+	url = https://github.com/ddumdi11/youtube-intake-service.git

--- a/src/core/batch_worker.py
+++ b/src/core/batch_worker.py
@@ -23,7 +23,7 @@ from .rating_store import (
     RatingStore,
     extract_module_from_result,
 )
-from .youtube_client import get_video_info
+from .youtube_client import resolve_video_info
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class BatchWorker(QThread):
         self.item_status_changed.emit(index, "loading")
         item.status = "loading"
 
-        video_info = get_video_info(item.url)
+        video_info = resolve_video_info(item.url)
         item.video_info = video_info
         self.item_metadata_loaded.emit(index, video_info)
 

--- a/src/core/comparison_worker.py
+++ b/src/core/comparison_worker.py
@@ -28,7 +28,7 @@ from .prompt_builder import (
     get_template_dir,
     normalize_markdown_headings,
 )
-from .youtube_client import build_thumbnail_urls, extract_video_id, get_video_info
+from .youtube_client import build_thumbnail_urls, extract_video_id, resolve_video_info
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class ComparisonWorker(QThread):
             self._emit_step("meta")
             if cfg.input_mode == "youtube":
                 try:
-                    video_info = get_video_info(cfg.url)
+                    video_info = resolve_video_info(cfg.url)
                 except ValueError as e:
                     self._fail("meta", str(e))
                     return

--- a/src/core/intake_adapter.py
+++ b/src/core/intake_adapter.py
@@ -93,8 +93,21 @@ def fetch(url: str, language: str = "de") -> IntakeResult:
         error_code = getattr(e, "error_code", "processing_failed")
         message = getattr(e, "message", None) or str(e)
         raise IntakeFailed(error_code, message) from e
+    except Exception as e:
+        # Unerwartete Fehler aus dem Core (NICHT IntakeError) dürfen nicht roh
+        # entkommen — sonst bricht der ValueError-Kontrakt der Aufrufer
+        # (resolve_video_info fängt nur IntakeUnavailable/IntakeFailed). Als
+        # harter Fehler mit generischem error_code weiterreichen.
+        raise IntakeFailed("processing_failed", f"Unerwarteter Core-Fehler: {e}") from e
 
     try:
+        raw_warnings = data.get("warnings", [])
+        if not isinstance(raw_warnings, list):
+            # Fail-fast wie bei den übrigen Kontrakt-Feldern statt still zu
+            # coercen (z.B. würde list("text") die Zeichen zerlegen).
+            raise TypeError(
+                f"'warnings' muss eine Liste sein, war {type(raw_warnings).__name__}"
+            )
         video_info = VideoInfo(
             title=data["title"],
             channel=data["channel"],
@@ -106,7 +119,7 @@ def fetch(url: str, language: str = "de") -> IntakeResult:
             video_info=video_info,
             status=data.get("status", ""),
             transcript_available=bool(data.get("transcript_available", False)),
-            warnings=list(data.get("warnings") or []),
+            warnings=list(raw_warnings),
         )
     except (KeyError, TypeError) as e:
         # Wire-Form ist eingefroren; ein Mapping-Fehler heißt Kontraktbruch → laut

--- a/src/core/intake_adapter.py
+++ b/src/core/intake_adapter.py
@@ -1,0 +1,117 @@
+"""In-Process-Adapter für den `youtube-intake-service` (Core).
+
+Ruft den **Core** direkt in-process auf (`youtube_intake_core.process`) — NIEMALS
+den Server. Der Core ist reine Logik ohne Port/`service.info`; ein versehentlicher
+Import der Server-/FastAPI-Schicht würde einen Port binden und mit dem laufenden
+Webclip-Daemon kollidieren (siehe Spec §1, „nie den Server"-Regel). Strukturell ist
+das ohnehin abgesichert: SOMAS installiert den Core ohne `[server]`-Extra, FastAPI
+ist im Venv gar nicht vorhanden.
+
+Kontrakt (Service v1.0.0, eingefroren):
+- Erfolg/Teilerfolg → dict mit 12 Feldern (u. a. `status`, `transcript_available`,
+  `title`, `channel`, `duration` [int-Sek.], `url`, `transcript`, `warnings`).
+- Harte Fehler (ungültige URL, Video weg) → typisierte Exception `IntakeError`
+  (mit `.error_code`) aus `youtube_intake_core`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from src.config.defaults import VideoInfo
+
+logger = logging.getLogger(__name__)
+
+
+class IntakeUnavailable(RuntimeError):
+    """Der Core ist nicht importierbar/installiert.
+
+    Signalisiert dem Router, dass er auf den bestehenden In-Process-YouTube-Pfad
+    (`get_video_info`) zurückfallen soll — KEIN inhaltlicher Fehler.
+    """
+
+
+class IntakeFailed(RuntimeError):
+    """Harter, inhaltlicher Fehler aus dem Core (ungültige URL, Video nicht verfügbar).
+
+    Trägt den `error_code` des Core für spätere differenzierte Fehleranzeigen.
+    """
+
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
+
+
+@dataclass
+class IntakeResult:
+    """Ergebnis eines Core-Aufrufs, gemappt auf SOMAS-Datenmodelle.
+
+    Attributes:
+        video_info: Auf `VideoInfo` gemappte Metadaten (+ Transkript).
+        status: `"complete"` | `"metadata_only"` (nie `"error"` — das wird geraised).
+        transcript_available: Verlässliches „hat Transkript?"-Signal
+            (NICHT über `transcript == ""` prüfen).
+        warnings: Nicht-fatale Hinweise des Core (u. a. Sprach-Fallback, s. O5).
+    """
+
+    video_info: VideoInfo
+    status: str
+    transcript_available: bool
+    warnings: list[str] = field(default_factory=list)
+
+
+def fetch(url: str, language: str = "de") -> IntakeResult:
+    """Ruft den Core in-process auf und mappt das Ergebnis auf `IntakeResult`.
+
+    Args:
+        url: YouTube-URL.
+        language: Bevorzugte Transkript-Sprache (Fallback-Kette liegt im Core, O5).
+
+    Returns:
+        IntakeResult mit `VideoInfo` + Status/Transkript-Verfügbarkeit/Warnungen.
+
+    Raises:
+        IntakeUnavailable: Core nicht installiert/importierbar → Aufrufer soll auf
+            den Alt-Pfad zurückfallen.
+        IntakeFailed: Harter, inhaltlicher Fehler des Core (mit `error_code`).
+    """
+    # Lazy import: nur den CORE, niemals den Server. Fehlt das Paket, ist das kein
+    # inhaltlicher Fehler, sondern „nicht verfügbar" → Fallback.
+    try:
+        from youtube_intake_core import process, IntakeError  # type: ignore
+    except ImportError as e:
+        raise IntakeUnavailable(
+            f"youtube_intake_core ist nicht installiert/importierbar: {e}"
+        ) from e
+
+    try:
+        data = process(url, language=language)
+    except IntakeError as e:
+        # Deckt InvalidURLError / VideoUnavailableError / processing_failed ab.
+        error_code = getattr(e, "error_code", "processing_failed")
+        message = getattr(e, "message", None) or str(e)
+        raise IntakeFailed(error_code, message) from e
+
+    try:
+        video_info = VideoInfo(
+            title=data["title"],
+            channel=data["channel"],
+            duration=data["duration"],
+            url=data["url"],
+            transcript=data.get("transcript") or "",
+        )
+        return IntakeResult(
+            video_info=video_info,
+            status=data.get("status", ""),
+            transcript_available=bool(data.get("transcript_available", False)),
+            warnings=list(data.get("warnings") or []),
+        )
+    except (KeyError, TypeError) as e:
+        # Wire-Form ist eingefroren; ein Mapping-Fehler heißt Kontraktbruch → laut
+        # als harter Fehler melden statt still Falsches zu liefern.
+        raise IntakeFailed(
+            "mapping_error",
+            f"Unerwartete Core-Antwortstruktur: {e}",
+        ) from e

--- a/src/core/youtube_client.py
+++ b/src/core/youtube_client.py
@@ -97,6 +97,60 @@ def get_video_info(url: str) -> VideoInfo:
         raise ValueError(f"Konnte Video-Informationen nicht abrufen: {e}")
 
 
+def resolve_video_info(url: str, *, use_core: Optional[bool] = None) -> VideoInfo:
+    """Router: holt Metadaten über den Intake-Core ODER den Alt-Pfad.
+
+    Ist der Intake-Core aktiviert (Preference ``use_intake_core``) und importierbar,
+    wird ``intake_adapter.fetch`` genutzt; andernfalls (oder bei nicht verfügbarem
+    Core) fällt die Funktion transparent auf ``get_video_info`` zurück. Der Default
+    ist AUS → ohne Opt-in verhält sich SOMAS exakt wie bisher.
+
+    Der öffentliche Kontrakt entspricht ``get_video_info``: harte Fehler werden als
+    ``ValueError`` geworfen (der typisierte ``IntakeFailed`` des Core wird dafür
+    umgewandelt), damit bestehende Aufrufer mit ``except ValueError`` unverändert
+    funktionieren. (Beim späteren Alt-Code-Rückbau ggf. auf ``except ValueError``
+    achten — ``IntakeError``/``InvalidURLError`` erben NICHT von ``ValueError``.)
+
+    Args:
+        url: YouTube-URL.
+        use_core: Erzwingt den Pfad; ``None`` liest die Preference ``use_intake_core``.
+
+    Returns:
+        VideoInfo-Objekt (Titel, Kanal, Dauer, URL, Transkript).
+
+    Raises:
+        ValueError: Bei ungültiger URL oder Abruf-Fehler (beide Pfade).
+    """
+    if use_core is None:
+        try:
+            from src.config.api_config import load_preferences
+            use_core = bool(load_preferences().get("use_intake_core", False))
+        except Exception:
+            use_core = False
+
+    if use_core:
+        try:
+            from src.core.intake_adapter import fetch, IntakeUnavailable, IntakeFailed
+        except ImportError as e:
+            logger.warning(f"Intake-Adapter nicht importierbar, Fallback: {e}")
+        else:
+            try:
+                result = fetch(url)
+                for warning in result.warnings:
+                    logger.info(f"Intake-Core Hinweis: {warning}")
+                return result.video_info
+            except IntakeUnavailable as e:
+                # Core nicht installiert → transparent auf Alt-Pfad zurückfallen.
+                logger.warning(f"Intake-Core nicht verfügbar, Fallback: {e}")
+            except IntakeFailed as e:
+                # Harter, inhaltlicher Fehler: als ValueError durchreichen
+                # (Kontrakt wie get_video_info; kein Fallback, der nur denselben
+                # Fehler langsamer reproduzieren würde).
+                raise ValueError(e.message) from e
+
+    return get_video_info(url)
+
+
 def get_transcript(url: str, language: str = "de") -> Optional[str]:
     """Holt das Transkript eines YouTube-Videos.
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -12,7 +12,7 @@ from PyQt6.QtCore import Qt, pyqtSlot, QEvent, QPoint
 from PyQt6.QtGui import QFont
 
 from src.config.defaults import VideoInfo, SomasConfig, TimeRange
-from src.core.youtube_client import get_video_info
+from src.core.youtube_client import resolve_video_info
 from src.core.prompt_builder import (
     build_prompt, build_prompt_from_transcript,
     load_presets, get_preset_by_name, get_preset_by_id, PromptPreset,
@@ -991,7 +991,7 @@ class MainWindow(QMainWindow):
             return
 
         try:
-            self.video_info = get_video_info(url)
+            self.video_info = resolve_video_info(url)
             self.video_info_source = "youtube"
             self._display_meta()
             self._clear_stale_sources()

--- a/src/gui/settings_dialog.py
+++ b/src/gui/settings_dialog.py
@@ -205,6 +205,18 @@ class SettingsDialog(QDialog):
         )
         group_layout.addRow(self.channel_meta_checkbox)
 
+        # YouTube-Intake-Core (In-Process statt direktem yt-dlp/Transkript)
+        self.intake_core_checkbox = QCheckBox(
+            "YouTube-Intake-Service (Core) für Metadaten/Transkript verwenden"
+        )
+        self.intake_core_checkbox.setToolTip(
+            "Nutzt den eingebundenen youtube-intake-service-Core in-process.\n"
+            "Fällt automatisch auf den bisherigen Weg zurück, wenn der Core fehlt.\n"
+            "Standard: aus."
+        )
+        self.intake_core_checkbox.setChecked(prefs.get("use_intake_core", False))
+        group_layout.addRow(self.intake_core_checkbox)
+
         return group
 
     def _create_wordpress_group(self) -> QGroupBox:
@@ -681,6 +693,7 @@ class SettingsDialog(QDialog):
             prefs["last_provider"] = default_provider
         prefs["debug_logging"] = self.debug_checkbox.isChecked()
         prefs["show_channel_meta"] = self.channel_meta_checkbox.isChecked()
+        prefs["use_intake_core"] = self.intake_core_checkbox.isChecked()
         save_preferences(prefs)
 
         # WordPress-Konfiguration speichern (nicht-sensibel + Passwort via keyring)

--- a/tests/test_intake_adapter.py
+++ b/tests/test_intake_adapter.py
@@ -1,0 +1,184 @@
+"""Tests für den Intake-Core-Adapter und den Router (vollständig offline).
+
+Der echte `youtube_intake_core` wird NICHT benötigt: er wird als Fake in
+`sys.modules` injiziert bzw. gezielt „unavailable" gemacht. So laufen die Tests
+unabhängig davon, ob das Submodul/der Core bereits installiert ist.
+
+Lauf: python -m pytest tests/test_intake_adapter.py -q
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.config.defaults import VideoInfo
+
+
+def _wire_dict(**overrides) -> dict:
+    """Baut ein 12-Feld-Erfolgs-dict gemäß eingefrorener Wire-Form (v1.0.0)."""
+    d = dict(
+        status="complete",
+        transcript_available=True,
+        title="Titel",
+        channel="Kanal",
+        duration=125,
+        duration_formatted="2:05",
+        url="https://youtu.be/abcdefghijk",
+        thumbnail_url_maxres="https://i.ytimg.com/vi/abcdefghijk/maxresdefault.jpg",
+        transcript="hallo welt",
+        markdown="# md",
+        warnings=[],
+        errors=[],
+    )
+    d.update(overrides)
+    return d
+
+
+def _install_fake_core(monkeypatch, process_impl):
+    """Injiziert ein Fake-`youtube_intake_core`-Modul mit `process` + `IntakeError`."""
+    mod = types.ModuleType("youtube_intake_core")
+
+    class IntakeError(Exception):
+        def __init__(self, error_code="processing_failed", message="boom"):
+            super().__init__(message)
+            self.error_code = error_code
+            self.message = message
+
+    mod.IntakeError = IntakeError
+    mod.process = process_impl
+    monkeypatch.setitem(sys.modules, "youtube_intake_core", mod)
+    return mod
+
+
+# --- Adapter: fetch() ---------------------------------------------------------
+
+def test_fetch_complete_maps_to_videoinfo(monkeypatch):
+    from src.core import intake_adapter
+    _install_fake_core(monkeypatch, lambda url, language="de": _wire_dict())
+
+    res = intake_adapter.fetch("https://youtu.be/abcdefghijk")
+
+    assert isinstance(res.video_info, VideoInfo)
+    assert res.video_info.title == "Titel"
+    assert res.video_info.channel == "Kanal"
+    assert res.video_info.duration == 125
+    assert res.video_info.transcript == "hallo welt"
+    assert res.status == "complete"
+    assert res.transcript_available is True
+
+
+def test_fetch_metadata_only(monkeypatch):
+    from src.core import intake_adapter
+    _install_fake_core(
+        monkeypatch,
+        lambda url, language="de": _wire_dict(
+            status="metadata_only",
+            transcript_available=False,
+            transcript="",
+            warnings=["Transkript-Sprache: en (Fallback von de)"],
+        ),
+    )
+
+    res = intake_adapter.fetch("u")
+
+    assert res.status == "metadata_only"
+    assert res.transcript_available is False
+    assert res.video_info.transcript == ""
+    assert res.warnings == ["Transkript-Sprache: en (Fallback von de)"]
+
+
+def test_fetch_hard_error_becomes_intakefailed(monkeypatch):
+    from src.core import intake_adapter
+    mod = _install_fake_core(monkeypatch, None)
+
+    def boom(url, language="de"):
+        raise mod.IntakeError("invalid_url", "keine gültige URL")
+
+    mod.process = boom
+
+    with pytest.raises(intake_adapter.IntakeFailed) as excinfo:
+        intake_adapter.fetch("u")
+    assert excinfo.value.error_code == "invalid_url"
+    assert "gültige URL" in excinfo.value.message
+
+
+def test_fetch_missing_core_is_unavailable(monkeypatch):
+    from src.core import intake_adapter
+    # None in sys.modules erzwingt ImportError beim Import — robust, egal ob der
+    # echte Core installiert ist oder nicht.
+    monkeypatch.setitem(sys.modules, "youtube_intake_core", None)
+
+    with pytest.raises(intake_adapter.IntakeUnavailable):
+        intake_adapter.fetch("u")
+
+
+def test_fetch_broken_wireform_is_intakefailed(monkeypatch):
+    from src.core import intake_adapter
+    _install_fake_core(monkeypatch, lambda url, language="de": {"title": "nur titel"})
+
+    with pytest.raises(intake_adapter.IntakeFailed) as excinfo:
+        intake_adapter.fetch("u")
+    assert excinfo.value.error_code == "mapping_error"
+
+
+# --- Router: resolve_video_info() --------------------------------------------
+
+def test_resolve_use_core_false_uses_old_path(monkeypatch):
+    from src.core import youtube_client
+    calls = {}
+
+    def fake_old(url):
+        calls["url"] = url
+        return "OLD"
+
+    monkeypatch.setattr(youtube_client, "get_video_info", fake_old)
+
+    assert youtube_client.resolve_video_info("u", use_core=False) == "OLD"
+    assert calls["url"] == "u"
+
+
+def test_resolve_use_core_true_success(monkeypatch):
+    from src.core import youtube_client, intake_adapter
+    vi = VideoInfo(title="T", channel="C", duration=1, url="u", transcript="")
+    monkeypatch.setattr(
+        intake_adapter, "fetch",
+        lambda url, language="de": intake_adapter.IntakeResult(vi, "complete", False, ["w"]),
+    )
+    monkeypatch.setattr(
+        youtube_client, "get_video_info",
+        lambda url: pytest.fail("Alt-Pfad darf bei Core-Erfolg nicht laufen"),
+    )
+
+    assert youtube_client.resolve_video_info("u", use_core=True) is vi
+
+
+def test_resolve_falls_back_on_unavailable(monkeypatch):
+    from src.core import youtube_client, intake_adapter
+
+    def boom(url, language="de"):
+        raise intake_adapter.IntakeUnavailable("kein Core")
+
+    monkeypatch.setattr(intake_adapter, "fetch", boom)
+    monkeypatch.setattr(youtube_client, "get_video_info", lambda url: "OLD")
+
+    assert youtube_client.resolve_video_info("u", use_core=True) == "OLD"
+
+
+def test_resolve_hard_error_raises_valueerror(monkeypatch):
+    from src.core import youtube_client, intake_adapter
+
+    def boom(url, language="de"):
+        raise intake_adapter.IntakeFailed("video_unavailable", "Video weg")
+
+    monkeypatch.setattr(intake_adapter, "fetch", boom)
+    monkeypatch.setattr(
+        youtube_client, "get_video_info",
+        lambda url: pytest.fail("Bei hartem Fehler KEIN Fallback erwartet"),
+    )
+
+    with pytest.raises(ValueError):
+        youtube_client.resolve_video_info("u", use_core=True)

--- a/tests/test_intake_adapter.py
+++ b/tests/test_intake_adapter.py
@@ -125,6 +125,35 @@ def test_fetch_broken_wireform_is_intakefailed(monkeypatch):
     assert excinfo.value.error_code == "mapping_error"
 
 
+def test_fetch_generic_error_becomes_intakefailed(monkeypatch):
+    from src.core import intake_adapter
+    mod = _install_fake_core(monkeypatch, None)
+
+    def boom(url, language="de"):
+        raise RuntimeError("irgendwas Unerwartetes im Core")
+
+    mod.process = boom
+
+    # Nicht-IntakeError darf NICHT roh entkommen (sonst bricht der ValueError-
+    # Kontrakt der Aufrufer) → als IntakeFailed mit generischem Code.
+    with pytest.raises(intake_adapter.IntakeFailed) as excinfo:
+        intake_adapter.fetch("u")
+    assert excinfo.value.error_code == "processing_failed"
+
+
+def test_fetch_nonlist_warnings_is_intakefailed(monkeypatch):
+    from src.core import intake_adapter
+    _install_fake_core(
+        monkeypatch,
+        lambda url, language="de": _wire_dict(warnings="kein array"),
+    )
+
+    # Nicht-Listen-warnings werden NICHT still coerct, sondern fail-fast.
+    with pytest.raises(intake_adapter.IntakeFailed) as excinfo:
+        intake_adapter.fetch("u")
+    assert excinfo.value.error_code == "mapping_error"
+
+
 # --- Router: resolve_video_info() --------------------------------------------
 
 def test_resolve_use_core_false_uses_old_path(monkeypatch):


### PR DESCRIPTION
…lback)

Adapter ruft youtube_intake_core.process in-process; Router resolve_video_info mit Fallback auf get_video_info; 3 Call-Sites; Settings-Toggle use_intake_core (Default aus); Offline-Tests. Submodul external/youtube-intake-service @ v1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * YouTube-Metadaten können jetzt optional über einen integrierten Intake-Workflow abgerufen werden.
  * In den Einstellungen gibt es eine neue Option, um diesen Modus ein- oder auszuschalten.

* **Bug Fixes**
  * Metadatenabrufe in Batch-, Vergleichs- und UI-Flows nutzen jetzt eine einheitliche Auflösung mit automatischem Fallback bei Verfügbarkeit.
  * Fehler beim Abruf werden klarer behandelt, statt den Ablauf unkontrolliert zu unterbrechen.

* **Tests**
  * Neue Offline-Tests prüfen die neue Abruflogik, Fehlerfälle und das Fallback-Verhalten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->