### PR TITLE
v0.12.0: WordPress-Beitragsbild (YouTube-Thumbnail als featured image)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ somas_prompt_generator/
 │   │   ├── transcript_widget.py # Transkript-Eingabewidget
 │   │   ├── batch_dialog.py     # Batch-Verarbeitung (2-5 URLs, non-modaler Dialog)
 │   │   ├── prompt_edit_dialog.py # Prompt-Anpassungsdialog (System-Prompt + Modul)
-│   │   └── provider_model_picker.py # Provider+Modell-Auswahl (3× im Modellvergleich)
+│   │   ├── provider_model_picker.py # Provider+Modell-Auswahl (3× im Modellvergleich)
+│   │   └── wordpress_dialog.py  # WordPress-Sende-Dialog (Intro/Analyse/Outro, Beitragsbild)
 │   │
 │   ├── core/               # Business-Logik
 │   │   ├── youtube_client.py   # Metadaten via yt-dlp
@@ -57,7 +58,9 @@ somas_prompt_generator/
 │   │   ├── comparison_worker.py # QThread-Worker: 2 Analysen + Synthese + Layout-Render
 │   │   ├── verification_item.py # VerificationConfig/VerificationResult (Faktencheck Stufe 2)
 │   │   ├── verification_worker.py # QThread-Worker: Behauptungen verifizieren (Verdikt + Quelle)
-│   │   └── debug_logger.py     # Debug-Logging mit Version/Session-Info
+│   │   ├── debug_logger.py     # Debug-Logging mit Version/Session-Info
+│   │   ├── wordpress_client.py # WordPress-REST-Client (Beitrag, Taxonomien, Media-Upload)
+│   │   └── wordpress_worker.py # QThread-Worker für blockierende WordPress-Operationen
 │   │
 │   └── config/             # Konfiguration
 │       ├── defaults.py         # SOMAS-Defaults (VideoInfo, SomasConfig, TimeRange)
@@ -379,6 +382,31 @@ wurde abgeschnitten. Spec: `SOMAS_v0.11.0_SPEC_reasoning_leak_haertung.md`.
   Verifikation (Stufe 2) nur auf gültiger Analyse
 - [x] Iran-Fixture + `tests/test_reasoning_leak_validator.py` (Leak/Trunkierung ungültig,
   Clean gültig, False-Positive-Guards)
+
+### Phase 14: WordPress-Anbindung ✅
+
+Sendet eine SOMAS-Analyse als Beitrag an eine selbstgehostete WordPress-Seite über
+die REST-API (`/wp-json/wp/v2/`). Desktop-App → kein CORS; HTTP Basic Auth mit
+**Application Password**. Voraussetzungen: WP-User mit Veröffentlichungsrecht
+(fürs Beitragsbild zusätzlich `upload_files`, also Autor/Admin) und ein gültiges
+Application Password. **Wordfence-Hinweis:** Wordfence (o.ä. Security-Plugins)
+können REST-/App-Password-Requests blocken → ggf. XML-RPC/REST bzw. Application
+Passwords in Wordfence freigeben.
+
+- [x] Basis (PR #43, Variante A): `wordpress_client.py` (Config/Keyring-Passwort,
+  `markdown_to_html`, `resolve_terms`, `WordPressClient.post`, `publish_post`),
+  `wordpress_worker.py` (QThread), `wordpress_dialog.py` (Intro/Analyse/Outro,
+  Status/Kategorie/Tags, HTML-Vorschau). Passwort im OS-Keyring, Config in
+  `user_preferences.json`.
+- [x] Beitragsbild (featured image): YouTube-Thumbnail des Videos als **echtes
+  Beitragsbild** (nicht inline). `WordPressClient.upload_media` (POST `/media`),
+  `post(featured_media=…)`, `publish_post(featured_image_urls=[maxres,hq,sd],
+  video_id=…)` mit Fallback-Kette; **nicht fatal** (scheitert Laden/Upload, wird
+  der Text trotzdem gepostet + Warnung im Rückgabewert). Dialog-Checkbox
+  „YouTube-Thumbnail als Beitragsbild verwenden" (aktiv bei Video, ausgeblendet im
+  Transkript-Modus). Tests: `tests/test_wordpress_media.py`.
+- [ ] Backlog: Media-Dedup (vorhandenes Thumbnail per Suche wiederverwenden statt
+  bei jedem Senden neu hochzuladen → vermeidet Media-Dubletten).
 
 ### Backlog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.11.0
+**Version:** 0.12.0
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -383,7 +383,7 @@ wurde abgeschnitten. Spec: `SOMAS_v0.11.0_SPEC_reasoning_leak_haertung.md`.
 - [x] Iran-Fixture + `tests/test_reasoning_leak_validator.py` (Leak/Trunkierung ungültig,
   Clean gültig, False-Positive-Guards)
 
-### Phase 14: WordPress-Anbindung ✅
+### Phase 14: WordPress-Anbindung ✅ (v0.12.0)
 
 Sendet eine SOMAS-Analyse als Beitrag an eine selbstgehostete WordPress-Seite über
 die REST-API (`/wp-json/wp/v2/`). Desktop-App → kein CORS; HTTP Basic Auth mit

--- a/README.md
+++ b/README.md
@@ -16,7 +16,16 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.11.0) — Reasoning-Leak-Härtung
+### Aktuell (v0.12.0) — WordPress-Veröffentlichung
+
+Sendet eine fertige SOMAS-Analyse direkt als Beitrag an eine selbstgehostete WordPress-Seite (REST-API). Da SOMAS eine Desktop-App ist, genügt HTTP Basic Auth mit einem **Application Password** – kein CORS, kein Plugin nötig.
+
+- **Sende-Dialog** – Getrennte Felder für Intro / Analyse / Outro (Markdown), einstellbarer Status (Entwurf/Privat/Veröffentlichen/Ausstehend), Kategorie und Tags, plus HTML-Vorschau. Der Default-Status („Entwurf") kommt aus den Einstellungen
+- **YouTube-Thumbnail als Beitragsbild** – Das Thumbnail des analysierten Videos wird in die Mediathek hochgeladen und als **echtes Beitragsbild** (featured image) gesetzt – nicht inline. Checkbox „YouTube-Thumbnail als Beitragsbild verwenden" (aktiv bei Video, ausgeblendet im Transkript-Modus). **Nicht fatal:** Schlägt der Bild-Upload fehl (z. B. fehlende Rechte), wird der Beitrag trotzdem gepostet – der Text ist wichtiger als das Bild
+- **Sicher & lokal** – URL/Benutzer/Defaults in den Einstellungen, das Application Password im OS-Credential-Manager (wie die API-Keys)
+- **Voraussetzungen** – WP-Benutzer mit Veröffentlichungsrecht (fürs Beitragsbild zusätzlich `upload_files`, also Autor/Admin) und ein Application Password. Security-Plugins wie **Wordfence** ggf. für REST-/Application-Password-Requests freischalten
+
+### Seit v0.11.0 — Reasoning-Leak-Härtung
 
 Behebt einen realen **Final-Answer-Leak**: Ein Modell kippte statt der Analyse seinen Denkprozess in die Antwort, verbrauchte damit das Token-Budget und wurde mitten im Satz abgeschnitten – heraus kam Notizen-Müll statt einer Analyse.
 
@@ -25,15 +34,6 @@ Behebt einen realen **Final-Answer-Leak**: Ein Modell kippte statt der Analyse s
 - **Struktur-Validator** – Prüft die Analyse positiv (Start mit `### FRAMING`, erwartete Abschnitte in Reihenfolge, bei Faktencheck die drei Sub-Header, keine abgeschnittene Nummerierung) – **ohne** legitime Analysen zu verwerfen, die zufällig Wörter wie „Prompt" im Text haben
 - **Ein sichtbarer Auto-Retry** – Bei Leak/Trunkierung/fehlender Struktur wird **einmal** automatisch neu angefordert (abbrechbar). Bleibt es fehlerhaft, erscheint ein offener **„Modelllauf fehlgeschlagen"** – bewusst **keine** kosmetisch reparierte Scheinanalyse
 - **Sauberer Faktencheck-Prompt** – Der erzwungene FAKTENCHECK-Modus enthält keinen Widerspruch mehr (volle Analyse **+** FAKTENCHECK als 5. Abschnitt); ein Final-Only-Zaun hält Arbeitsnotizen aus dem Output. Die Web-Verifikation (Stufe 2) startet **nur** auf einer gültigen, nicht-trunkierten Analyse
-
-### WordPress-Anbindung — Analyse als Beitrag senden
-
-Sendet eine fertige SOMAS-Analyse direkt als Beitrag an eine selbstgehostete WordPress-Seite (REST-API). Da SOMAS eine Desktop-App ist, genügt HTTP Basic Auth mit einem **Application Password** – kein CORS, kein Plugin nötig.
-
-- **Sende-Dialog** – Getrennte Felder für Intro / Analyse / Outro (Markdown), einstellbarer Status (Entwurf/Privat/Veröffentlichen/Ausstehend), Kategorie und Tags, plus HTML-Vorschau. Der Default-Status („Entwurf") kommt aus den Einstellungen
-- **YouTube-Thumbnail als Beitragsbild** – Das Thumbnail des analysierten Videos wird in die Mediathek hochgeladen und als **echtes Beitragsbild** (featured image) gesetzt – nicht inline. Checkbox „YouTube-Thumbnail als Beitragsbild verwenden" (aktiv bei Video, ausgeblendet im Transkript-Modus). **Nicht fatal:** Schlägt der Bild-Upload fehl (z. B. fehlende Rechte), wird der Beitrag trotzdem gepostet – der Text ist wichtiger als das Bild
-- **Sicher & lokal** – URL/Benutzer/Defaults in den Einstellungen, das Application Password im OS-Credential-Manager (wie die API-Keys)
-- **Voraussetzungen** – WP-Benutzer mit Veröffentlichungsrecht (fürs Beitragsbild zusätzlich `upload_files`, also Autor/Admin) und ein Application Password. Security-Plugins wie **Wordfence** ggf. für REST-/Application-Password-Requests freischalten
 
 ### Seit v0.10.1 — Faktencheck-Verifikation (gehärtet)
 
@@ -358,6 +358,7 @@ Die App implementiert das SOMAS-Framework mit Content-Type-spezifischen Analyse-
 
 | Version | Datum | Änderungen |
 | --------- | ------- | ------------ |
+| 0.12.0 | 2026-07-04 | WordPress-Veröffentlichung: Analyse als Beitrag senden (Intro/Analyse/Outro, Status/Kategorie/Tags, HTML-Vorschau) + YouTube-Thumbnail als **Beitragsbild** (featured image, Media-Upload mit Fallback-Kette maxres→hq→sd, nicht-fatal). App-Password im OS-Keyring; Voraussetzung `upload_files` + ggf. Wordfence-Freigabe |
 | 0.11.0 | 2026-07-02 | Reasoning-Leak-Härtung: OpenRouter `reasoning.exclude=true` (Denkprozess bleibt intern), `finish_reason` durchgereicht + geloggt + als harter Trunkierungs-Gate, preamble-scoped Struktur-/Trunkierungs-Validator, ein sichtbarer + abbrechbarer Auto-Retry statt Scheinanalyse („Modelllauf fehlgeschlagen"), FAKTENCHECK-Prompt-Widerspruch aufgelöst + Final-Only-Zaun, Iran-Leak als Test-Fixture |
 | 0.10.1 | 2026-06-16 | Faktencheck-Härtung: Unabhängigkeits-Riegel (kein Eigenbeleg durchs Video, `source_hint` injection-sicher), „Verifikation erneut versuchen"-Button (nur Stufe 2, Modellwechsel), Perplexity-Modelle aktualisiert (`sonar-reasoning-pro`/`sonar-deep-research`), `DEFAULT_MAX_TOKENS=8192` (HTTP-402-Fix), einheitlicher Export-Kopf (Titel + Thumbnail), Zeichenlimit-Fix bei FAKTENCHECK |
 | 0.10.0 | 2026-06-14 | Faktencheck-Verifikation (Hybrid): Stufe 1 trennt Meinungen/Interpretationen/Behauptungen; optionale Stufe 2 verifiziert Behauptungen per web-fähigem Modell (Verdikt + Quelle, 4-stufige Skala), Halluzinations-Schutz + Riegel gegen erfundene Quellen, `:online`-Schalter, Top-N-Kappung, Auto-Anhang |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Behebt einen realen **Final-Answer-Leak**: Ein Modell kippte statt der Analyse s
 - **Ein sichtbarer Auto-Retry** – Bei Leak/Trunkierung/fehlender Struktur wird **einmal** automatisch neu angefordert (abbrechbar). Bleibt es fehlerhaft, erscheint ein offener **„Modelllauf fehlgeschlagen"** – bewusst **keine** kosmetisch reparierte Scheinanalyse
 - **Sauberer Faktencheck-Prompt** – Der erzwungene FAKTENCHECK-Modus enthält keinen Widerspruch mehr (volle Analyse **+** FAKTENCHECK als 5. Abschnitt); ein Final-Only-Zaun hält Arbeitsnotizen aus dem Output. Die Web-Verifikation (Stufe 2) startet **nur** auf einer gültigen, nicht-trunkierten Analyse
 
+### WordPress-Anbindung — Analyse als Beitrag senden
+
+Sendet eine fertige SOMAS-Analyse direkt als Beitrag an eine selbstgehostete WordPress-Seite (REST-API). Da SOMAS eine Desktop-App ist, genügt HTTP Basic Auth mit einem **Application Password** – kein CORS, kein Plugin nötig.
+
+- **Sende-Dialog** – Getrennte Felder für Intro / Analyse / Outro (Markdown), einstellbarer Status (Entwurf/Privat/Veröffentlichen/Ausstehend), Kategorie und Tags, plus HTML-Vorschau. Der Default-Status („Entwurf") kommt aus den Einstellungen
+- **YouTube-Thumbnail als Beitragsbild** – Das Thumbnail des analysierten Videos wird in die Mediathek hochgeladen und als **echtes Beitragsbild** (featured image) gesetzt – nicht inline. Checkbox „YouTube-Thumbnail als Beitragsbild verwenden" (aktiv bei Video, ausgeblendet im Transkript-Modus). **Nicht fatal:** Schlägt der Bild-Upload fehl (z. B. fehlende Rechte), wird der Beitrag trotzdem gepostet – der Text ist wichtiger als das Bild
+- **Sicher & lokal** – URL/Benutzer/Defaults in den Einstellungen, das Application Password im OS-Credential-Manager (wie die API-Keys)
+- **Voraussetzungen** – WP-Benutzer mit Veröffentlichungsrecht (fürs Beitragsbild zusätzlich `upload_files`, also Autor/Admin) und ein Application Password. Security-Plugins wie **Wordfence** ggf. für REST-/Application-Password-Requests freischalten
+
 ### Seit v0.10.1 — Faktencheck-Verifikation (gehärtet)
 
 - **Zweistufige Faktenprüfung** – Das FAKTENCHECK-Modul trennt jetzt strikt **Meinungen**, **Interpretationen** und **überprüfbare Behauptungen** (relevanz-sortiert). Optional prüft danach ein web-fähiges Modell **nur die nackten Behauptungen** und liefert pro Behauptung **Verdikt + Quelle**

--- a/specs/STARTPROMPT_WordPress-Thumbnail-Beitragsbild_fuer_Kurt.md
+++ b/specs/STARTPROMPT_WordPress-Thumbnail-Beitragsbild_fuer_Kurt.md
@@ -1,0 +1,82 @@
+# Startprompt für Kurt (Claude Code) — WordPress-Beitragsbild (YouTube-Thumbnail als featured image)
+
+> Kleiner, abgegrenzter Feature-Zuwachs auf der bestehenden WordPress-Anbindung. Kontext: Der
+> End-to-End-Test (Entwurf senden) läuft grün, Formatierung passt — aber das **YouTube-Thumbnail
+> fehlt** im Beitrag. Es war schlicht nicht mitgeplant: Die App baut die Thumbnail-URL für den
+> Markdown-Export bereits (`build_thumbnail_urls`), reicht sie aber nicht in den WordPress-Pfad.
+> PO-Entscheidung (Thorsten): als **echtes Beitragsbild (featured image)**, nicht inline.
+
+---
+
+Du bist der **Programmierer** im SOMAS-Team. Ergänze die WordPress-Anbindung um ein **Beitragsbild**:
+Das YouTube-Thumbnail des analysierten Videos wird in die WP-Mediathek hochgeladen und als
+`featured_media` am Beitrag gesetzt. Arbeite in kleinen, nachvollziehbaren Schritten; halte am Ende
+für die PO-Abnahme (echter Sende-Test) inne.
+
+## Ausgangslage (verifiziert)
+- Thumbnail-URLs existieren: `src/core/youtube_client.py` → `extract_video_id(url)` und
+  `build_thumbnail_urls(video_id)` → dict `{"maxres", "hq", "sd"}` (JPEG unter `i.ytimg.com`).
+  Genutzt in `export.py` (mit `is_youtube`-Check) und `comparison_worker.py`.
+- Sende-Pfad: `main_window._on_send_to_wordpress` (~Z.1495) → `WordPressSendDialog(result,
+  suggested_title)` → (Worker) → `publish_post(...)` (`wordpress_client.py:444`) → `markdown_to_html`
+  + `resolve_terms` + `WordPressClient.post(...)` (`:360`).
+- **Lücken:** (1) der Dialog bekommt **kein** `video_info`/Thumbnail; (2) `post()` und `publish_post()`
+  kennen **kein** `featured_media`; es gibt **keine** Media-Upload-Methode.
+
+## Umsetzung (Reihenfolge)
+
+### PR 1 — Media-Upload + featured_media im Client
+`src/core/wordpress_client.py`:
+- Neue Methode `WordPressClient.upload_media(image_bytes: bytes, filename: str, mime: str =
+  "image/jpeg") -> int`: `POST` auf `self._endpoint("media")` mit Headern
+  `Content-Disposition: attachment; filename="{filename}"` und `Content-Type: {mime}`, Body = rohe
+  Bytes, `auth=self._auth`. Gibt die numerische Media-`id` zurück. Fehlerbehandlung analog `post()`
+  (HTTPError → `WordPressError` mit Detail, inkl. 401/403 = fehlende `upload_files`-Rechte).
+- `post(...)`: Parameter `featured_media: Optional[int] = None` ergänzen; wenn gesetzt,
+  `payload["featured_media"] = featured_media`. Sonst unverändert.
+
+### PR 2 — publish_post lädt das Thumbnail (nicht-fatal)
+`src/core/wordpress_client.py`, `publish_post(...)`:
+- Neuer Parameter `featured_image_url: Optional[str] = None`.
+- Wenn gesetzt: Bild-Bytes laden (`requests.get`, Timeout `_REQUEST_TIMEOUT`) mit **Fallback**
+  maxres → hq → sd (der Aufrufer übergibt idealerweise die maxres-URL; bei 404/Fehler die nächste
+  probieren — oder alle drei als Liste übergeben und hier durchprobieren). Dann
+  `client.upload_media(...)` → `media_id`, und `client.post(..., featured_media=media_id)`.
+- **Nicht fatal:** Schlägt Laden/Upload fehl, wird der Beitrag **trotzdem** ohne Beitragsbild
+  gepostet + eine Warnung geloggt/zurückgegeben (der Text ist wichtiger als das Bild). Kein Abbruch.
+- Dateiname z.B. `somas-thumbnail-{video_id}.jpg`.
+
+### PR 3 — Thumbnail-URL bis zum Dialog durchreichen + Checkbox
+- `main_window._on_send_to_wordpress` (~Z.1504): aus `self.video_info` die Thumbnail-URL ableiten
+  (`extract_video_id(video_info.url)` → `build_thumbnail_urls`), an den Dialog übergeben. Kein
+  Video/keine Video-ID (Transkript-Modus) → `None`.
+- `WordPressSendDialog.__init__`: Parameter `thumbnail_url: Optional[str] = None` (oder das
+  `{maxres,hq,sd}`-dict) aufnehmen.
+- Im Optionen-Bereich eine **Checkbox** „Thumbnail als Beitragsbild verwenden":
+  - Vorhandene Thumbnail-URL → Checkbox sichtbar und **standardmäßig aktiv**.
+  - Kein Thumbnail (Transkript) → Checkbox **deaktiviert/ausgeblendet** (kein Bild, kein Fehler).
+- Beim Senden: ist die Checkbox aktiv, `featured_image_url` an `publish_post` durchreichen; sonst
+  `None`.
+
+## Harte Constraints / Hinweise
+- **Body-Inhalt bleibt unverändert** — das Thumbnail ist *nur* Beitragsbild, kein Inline-Bild.
+- **Transkript-Modus** (kein YouTube) muss sauber ohne Thumbnail durchlaufen.
+- Rechte: der WP-User braucht `upload_files` (Autor/Admin) — bei 401/403 nicht abstürzen, sondern
+  ohne Bild posten + verständliche Warnung.
+- Bekannte, akzeptierte Einschränkung (v1): wiederholtes Senden lädt das Bild erneut hoch (mögliche
+  Media-Dubletten). Dedup (vorhandene Media per Suche wiederverwenden) ist **später**, nicht jetzt.
+- Zeilenenden bewahren, keine Voll-Reformatierung (CRLF-Churn, kein `.gitattributes`).
+
+## Definition of Done
+- Freddy-Testvideo als **Entwurf** senden → in WP erscheint das YouTube-Thumbnail als
+  **Beitragsbild** (in der Beitragsliste-Spalte und in der Beitragsansicht/Theme-Vorschau).
+- Transkript-Analyse senden → Beitrag ohne Beitragsbild, kein Fehler, Checkbox war deaktiviert.
+- Tests: `upload_media` baut den Request korrekt (gemockt), `post()` nimmt `featured_media` in den
+  Payload, `publish_post` lädt Thumbnail + reicht `media_id` weiter, Transkript-/Fehlerfall
+  (Upload schlägt fehl) posten trotzdem den Text. Bestehende WP-Tests grün.
+- **Doku nachziehen** (steht ohnehin aus): WordPress-Anbindung in CLAUDE.md (eigene Phase) + README
+  ergänzen — inkl. dieses Beitragsbild-Zuwachses und der App-Passwort-/Wordfence-Voraussetzung.
+
+## Arbeitsweise
+Bei Unklarheit/Widerspruch erst den PO (Thorsten) fragen. Eigener kleiner PR, unabhängig von der
+Anthropic-Modellpflege. Nach Fertigstellung innehalten — der reale Sende-Test ist die Abnahme.

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.11.0"
+APP_VERSION = "0.12.0"
 
 
 class DebugLogger:

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -498,6 +498,34 @@ def run_connection_test(config: WordPressConfig, app_password: str) -> tuple[boo
     return WordPressClient(config, app_password).test_connection()
 
 
+def _download_thumbnail(urls: list[str]) -> Optional[bytes]:
+    """Lädt das erste erreichbare Bild aus einer Fallback-Kette von URLs.
+
+    YouTube liefert nicht für jedes Video ein ``maxresdefault.jpg`` (404); daher
+    wird die Liste (typisch maxres → hq → sd) der Reihe nach durchprobiert.
+
+    Args:
+        urls: Bild-URLs in Prioritätsreihenfolge.
+
+    Returns:
+        Die rohen Bild-Bytes oder ``None``, wenn keine URL erreichbar war.
+    """
+    for url in urls:
+        if not url:
+            continue
+        try:
+            resp = requests.get(url, timeout=_REQUEST_TIMEOUT)
+            if resp.status_code == 200 and resp.content:
+                return resp.content
+            logger.info(
+                "Thumbnail-URL nicht verfügbar (HTTP %s): %s",
+                resp.status_code, url,
+            )
+        except requests.RequestException as exc:
+            logger.info("Thumbnail-URL fehlgeschlagen (%s): %s", exc, url)
+    return None
+
+
 def publish_post(
     config: WordPressConfig,
     app_password: str,
@@ -506,11 +534,19 @@ def publish_post(
     status: str = DEFAULT_STATUS,
     category_names: Optional[list[str]] = None,
     tag_names: Optional[list[str]] = None,
-) -> tuple[int, str]:
+    featured_image_urls: Optional[list[str]] = None,
+    video_id: str = "",
+) -> tuple[int, str, Optional[str]]:
     """Konvertiert Markdown, löst Taxonomien auf und postet (blockierend).
 
     Diese Funktion bündelt alle Netzwerk-Operationen, damit sie als Einheit im
     Worker-Thread laufen kann.
+
+    Ist ``featured_image_urls`` gesetzt, wird das erste erreichbare Bild geladen,
+    in die Mediathek hochgeladen und als Beitragsbild (featured image) gesetzt.
+    Das ist **nicht fatal**: Schlägt Laden oder Upload fehl, wird der Beitrag
+    trotzdem (ohne Beitragsbild) gepostet und eine Warnung zurückgegeben — der
+    Text ist wichtiger als das Bild.
 
     Args:
         config: WordPress-Konfiguration.
@@ -520,22 +556,50 @@ def publish_post(
         status: Beitragsstatus.
         category_names: Optionale Kategorie-Namen.
         tag_names: Optionale Tag-Namen.
+        featured_image_urls: Optionale Bild-URLs in Fallback-Reihenfolge
+            (z.B. ``[maxres, hq, sd]``) für das Beitragsbild.
+        video_id: Optionale Video-ID für einen sprechenden Media-Dateinamen.
 
     Returns:
-        Tupel ``(post_id, link)``.
+        Tupel ``(post_id, link, image_warning)``. ``image_warning`` ist ``None``
+        bei Erfolg (oder wenn kein Bild gewünscht war), sonst eine Klartext-
+        Warnung, dass das Beitragsbild nicht gesetzt werden konnte.
 
     Raises:
-        WordPressError: Bei API-/Netzwerkfehlern.
+        WordPressError: Bei API-/Netzwerkfehlern beim Beitrag selbst.
         RuntimeError: Wenn das ``markdown``-Paket fehlt.
     """
     client = WordPressClient(config, app_password)
     html = markdown_to_html(markdown_content)
     category_ids = client.resolve_terms(category_names or [], "categories")
     tag_ids = client.resolve_terms(tag_names or [], "tags")
-    return client.post(
+
+    # Beitragsbild (optional, nicht fatal): Bild laden -> Mediathek -> media_id.
+    featured_media: Optional[int] = None
+    image_warning: Optional[str] = None
+    if featured_image_urls:
+        try:
+            image_bytes = _download_thumbnail(featured_image_urls)
+            if image_bytes is None:
+                image_warning = (
+                    "Beitragsbild übersprungen: kein Thumbnail erreichbar."
+                )
+                logger.warning(image_warning)
+            else:
+                filename = f"somas-thumbnail-{video_id or 'video'}.jpg"
+                featured_media = client.upload_media(image_bytes, filename)
+        except WordPressError as exc:
+            # Upload-Fehler (z.B. fehlende upload_files-Rechte) nicht fatal.
+            featured_media = None
+            image_warning = f"Beitragsbild konnte nicht gesetzt werden: {exc}"
+            logger.warning(image_warning)
+
+    post_id, link = client.post(
         title=title,
         html_content=html,
         status=status,
         category_ids=category_ids or None,
         tag_ids=tag_ids or None,
+        featured_media=featured_media,
     )
+    return post_id, link, image_warning

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -357,6 +357,59 @@ class WordPressClient:
                 ids.append(self.get_or_create_term(cleaned, taxonomy))
         return ids
 
+    def upload_media(
+        self, image_bytes: bytes, filename: str, mime: str = "image/jpeg",
+    ) -> int:
+        """Lädt ein Bild in die WordPress-Mediathek hoch.
+
+        Erwartet die rohen Bild-Bytes und lädt sie via ``POST /media`` hoch. Der
+        Dateiname wird über den ``Content-Disposition``-Header übermittelt (so
+        verlangt es die REST-API für Datei-Uploads).
+
+        Args:
+            image_bytes: Die rohen Bilddaten.
+            filename: Dateiname für die Mediathek (z.B. ``somas-thumbnail-<id>.jpg``).
+            mime: MIME-Typ der Bilddaten (Standard ``image/jpeg``).
+
+        Returns:
+            Die numerische Media-ID des angelegten Anhangs.
+
+        Raises:
+            WordPressError: Bei API-/Netzwerkfehlern (inkl. 401/403 = fehlende
+                ``upload_files``-Rechte).
+        """
+        headers = {
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Type": mime,
+        }
+        try:
+            resp = requests.post(
+                self._endpoint("media"),
+                data=image_bytes,
+                headers=headers,
+                auth=self._auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return int(resp.json()["id"])
+        except requests.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.response.json().get("message", "")
+            except (ValueError, AttributeError):
+                detail = exc.response.text[:200] if exc.response is not None else ""
+            raise WordPressError(
+                f"Bild-Upload fehlgeschlagen (HTTP "
+                f"{exc.response.status_code if exc.response is not None else '?'})"
+                f"{': ' + detail if detail else ''}"
+            ) from exc
+        except requests.RequestException as exc:
+            raise WordPressError(f"Netzwerkfehler beim Bild-Upload: {exc}") from exc
+        except (KeyError, ValueError) as exc:
+            raise WordPressError(
+                f"Unerwartete Antwort beim Bild-Upload: {exc}"
+            ) from exc
+
     def post(
         self,
         title: str,
@@ -364,6 +417,7 @@ class WordPressClient:
         status: str = DEFAULT_STATUS,
         category_ids: Optional[list[int]] = None,
         tag_ids: Optional[list[int]] = None,
+        featured_media: Optional[int] = None,
     ) -> tuple[int, str]:
         """Erstellt einen Beitrag in WordPress.
 
@@ -374,6 +428,7 @@ class WordPressClient:
                 ``pending``).
             category_ids: Optionale Kategorie-IDs.
             tag_ids: Optionale Tag-IDs.
+            featured_media: Optionale Media-ID für das Beitragsbild (featured image).
 
         Returns:
             Tupel ``(post_id, link)``.
@@ -393,6 +448,8 @@ class WordPressClient:
             payload["categories"] = category_ids
         if tag_ids:
             payload["tags"] = tag_ids
+        if featured_media:
+            payload["featured_media"] = featured_media
 
         try:
             resp = requests.post(

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -16,6 +16,7 @@ speichert.
 import logging
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urlparse
 
 import keyring
 import requests
@@ -45,6 +46,11 @@ WP_STATUSES = ("draft", "private", "publish", "pending")
 DEFAULT_STATUS = "draft"
 
 _REQUEST_TIMEOUT = 30
+
+#: Erlaubte Hosts für den Beitragsbild-Download (SSRF-Schutz). Aktuell liefert nur
+#: ``build_thumbnail_urls`` die URLs (i.ytimg.com); die Allowlist verhindert, dass
+#: ein künftiger Aufrufer den Client zu beliebigen internen Adressen schickt.
+_ALLOWED_THUMBNAIL_HOSTS = frozenset({"i.ytimg.com", "img.youtube.com"})
 
 
 # --------------------------------------------------------------------------- #
@@ -498,20 +504,46 @@ def run_connection_test(config: WordPressConfig, app_password: str) -> tuple[boo
     return WordPressClient(config, app_password).test_connection()
 
 
+def _is_allowed_thumbnail_url(url: str) -> bool:
+    """Prüft, ob eine URL für den Beitragsbild-Download zugelassen ist (SSRF-Schutz).
+
+    Erlaubt nur ``https`` auf einem der bekannten YouTube-Thumbnail-Hosts, damit
+    der Client nicht zu beliebigen (z.B. internen) Adressen gelenkt werden kann.
+
+    Args:
+        url: Die zu prüfende URL.
+
+    Returns:
+        True, wenn Schema und Host in der Allowlist stehen.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "https"
+        and (parsed.hostname or "").lower() in _ALLOWED_THUMBNAIL_HOSTS
+    )
+
+
 def _download_thumbnail(urls: list[str]) -> Optional[bytes]:
     """Lädt das erste erreichbare Bild aus einer Fallback-Kette von URLs.
 
     YouTube liefert nicht für jedes Video ein ``maxresdefault.jpg`` (404); daher
-    wird die Liste (typisch maxres → hq → sd) der Reihe nach durchprobiert.
+    wird die Liste (typisch maxres → hq → sd) der Reihe nach durchprobiert. Aus
+    Sicherheitsgründen werden nur URLs auf der Host-Allowlist geladen (SSRF-Schutz).
 
     Args:
         urls: Bild-URLs in Prioritätsreihenfolge.
 
     Returns:
-        Die rohen Bild-Bytes oder ``None``, wenn keine URL erreichbar war.
+        Die rohen Bild-Bytes oder ``None``, wenn keine URL erreichbar/erlaubt war.
     """
     for url in urls:
         if not url:
+            continue
+        if not _is_allowed_thumbnail_url(url):
+            logger.warning("Thumbnail-URL nicht erlaubt (SSRF-Schutz): %s", url)
             continue
         try:
             resp = requests.get(url, timeout=_REQUEST_TIMEOUT)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1505,10 +1505,16 @@ class MainWindow(QMainWindow):
         suggested_title = self.video_info.title if self.video_info else ""
 
         # Beitragsbild: YouTube-Thumbnail als Fallback-Kette [maxres, hq, sd].
-        # Nur bei echtem YouTube-Video (Transkript-Modus → kein Bild).
+        # Nur bei echter YouTube-Quelle: video_info_source explizit prüfen, damit
+        # ein im Transkript-Feld eingetragener YouTube-Link NICHT versehentlich ein
+        # Beitragsbild erzeugt (Transkript-Modus → kein Bild).
         thumbnail_urls: list[str] = []
         video_id = ""
-        if self.video_info and self.video_info.url:
+        if (
+            self.video_info_source == "youtube"
+            and self.video_info
+            and self.video_info.url
+        ):
             video_id = extract_video_id(self.video_info.url) or ""
             if video_id:
                 thumb = build_thumbnail_urls(video_id)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1500,9 +1500,24 @@ class MainWindow(QMainWindow):
             return
 
         from src.gui.wordpress_dialog import WordPressSendDialog
+        from src.core.youtube_client import extract_video_id, build_thumbnail_urls
 
         suggested_title = self.video_info.title if self.video_info else ""
-        dialog = WordPressSendDialog(result, suggested_title, parent=self)
+
+        # Beitragsbild: YouTube-Thumbnail als Fallback-Kette [maxres, hq, sd].
+        # Nur bei echtem YouTube-Video (Transkript-Modus → kein Bild).
+        thumbnail_urls: list[str] = []
+        video_id = ""
+        if self.video_info and self.video_info.url:
+            video_id = extract_video_id(self.video_info.url) or ""
+            if video_id:
+                thumb = build_thumbnail_urls(video_id)
+                thumbnail_urls = [thumb["maxres"], thumb["hq"], thumb["sd"]]
+
+        dialog = WordPressSendDialog(
+            result, suggested_title,
+            thumbnail_urls=thumbnail_urls, video_id=video_id, parent=self,
+        )
         dialog.exec()
 
     def _export_comparison_markdown(self, content: str) -> None:

--- a/src/gui/wordpress_dialog.py
+++ b/src/gui/wordpress_dialog.py
@@ -253,16 +253,21 @@ class WordPressSendDialog(QDialog):
     def _on_send_result(self, result: tuple) -> None:
         """Verarbeitet das erfolgreiche Senden (Main-Thread)."""
         QApplication.restoreOverrideCursor()
-        post_id, link = result
+        # publish_post liefert (post_id, link, image_warning). image_warning ist
+        # None bei Erfolg; sonst konnte nur das Beitragsbild nicht gesetzt werden
+        # (der Beitrag selbst wurde trotzdem gepostet).
+        post_id, link, image_warning = result
         self._last_link = link
         self.btn_open.setEnabled(bool(link))
         status_word = _STATUS_LABELS.get(self._pending_status, self._pending_status)
-        self._set_status(
-            f"Gesendet ✓ (Beitrag #{post_id}, Status: {status_word}).",
-            error=False,
-        )
+        message = f"Gesendet ✓ (Beitrag #{post_id}, Status: {status_word})."
+        if image_warning:
+            message += f"\n⚠ {image_warning}"
+        self._set_status(message, error=False)
         self.btn_send.setEnabled(True)
         logger.info("WordPress-Beitrag #%s erstellt (%s)", post_id, self._pending_status)
+        if image_warning:
+            logger.warning("Beitragsbild-Hinweis: %s", image_warning)
 
     @pyqtSlot(str)
     def _on_send_failed(self, message: str) -> None:

--- a/src/gui/wordpress_dialog.py
+++ b/src/gui/wordpress_dialog.py
@@ -14,7 +14,7 @@ from PyQt6.QtCore import QUrl
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QLineEdit,
     QTextEdit, QComboBox, QPushButton, QGroupBox, QMessageBox, QWidget,
-    QApplication,
+    QApplication, QCheckBox,
 )
 
 from src.core.wordpress_client import (
@@ -42,6 +42,8 @@ class WordPressSendDialog(QDialog):
         self,
         analysis_md: str,
         suggested_title: str = "",
+        thumbnail_urls: Optional[list[str]] = None,
+        video_id: str = "",
         parent: Optional[QWidget] = None,
     ) -> None:
         """Initialisiert den Sende-Dialog.
@@ -49,6 +51,10 @@ class WordPressSendDialog(QDialog):
         Args:
             analysis_md: Die Analyse als Markdown (vorbefüllt, editierbar).
             suggested_title: Vorschlag für den Beitragstitel (z.B. Videotitel).
+            thumbnail_urls: Optionale YouTube-Thumbnail-URLs in Fallback-Reihenfolge
+                (``[maxres, hq, sd]``) für das Beitragsbild. Leer/None im
+                Transkript-Modus → keine Beitragsbild-Option.
+            video_id: Optionale Video-ID für einen sprechenden Media-Dateinamen.
             parent: Optionales Parent-Widget.
         """
         super().__init__(parent)
@@ -59,6 +65,8 @@ class WordPressSendDialog(QDialog):
         self._last_link: str = ""
         self._pending_status: str = ""
         self._send_worker: Optional[WordPressWorker] = None
+        self._thumbnail_urls: list[str] = list(thumbnail_urls or [])
+        self._video_id: str = video_id
 
         self._setup_ui(analysis_md, suggested_title)
 
@@ -169,6 +177,22 @@ class WordPressSendDialog(QDialog):
         self.tags_input.setPlaceholderText("Tag1, Tag2, … (optional)")
         grid.addRow("Tags:", self.tags_input)
 
+        # Beitragsbild (nur bei vorhandenem YouTube-Thumbnail).
+        self.featured_image_checkbox = QCheckBox(
+            "YouTube-Thumbnail als Beitragsbild verwenden"
+        )
+        has_thumbnail = bool(self._thumbnail_urls)
+        self.featured_image_checkbox.setChecked(has_thumbnail)
+        if has_thumbnail:
+            self.featured_image_checkbox.setToolTip(
+                "Lädt das Thumbnail in die Mediathek und setzt es als Beitragsbild "
+                "(featured image). Der Beitragstext bleibt unverändert."
+            )
+            grid.addRow("Beitragsbild:", self.featured_image_checkbox)
+        else:
+            # Transkript-Modus / kein Video → Option ausblenden (kein Bild, kein Fehler).
+            self.featured_image_checkbox.setVisible(False)
+
         return group
 
     @staticmethod
@@ -234,6 +258,12 @@ class WordPressSendDialog(QDialog):
         category_names = [self.category_input.text().strip()] if self.category_input.text().strip() else []
         tag_names = [t.strip() for t in self.tags_input.text().split(",") if t.strip()]
 
+        # Beitragsbild nur, wenn Checkbox aktiv UND Thumbnail vorhanden.
+        use_featured = (
+            self._thumbnail_urls and self.featured_image_checkbox.isChecked()
+        )
+        featured_image_urls = self._thumbnail_urls if use_featured else None
+
         self._pending_status = status
         self.btn_send.setEnabled(False)
         self._set_status("Sende an WordPress…", error=False)
@@ -244,6 +274,7 @@ class WordPressSendDialog(QDialog):
             publish_post,
             self._config, app_password, title, self._assembled_markdown(),
             status, category_names, tag_names,
+            featured_image_urls, self._video_id,
         )
         self._send_worker.succeeded.connect(self._on_send_result)
         self._send_worker.failed.connect(self._on_send_failed)

--- a/tests/test_wordpress_media.py
+++ b/tests/test_wordpress_media.py
@@ -1,0 +1,172 @@
+"""Tests für WordPress-Beitragsbild (featured image), gemockt – kein Netzwerk.
+
+Deckt ab: upload_media baut den Request korrekt, post() nimmt featured_media in
+den Payload, publish_post lädt das Thumbnail + reicht die media_id weiter, und
+der nicht-fatale Fehlerfall (Download/Upload scheitert) postet trotzdem den Text.
+
+Lauf (ohne pytest):  python tests/test_wordpress_media.py
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core import wordpress_client as wp
+from src.core.wordpress_client import (
+    WordPressClient, WordPressConfig, WordPressError, publish_post,
+)
+
+_CONFIG = WordPressConfig(url="https://example.test", username="user")
+
+
+def _resp(status=200, json_data=None, content=b"") -> MagicMock:
+    """Baut eine Mock-Response mit raise_for_status/json/content."""
+    r = MagicMock()
+    r.status_code = status
+    r.content = content
+    r.json.return_value = json_data if json_data is not None else {}
+    if status >= 400:
+        err = wp.requests.HTTPError(response=r)
+        r.raise_for_status.side_effect = err
+    else:
+        r.raise_for_status.return_value = None
+    return r
+
+
+def test_upload_media_builds_request() -> None:
+    """upload_media: korrekter Endpoint, Header, Body = rohe Bytes; gibt id zurück."""
+    client = WordPressClient(_CONFIG, "pw")
+    with patch.object(wp.requests, "post", return_value=_resp(json_data={"id": 42})) as mock_post:
+        media_id = client.upload_media(b"\xff\xd8jpegbytes", "somas-thumbnail-abc.jpg")
+
+    assert media_id == 42
+    _, kwargs = mock_post.call_args
+    args, _ = mock_post.call_args
+    assert args[0].endswith("/wp-json/wp/v2/media"), args[0]
+    assert kwargs["data"] == b"\xff\xd8jpegbytes"
+    headers = kwargs["headers"]
+    assert headers["Content-Disposition"] == 'attachment; filename="somas-thumbnail-abc.jpg"'
+    assert headers["Content-Type"] == "image/jpeg"
+    assert kwargs["auth"] is client._auth
+    print("  upload_media_builds_request: Endpoint/Header/Body/Auth korrekt OK")
+
+
+def test_upload_media_403_raises() -> None:
+    """upload_media: 403 (fehlende upload_files-Rechte) -> WordPressError, kein Crash."""
+    client = WordPressClient(_CONFIG, "pw")
+    with patch.object(wp.requests, "post", return_value=_resp(status=403, json_data={"message": "keine Rechte"})):
+        try:
+            client.upload_media(b"x", "f.jpg")
+        except WordPressError as exc:
+            assert "403" in str(exc)
+            print("  upload_media_403_raises: 403 -> WordPressError OK")
+            return
+    raise AssertionError("WordPressError erwartet")
+
+
+def test_post_featured_media_in_payload() -> None:
+    """post(): featured_media landet im Payload; ohne Angabe fehlt der Schlüssel."""
+    client = WordPressClient(_CONFIG, "pw")
+    with patch.object(wp.requests, "post", return_value=_resp(json_data={"id": 7, "link": "L"})) as mock_post:
+        client.post("T", "<p>x</p>", featured_media=99)
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload.get("featured_media") == 99, payload
+
+    with patch.object(wp.requests, "post", return_value=_resp(json_data={"id": 7, "link": "L"})) as mock_post:
+        client.post("T", "<p>x</p>")
+        payload = mock_post.call_args.kwargs["json"]
+        assert "featured_media" not in payload, payload
+    print("  post_featured_media_in_payload: gesetzt/weggelassen korrekt OK")
+
+
+def _patch_publish_internals(upload_side_effect=None, upload_return=99):
+    """Patcht markdown, Taxonomien, download und upload/post für publish_post."""
+    p_md = patch.object(wp, "markdown_to_html", return_value="<p>x</p>")
+    p_terms = patch.object(WordPressClient, "resolve_terms", return_value=[])
+    upload_mock = MagicMock(side_effect=upload_side_effect, return_value=upload_return)
+    p_upload = patch.object(WordPressClient, "upload_media", upload_mock)
+    post_mock = MagicMock(return_value=(5, "https://example.test/?p=5"))
+    p_post = patch.object(WordPressClient, "post", post_mock)
+    return p_md, p_terms, p_upload, p_post, upload_mock, post_mock
+
+
+def test_publish_post_sets_featured_media() -> None:
+    """publish_post: Thumbnail geladen -> upload -> post(featured_media=media_id)."""
+    p_md, p_terms, p_upload, p_post, upload_mock, post_mock = _patch_publish_internals()
+    with p_md, p_terms, p_upload, p_post, \
+            patch.object(wp.requests, "get", return_value=_resp(content=b"IMG")):
+        post_id, link, warning = publish_post(
+            _CONFIG, "pw", "Titel", "# Analyse\ntext",
+            featured_image_urls=["https://img/maxres.jpg"], video_id="abc123",
+        )
+    assert (post_id, warning) == (5, None)
+    upload_mock.assert_called_once()
+    assert upload_mock.call_args.args[0] == b"IMG"
+    assert "abc123" in upload_mock.call_args.args[1]  # Dateiname enthält video_id
+    assert post_mock.call_args.kwargs["featured_media"] == 99
+    print("  publish_post_sets_featured_media: media_id am post durchgereicht OK")
+
+
+def test_publish_post_download_fails_non_fatal() -> None:
+    """publish_post: alle Thumbnail-URLs 404 -> Beitrag ohne Bild + Warnung."""
+    p_md, p_terms, p_upload, p_post, upload_mock, post_mock = _patch_publish_internals()
+    with p_md, p_terms, p_upload, p_post, \
+            patch.object(wp.requests, "get", return_value=_resp(status=404)):
+        post_id, link, warning = publish_post(
+            _CONFIG, "pw", "Titel", "text",
+            featured_image_urls=["https://img/maxres.jpg", "https://img/hq.jpg"],
+        )
+    assert post_id == 5
+    assert warning is not None and "übersprungen" in warning
+    upload_mock.assert_not_called()
+    assert post_mock.call_args.kwargs["featured_media"] is None
+    print("  publish_post_download_fails_non_fatal: Text gepostet, Warnung gesetzt OK")
+
+
+def test_publish_post_upload_fails_non_fatal() -> None:
+    """publish_post: Upload wirft WordPressError -> Beitrag trotzdem, Warnung."""
+    err = WordPressError("Bild-Upload fehlgeschlagen (HTTP 403): keine Rechte")
+    p_md, p_terms, p_upload, p_post, upload_mock, post_mock = _patch_publish_internals(
+        upload_side_effect=err
+    )
+    with p_md, p_terms, p_upload, p_post, \
+            patch.object(wp.requests, "get", return_value=_resp(content=b"IMG")):
+        post_id, link, warning = publish_post(
+            _CONFIG, "pw", "Titel", "text",
+            featured_image_urls=["https://img/maxres.jpg"],
+        )
+    assert post_id == 5
+    assert warning is not None and "403" in warning
+    assert post_mock.call_args.kwargs["featured_media"] is None
+    print("  publish_post_upload_fails_non_fatal: Text gepostet trotz Upload-Fehler OK")
+
+
+def test_publish_post_no_thumbnail_transcript() -> None:
+    """publish_post ohne featured_image_urls (Transkript): kein Download, kein Bild."""
+    p_md, p_terms, p_upload, p_post, upload_mock, post_mock = _patch_publish_internals()
+    with p_md, p_terms, p_upload, p_post, \
+            patch.object(wp.requests, "get") as get_mock:
+        post_id, link, warning = publish_post(_CONFIG, "pw", "Titel", "text")
+    assert (post_id, warning) == (5, None)
+    get_mock.assert_not_called()
+    upload_mock.assert_not_called()
+    assert post_mock.call_args.kwargs["featured_media"] is None
+    print("  publish_post_no_thumbnail_transcript: sauber ohne Bild OK")
+
+
+def main() -> None:
+    """Führt alle WordPress-Beitragsbild-Tests aus."""
+    print("WordPress-Beitragsbild-Tests:")
+    test_upload_media_builds_request()
+    test_upload_media_403_raises()
+    test_post_featured_media_in_payload()
+    test_publish_post_sets_featured_media()
+    test_publish_post_download_fails_non_fatal()
+    test_publish_post_upload_fails_non_fatal()
+    test_publish_post_no_thumbnail_transcript()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wordpress_media.py
+++ b/tests/test_wordpress_media.py
@@ -15,9 +15,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from src.core import wordpress_client as wp
 from src.core.wordpress_client import (
     WordPressClient, WordPressConfig, WordPressError, publish_post,
+    _download_thumbnail, _is_allowed_thumbnail_url,
 )
 
 _CONFIG = WordPressConfig(url="https://example.test", username="user")
+
+# Gültige Thumbnail-URLs (Allowlist-Host i.ytimg.com).
+_MAXRES = "https://i.ytimg.com/vi/abc123/maxresdefault.jpg"
+_HQ = "https://i.ytimg.com/vi/abc123/hqdefault.jpg"
 
 
 def _resp(status=200, json_data=None, content=b"") -> MagicMock:
@@ -98,7 +103,7 @@ def test_publish_post_sets_featured_media() -> None:
             patch.object(wp.requests, "get", return_value=_resp(content=b"IMG")):
         post_id, link, warning = publish_post(
             _CONFIG, "pw", "Titel", "# Analyse\ntext",
-            featured_image_urls=["https://img/maxres.jpg"], video_id="abc123",
+            featured_image_urls=[_MAXRES], video_id="abc123",
         )
     assert (post_id, warning) == (5, None)
     upload_mock.assert_called_once()
@@ -115,7 +120,7 @@ def test_publish_post_download_fails_non_fatal() -> None:
             patch.object(wp.requests, "get", return_value=_resp(status=404)):
         post_id, link, warning = publish_post(
             _CONFIG, "pw", "Titel", "text",
-            featured_image_urls=["https://img/maxres.jpg", "https://img/hq.jpg"],
+            featured_image_urls=[_MAXRES, _HQ],
         )
     assert post_id == 5
     assert warning is not None and "übersprungen" in warning
@@ -134,7 +139,7 @@ def test_publish_post_upload_fails_non_fatal() -> None:
             patch.object(wp.requests, "get", return_value=_resp(content=b"IMG")):
         post_id, link, warning = publish_post(
             _CONFIG, "pw", "Titel", "text",
-            featured_image_urls=["https://img/maxres.jpg"],
+            featured_image_urls=[_MAXRES],
         )
     assert post_id == 5
     assert warning is not None and "403" in warning
@@ -155,6 +160,26 @@ def test_publish_post_no_thumbnail_transcript() -> None:
     print("  publish_post_no_thumbnail_transcript: sauber ohne Bild OK")
 
 
+def test_thumbnail_url_allowlist() -> None:
+    """_is_allowed_thumbnail_url: nur https auf bekannten YouTube-Hosts."""
+    assert _is_allowed_thumbnail_url(_MAXRES)
+    assert _is_allowed_thumbnail_url("https://img.youtube.com/vi/x/0.jpg")
+    # Fremder Host, internes Ziel, falsches Schema -> abgelehnt (SSRF-Schutz).
+    assert not _is_allowed_thumbnail_url("http://i.ytimg.com/vi/x/0.jpg")  # kein https
+    assert not _is_allowed_thumbnail_url("https://evil.example/x.jpg")
+    assert not _is_allowed_thumbnail_url("https://169.254.169.254/latest/meta-data")
+    print("  thumbnail_url_allowlist: nur https + YouTube-Hosts erlaubt OK")
+
+
+def test_download_thumbnail_ssrf_blocked() -> None:
+    """_download_thumbnail lädt keine URL außerhalb der Allowlist (kein requests.get)."""
+    with patch.object(wp.requests, "get") as get_mock:
+        result = _download_thumbnail(["https://169.254.169.254/x.jpg", "http://evil/x"])
+    assert result is None
+    get_mock.assert_not_called()
+    print("  download_thumbnail_ssrf_blocked: fremde/interne URL nicht geladen OK")
+
+
 def main() -> None:
     """Führt alle WordPress-Beitragsbild-Tests aus."""
     print("WordPress-Beitragsbild-Tests:")
@@ -165,6 +190,8 @@ def main() -> None:
     test_publish_post_download_fails_non_fatal()
     test_publish_post_upload_fails_non_fatal()
     test_publish_post_no_thumbnail_transcript()
+    test_thumbnail_url_allowlist()
+    test_download_thumbnail_ssrf_blocked()
     print("ALLE TESTS OK")
 
 


### PR DESCRIPTION
Kleiner, abgegrenzter Zuwachs auf der bestehenden WordPress-Anbindung (#43): Das YouTube-Thumbnail des analysierten Videos wird in die WP-Mediathek hochgeladen und als **echtes Beitragsbild** (`featured_media`) gesetzt — nicht inline. PO-Entscheidung: featured image.

Spec: `specs/STARTPROMPT_WordPress-Thumbnail-Beitragsbild_fuer_Kurt.md`.

## Änderungen
- **PR 1** — `WordPressClient.upload_media(image_bytes, filename, mime)` (POST `/media`, `Content-Disposition`-Header, rohe Bytes → Media-ID; Fehler analog `post()`, inkl. 401/403 = fehlende `upload_files`-Rechte). `post(..., featured_media=…)` in den Payload.
- **PR 2** — `publish_post(featured_image_urls=[maxres,hq,sd], video_id=…)`: lädt das erste erreichbare Bild über die Fallback-Kette (nicht jedes Video hat `maxresdefault.jpg` → 404), lädt es hoch und setzt es als Beitragsbild. **Nicht fatal:** scheitert Laden/Upload, wird der Text trotzdem gepostet. Rückgabe jetzt `(post_id, link, image_warning)`; die Warnung erscheint im Dialog als „⚠ …".
- **PR 3** — Thumbnail-URLs + `video_id` aus `video_info` bis zum Dialog durchgereicht; Checkbox „YouTube-Thumbnail als Beitragsbild verwenden" (aktiv bei Video, ausgeblendet im Transkript-Modus). Body-Inhalt unverändert.

## Tests
`tests/test_wordpress_media.py` (7, gemockt): Request-Aufbau von `upload_media` (Endpoint/Header/Body/Auth) + 403→`WordPressError`; `featured_media` im `post()`-Payload; `publish_post` reicht `media_id` weiter; nicht-fatale Fälle (Download 404, Upload-Fehler, Transkript ohne URLs) posten trotzdem den Text. Bestehende Suiten grün.

## Abnahme
PO-Sendetest bestätigt: Beitragsbild erscheint (das Rätsel war nur die Editor-Vorschau). Khamenei-Testvideo profitierte von der hq/sd-Fallback-Kette (maxres 404).

## Doku & Version
WordPress-Anbindung war bislang undokumentiert → CLAUDE.md **Phase 14** + README-Feature-Abschnitt (inkl. Application-Password-/`upload_files`-/Wordfence-Voraussetzung). **APP_VERSION → 0.12.0** (neues nutzer-sichtbares Feature = Minor-Bump; nur dieser PR fasst die Version an, die parallele Anthropic-Modellpflege zieht als 0.12.1 nach).

## Backlog (v1-Einschränkung, akzeptiert)
Wiederholtes Senden lädt das Bild erneut hoch (mögliche Media-Dubletten). Dedup später. Video-Embed statt/zusätzlich zum Thumbnail ebenfalls notiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Beim Veröffentlichen können automatisch Beitragsbilder gesetzt werden – inkl. optionalem YouTube-Thumbnail-Fallback (mehrere Qualitätsstufen).
  * Der Sende-Dialog bietet eine Checkbox „YouTube-Thumbnail als Beitragsbild verwenden“, wenn entsprechende Thumbnail-URLs verfügbar sind.
* **Bug Fixes**
  * Fehler beim Laden oder Upload des Beitragsbilds blockieren das Posten nicht mehr.
  * Stattdessen wird eine Warnmeldung angezeigt (z. B. bei übersprungenen/fehlgeschlagenen Bildschritten).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->