### PR TITLE
chore: Faktencheck-Theorie/Specs versionieren + notizen/ ignorieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ examples/
 # Local archive for old/unused files
 Archiv/
 
+# Zwischennotizen bleiben lokal (PO-Entscheidung 2026-07-12)
+notizen/
+
 # Local launcher (machine-specific, not for GitHub)
 start.bat
 

--- a/specs/FAKTENCHECK_THEORIE.md
+++ b/specs/FAKTENCHECK_THEORIE.md
@@ -1,0 +1,343 @@
+# Faktencheck: Theorie & Methodik
+
+**Version:** 0.1 · **Stand:** 2026-07-12 · **Status:** LEBENDES DOKUMENT
+
+> Referenzdokument für alle Faktencheck-Entscheidungen im SOMAS Prompt Generator.
+> Die Theoriepflege (Begriffsarbeit, Prüflogik, Diskursmethodik) lebt als Nebenstrang
+> im Schwesterprojekt Abbild-Werkstatt; das jeweils aktuelle Destillat wird hier
+> versioniert abgelegt. Implementierungs-Specs (v0.10.x, v0.13.x, …) richten sich an
+> diesem Dokument aus — bei Widerspruch gilt: Theorie hier klären, DANN Spec ändern.
+>
+> Hauptquellen v0.1: Perplexity-Erörterung 2026-07-11
+> (`notizen/Faktencheck-Eroerterung_Perplexity_2026-07-11md.md`, mit AFC-Literatur),
+> Merkzettel D1–D10 (`specs/MERKZETTEL_v0.10.1_offene_punkte.md`), Realtest-Empirie
+> der App (Stand v0.12.1).
+
+---
+
+## 1. Einordnung: Automated Fact-Checking (AFC)
+
+Die Forschungsstandard-Pipeline des Automated Fact-Checking lautet:
+
+```text
+Claim Detection → Check-worthiness → Evidence Retrieval → Claim Verification
+                                                          (Verdict + Justification)
+```
+
+SOMAS erweitert dieses Modell um eine **vorgelagerte Diskursanalyse** (Framing,
+Kernthese, Elaboration, Implikation, Subtext). Das Sechs-Ebenen-Modell:
+
+| Ebene | Aufgabe | AFC-Entsprechung |
+| ----- | ------- | ---------------- |
+| 1 | SOMAS-Zerlegung (Diskurs-/Framing-Analyse) | vorgelagert, kein AFC-Standard |
+| 2 | Extraktion & Kategorisierung: Meinung / Interpretation / Behauptung | Claim Detection & Extraction |
+| 3 | Sortierung der überprüfbaren Behauptungen nach definierter Policy | Check-worthiness Detection |
+| 4 | Rechercheaufträge je Behauptung erstellen | Query Planning |
+| 5 | Online-Recherche, Evidenz sammeln | Evidence Retrieval, Claim Matching |
+| 6 | Verdikt anhand der Evidenz, mit Begründung | Verdict Prediction + Justification |
+
+**Grundsatz-Invariante:** Die Diskursanalyse (Ebene 1) erklärt, *warum* ein Claim
+relevant oder potenziell irreführend ist — sie darf aber **niemals das Verdikt
+beeinflussen**. Aus vermutetem Framing folgt keine Unwahrheit einer Behauptung.
+
+Realistische Selbstbeschreibung: Das System ist ein **AI-assisted Evidence
+Assessment**, kein vollautomatischer Wahrheitsentscheid. Claim-Auswahl,
+Evidenzgewinnung und Begründung sind getrennte, je fehleranfällige Aufgaben.
+
+---
+
+## 2. Claim-Lehre
+
+### 2.1 Claim-Typen
+
+Mindestens sechs Klassen — verhindert, dass Nicht-Prüfbares ein Tatsachenverdikt bekommt:
+
+| Typ | Beispiel | Prüfmodus |
+| --- | -------- | --------- |
+| Harte Tatsachenbehauptung | „Die Inflation lag 2025 bei 3 %." | direkt verifizierbar |
+| Quantitative Behauptung | „Die Kriminalität hat sich verdoppelt." | Daten, Zeitraum, Bezugsgröße |
+| Kausale Behauptung | „Maßnahme X verursachte Y." | Kausalevidenz, Alternativerklärungen |
+| Prognose | „Das führt nächstes Jahr zu Rezession." | nicht wahr/falsch; Plausibilität/Quellenlage |
+| Interpretation | „Das ist ein politischer Erfolg." | kein Tatsachenverdikt |
+| Meinung / Werturteil | „Das ist unverantwortlich." | ausweisen, nicht prüfen |
+
+### 2.2 Atomisierung
+
+Jeder Claim mit mehreren Teilbehauptungen wird in **atomare Prüfeinheiten** zerlegt.
+Referenzbeispiel (IRGC-Realtest): „Kosten laut zitierter Analyse 54–120 Mrd. €/Jahr,
+genannte Schätzung ~100 Mrd." enthält mindestens vier Prüfeinheiten:
+
+1. *Quellenexistenz* — es gibt eine identifizierbare Analyse mit dieser Schätzung.
+2. *Methodik* — die Methode trägt eine jährliche Gesamtschätzung für Europa.
+3. *Quantität* — die Analyse nennt ~100 Mrd. €/Jahr.
+4. *Kausalzurechnung* — die Kosten sind der IRGC ursächlich zurechenbar.
+
+Ohne Atomisierung entstehen unauflösbare „teilweise bestätigt"-Verdikte, weil
+belegte und unbelegte Teile im selben Claim verschmelzen.
+
+### 2.3 Attribution vs. Objekt-Claim
+
+Strikt trennen:
+
+- **Attributions-Claim:** „Organisation A erklärte, X sei geschehen." → prüfbar über
+  Existenz des Originalstatements.
+- **Objekt-Claim:** „X ist geschehen." → braucht unabhängige Belege.
+
+Ein bestätigter Attributions-Claim darf beim Leser nie wie eine Bestätigung des
+Sachverhalts wirken (eigenes Verdikt: „Aussage belegt, Sachverhalt offen").
+
+### 2.4 Claim-Klassen (Arbeitsklassen für die Priorisierung)
+
+| Klasse | Bedeutung | Behandlung |
+| ------ | --------- | ---------- |
+| A: Kernclaim | trägt die Hauptthese | immer Deep Research, Primärquellen + Gegenrecherche |
+| B: Tragender Subclaim | sichert zentrale Schlussfolgerung | Deep Research |
+| C: Kontextclaim | Hintergrund/Einordnung | nur bei freier Kapazität |
+| D: Basis-/Metadatenclaim | Allgemeinwissen, Biografie, Lexikonfakt | kein Deep Research; allenfalls Schnellprüfung |
+
+Klassifizierung erfolgt **vor** jeder numerischen Priorisierung — sonst überholt ein
+leicht prüfbarer D-Claim einen A-Claim.
+
+### 2.5 Argumentgewicht
+
+Leitfrage pro Claim (kontrafaktischer Test):
+
+> Welche Schlussfolgerung des Ausgangstexts würde geschwächt, verändert oder
+> unhaltbar, wenn dieser Claim falsch wäre?
+
+Ergebnis ist ein kleiner Argument-Abhängigkeitsgraph (Kernthese ← tragende
+Subclaims ← Kontext/Beispiele). Ein wahres, aber nicht tragendes Beispiel (z. B.
+Einzelbeschlagnahmung) belegt keine quantitative Kernthese — das Verdikt muss die
+geringe Tragweite ausweisen können.
+
+---
+
+## 3. Kernprinzip: prüfbar ≠ prüfwürdig
+
+**Die zentrale Fehlerquelle beobachteter Fehlallokation:** Ein Priorisierer, der
+faktische *Prüfbarkeit* mit *Recherchewürdigkeit* verwechselt, verschwendet
+Recherchebudget auf Selbstverständliches, während erkenntnisträchtige Claims
+unten aus der Liste fallen.
+
+Drei empirisch belegte Fehlmodi (Realtests der App, 07/2026):
+
+1. **Prüfbar ist nicht prüfwürdig:** „Das ZDF ist öffentlich-rechtlich" ist perfekt
+   prüfbar, aber ohne Erkenntnisgewinn.
+2. **Hintergrund verdrängt die tragende These:** korrekte historische Basissätze
+   fressen die Recherche-Slots des eigentlichen Prüfgegenstands (z. B. Wortlaut und
+   Rechtsstatus eines behaupteten aktuellen Abkommens).
+3. **Attribution wird mit Tatsachenbehauptung verwechselt** (siehe 2.3).
+
+---
+
+## 4. Priorisierung: Policy statt Bauchgefühl
+
+### 4.1 Zwei getrennte Scores
+
+Relevanz wird nicht als ein diffuser Wert, sondern als Produkt getrennter
+Dimensionen bestimmt:
+
+```text
+ResearchPriority = ClaimImportance × ResearchValue × Checkability
+```
+
+**ClaimImportance** („Würde sich die Kernaussage ändern, wenn der Claim falsch
+wäre?"): These-Nähe, Schlussfolgerungsabhängigkeit, Schadenspotenzial,
+Reichweite/Mobilisierung, Konkretheit.
+
+**ResearchValue** („Lohnt knappe KI-Recherchekapazität genau hierfür?"):
+Nicht-Trivialität, Neuheit/Aktualität, Streitigkeit, Quellenzugang, Evidenzlücke,
+Diskrepanzpotenzial (überraschend präzise/große Zahlen sind besonders fehleranfällig).
+
+Ein Claim kommt nur in die Deep-Research-Auswahl, wenn er in **beiden** Dimensionen
+ausreichend hoch liegt.
+
+### 4.2 Harte Gates (vor jedem Scoring)
+
+```text
+Gate 1: Externe Tatsachen-/Zahlen-/Kausal-/Dokumentbehauptung?
+        Nein → Meinung/Deutung markieren, nicht recherchieren
+Gate 2: Relevant für Kernthese, tragende Argumentation oder Schadenspotenzial?
+        Nein → Kontextclaim, nur dokumentieren
+Gate 3: Trivial bzw. mit einer kanonischen Quelle auflösbar?
+        Ja → Basisfakt/Schnellprüfung, kein Deep-Research-Slot
+Gate 4: Attributionsbehauptung?
+        Ja → Attributions- und Objekt-Claim getrennt ausgeben
+Gate 5: Zu vage?
+        Ja → operationalisieren oder als „nicht ausreichend präzise" ausweisen
+```
+
+### 4.3 Quoten statt reiner Top-X
+
+Eine reine Top-X-Liste kann von 30 leichten Randdetails geflutet werden.
+Budgetrichtwerte:
+
+- 50–60 % Kernclaims der Hauptthese
+- 20–30 % tragende Subclaims und Kausalbrücken
+- 10–20 % Gegenhypothesen, relevante Auslassungen, Kontext
+- ≤ 10 % Basis-/Plausibilitätschecks
+- 0 % Off-Topic-Claims (separate Nachrichtensegmente ggf. als eigener Abschnitt
+  mit eigenem Budget)
+
+### 4.4 Policy als Code
+
+Gewichte, Quoten, Ausschlüsse und Schwellen wählt **nicht das Modell**, sondern eine
+versionierte, deterministische Konfiguration (z. B. `relevance_policy_v1.json`).
+Jede Auswahl ist auditierbar: Score-Komponenten + Policy-Version + Begründung werden
+mit ausgegeben. So lässt sich die Auswahlpolitik ändern, ohne die Pipeline umzubauen.
+
+---
+
+## 5. Recherche
+
+### 5.1 Rechercheauftrag pro Claim (nicht „Ist das wahr?")
+
+Offene Wahrheitsfragen erzeugen Bestätigungsfehler; ein Claim-Blob als Such-Seed
+findet bei Nischenthemen nichts Relevantes (empirisch: Sonar-Totalausfall beim
+„OpenRouter Fusion"-Test). Stattdessen bekommt jeder ausgewählte Claim eine
+**Recherchekarte**: normalisierte Entitäten, Zeitraum, Claim-Typ, konkrete
+Recherchefragen, **Gegenhypothesen**, bevorzugte Quellenklassen, verbotene
+Abkürzungen (Snippet als Beleg, unbelegte Sekundärquelle als alleinige Evidenz),
+geforderte Evidenzarten (Methode, Abgrenzung, Zurechnung, unabhängige Bestätigung).
+
+### 5.2 Quellenhierarchie
+
+1. Primärquellen (Gesetze, amtliche Statistik, Gerichtsentscheidungen, Originalstudien)
+2. Fachinstitutionen (Institute, Metaanalysen, internationale Organisationen)
+3. Qualitätsjournalismus mit transparenter Primärquellenbasis
+4. Vorhandene Faktenchecks als Recherchehinweis, nicht als alleiniger Beweis
+5. Sekundärmaterial, Social Media, Such-Snippets nur zur Hypothesenbildung
+
+Optionaler vorgelagerter Schritt: Claim-Matching gegen bereits publizierte
+Faktenchecks (Google Fact Check Tools API / ClaimReview).
+
+### 5.3 Zeit- und Scope-Logik
+
+Eine Quelle kann korrekt sein und trotzdem nicht passen: Akteur, Metrik, Geografie
+und Zeitraum müssen einzeln abgeglichen werden (`scope_match`). Eine zufällig
+ähnliche Zahl mit anderem Zeitraum/anderer Messgröße ist **kein** Teilbeleg.
+
+---
+
+## 6. Evidenz und Verdikt
+
+### 6.1 Evidenzobjekte statt Quellenliste
+
+Jede Quelle wird in eine explizite Claim-Evidenz-Beziehung übersetzt: URL, Publisher,
+Datum, Abrufzeitpunkt, Quellen-Tier, relevanter Auszug, Haltung
+(`supports | refutes | contextualizes | insufficient`), `scope_match`, Limitationen.
+Keine Zitate ohne Fundstelle.
+
+### 6.2 Trennung von Evidenz und Urteil (Zielbild)
+
+> Der Verdikt-Schritt erhält keinen offenen Webzugang. Er urteilt ausschließlich
+> über Claim + gespeichertes Evidenzpaket.
+
+Das verhindert, dass der finale Prüfer unprotokollierte Behauptungen oder
+Modellwissen in den Bericht zieht. (SOMAS-Ist v0.12.1: Recherche und Verdikt noch
+in einem Call — bewusste Übergangslösung.)
+
+### 6.3 Verdikt-Taxonomie
+
+Intern differenziert, im UI auf kompakte Hauptverdikte gemappt (mit Begründungszeile):
+
+| Intern | UI-Label | Wann |
+| ------ | -------- | ---- |
+| `supported` | Bestätigt | alle wesentlichen Teilbedingungen gestützt |
+| `partially_supported` | Teilweise bestätigt | **genau benannter** Teilclaim gestützt |
+| `unsupported` | Unbelegt | keine ausreichende belastbare Evidenz |
+| `contradicted` | Widerlegt | Evidenz widerspricht der Kernbehauptung |
+| `under_specified` | Zu unpräzise prüfbar | Akteur/Zeitraum/Metrik/Begriff unbestimmt |
+| `attribution_only` | Aussage belegt, Sachverhalt offen | nur das Statement ist nachweisbar |
+| `methodologically_unfounded` | Methodisch nicht herleitbar | präzise Zahl/Kausalität ohne tragfähige Methode |
+| `mixed_evidence` | Widersprüchliche Quellenlage | relevante Quellen widersprechen einander |
+
+**Leitplanken:**
+
+- Kein positives Teilverdikt ohne explizit ausgewiesenen, belegten Teilclaim samt Quelle.
+- „Nicht überprüfbar" ist eine technische Ausnahme (Quelle unzugänglich, Akteur nicht
+  identifizierbar, nicht operationalisierbar) — kein Sammelbecken.
+- Unabhängigkeits-Riegel: das geprüfte Material selbst zählt nie als Beleg
+  (in SOMAS seit v0.10.1, real bewährt).
+- Jede Behauptung wird unabhängig geprüft; kein Verdikt wird aus einem anderen abgeleitet.
+
+### 6.4 Ausgabe-Anatomie
+
+Vollständiges Verdikt enthält: Originalclaim + Fundstelle, normalisierte Fassung,
+Verdikt + Konfidenz + Begründung, Pro-/Kontra-/Kontext-Evidenz, offene
+Unsicherheiten, Policy-Version.
+
+---
+
+## 7. Empirische Befunde SOMAS (Stand 07/2026)
+
+- **Such-Seed ist der größte Hebel (D6a):** Behauptungs-Blob als ein Request führt zu
+  thematisch fremden Quellen und pauschalem „nicht überprüfbar"; Recherche pro Claim
+  mit gezieltem Auftrag behebt das strukturell.
+- **Modellwahl ist themenabhängig:** gut indexierte Allgemeinfakten → Perplexity
+  Sonar Pro; frische/Nischen-Themen → agentischer Web-Searcher (z. B. Opus via
+  OpenRouter). `sonar-reasoning-pro` fürs Belegen schwach.
+- **Perplexity-Tiefe konfigurieren:** ohne `web_search_options.search_context_size:
+  "high"` sucht Sonar auf Default „low" — wesentliche Ursache oberflächlicher Läufe.
+- **confident ≠ correct:** auch beste agentische Modelle irren selbstbewusst bei
+  Zahlen-/Vergleichsclaims → menschlicher Spot-Check gegen Primärquellen bleibt Teil
+  der Methodik (Human-in-the-Loop).
+- **Token-Budget ist Prüfqualität:** geteilte Budgets (Analyse+Faktencheck bzw. alle
+  Claims in einem Call) schneiden lange Listen ab; Reasoning-Modelle können das
+  Budget vollständig intern verbrauchen (`finish_reason`-Gate nötig).
+- **Websuche ≠ Research:** Single-Pass-Retrieval (`sonar`, `:online`) vs. iterativer
+  agentischer Loop (`sonar-deep-research`); Research ⊃ Websuche.
+
+---
+
+## 8. Umsetzungsleitplanken für SOMAS
+
+1. **Parallel statt Umbau:** Der bestehende zweistufige Faktencheck (v0.10.x) bleibt
+   als Basis-Strategie erhalten. Neue Wege docken als zusätzliche, per UI wählbare
+   Strategie an (Strategie-Abstraktion). Alte Wege werden erst nach bewährtem
+   Parallelbetrieb zurückgebaut.
+2. **Kern als eigenständiges Modul** (Arbeitstitel `factcheck_core`), von SOMAS
+   in-process importiert — nach dem bewährten Muster `youtube-intake-service`.
+   Keine Server-/n8n-Infrastruktur als Voraussetzung; n8n-Tauglichkeit bleibt als
+   Option erhalten, weil die Stufen über JSON-Verträge kommunizieren.
+3. **State Machine, kein Agentenschwarm:** deterministische Stufenfolge mit
+   validierten JSON-Übergaben (Schema-Validierung außerhalb des LLM, Retry mit
+   Reparaturprompt, dann Eskalation). Agentische Freiheit nur eng begrenzt im
+   Recherche-Schritt.
+4. **Nicht dem Modell überlassen:** Relevanzgewichtung, zulässige Quellenklassen,
+   Verdikt-Taxonomie, Auswahl-Quoten — alles Policy/Code.
+5. **Stufen (Zielbild):** Claim Refiner → Argument Mapper → Triage (deterministisch)
+   → Research Planner → Research Worker → Evidence Critic → Verifier; jede Stufe hat
+   definierte Nicht-Zuständigkeiten (z. B. Refiner entscheidet nicht über Relevanz
+   oder Wahrheit).
+6. **MVP-Reihenfolge:** Refiner + Mapper + PolicyScorer + Planner zuerst; der
+   vorhandene Verifikations-Call wird zunächst weiterverwendet — nur für die
+   selektierten, verfeinerten Claims (je Claim eigener Call = eigenes Token-Budget).
+   Evidenzobjekte, Critic und getrennter Verdict-Writer folgen danach.
+7. **Transparenz im UI:** Nach dem Lauf ausweisen, wie viele Claims extrahiert,
+   deep-recherchiert, schnellgeprüft, dokumentiert oder als Meinung markiert wurden —
+   samt Policy-Version. Die App hat nichts „vergessen", sie hat nach Regeln priorisiert.
+8. **Regressionstest-Korpus:** manuell geprüfte Texte mit erwarteten Claim-/
+   Verdict-Strukturen als Dauertest gegen Qualitätsdrift.
+
+---
+
+## 9. Quellen
+
+- Perplexity-Erörterung 2026-07-11 (GPT-5.6 Terra Thinking), inkl. Analyse von vier
+  realen SOMAS-Faktenchecks: `notizen/Faktencheck-Eroerterung_Perplexity_2026-07-11md.md`
+- Guo et al.: *A Survey on Automated Fact-Checking* (TACL 2022) · AFC-Survey arxiv 2108.11896
+- ClaimBuster (Hassan et al., KDD 2017) — Check-worthiness als eigenes Problem
+- Full Fact AI — Praxis: Automatisierung von Auffinden/Priorisieren, nicht des Wahrheitsentscheids
+- IFCN Code of Principles — Transparenz von Methode, Quellen, Korrekturen
+- Google Fact Check Tools API / ClaimReview — Claim-Matching gegen publizierte Checks
+- SOMAS-Specs: `SOMAS_v0.10.0_SPEC_faktencheck_verifikation.md`,
+  `MERKZETTEL_v0.10.1_offene_punkte.md` (D1–D10), `SOMAS_v0.11.0_SPEC_reasoning_leak_haertung.md`
+
+---
+
+## Änderungshistorie
+
+| Version | Datum | Änderung |
+| ------- | ----- | -------- |
+| 0.1 | 2026-07-12 | Erstfassung aus Perplexity-Erörterung 2026-07-11 + D-Merkzettel + App-Empirie (Hauptchat) |

--- a/specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md
+++ b/specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md
@@ -1,0 +1,196 @@
+# SOMAS v0.13.0 — Faktencheck Plus (argumentgewichtete Recherche)
+
+**Status:** ENTWURF · PO-Fragen entschieden (§8) · **Stand:** 2026-07-12
+**Grundlage:** `specs/FAKTENCHECK_THEORIE.md` v0.1 (maßgeblich, insb. §4, §6, §8)
+**Rollen:** Architekt = Claude.ai (dieser Chat) · Umsetzung = Kurt (Claude Code) · PO = Thorsten
+
+---
+
+## 1. Ziel
+
+Ein zweiter, per Checkbox wählbarer Faktencheck-Weg, der die empirisch belegten
+Fehlallokationen des bestehenden Wegs behebt (prüfbar ≠ prüfwürdig; Claim-Blob als
+Such-Seed; unauflösbare „teilweise bestätigt"-Verdikte). Der bestehende zweistufige
+Faktencheck (v0.10.x) bleibt **unverändert** als Basis-Strategie erhalten —
+Parallel-Präzedenzfall gemäß Theorie §8.1.
+
+**Nicht-Ziele (v0.13.0):** Evidenzobjekte, Evidence Critic, getrennter
+Verdict-Writer ohne Webzugang, ClaimReview-Matching, Policy-Profile-Auswahl im UI,
+n8n-Anbindung, Auslagerung als Submodul. Alles spätere Ausbaustufen.
+
+## 2. Architektur-Entscheidungen
+
+1. **Strategie-Abstraktion:** Neues Interface (z. B. `VerificationStrategy`) mit
+   zwei Implementierungen: `ClassicVerification` (bestehender Ein-Call-Weg,
+   Verhalten bitgenau unverändert) und `PlusVerification` (neu). Auswahl über
+   GUI-Checkbox; Persistenz in `user_preferences.json` (`use_factcheck_plus`,
+   Default AUS — analog `use_intake_core`).
+2. **Paketstruktur:** Neues Subpackage `src/core/factcheck_plus/` — **ohne
+   Qt-Imports**, Kommunikation zwischen Stufen ausschließlich über validierte
+   JSON-/Dataclass-Verträge. Damit später als eigenständiges `factcheck_core`
+   extrahierbar (Intake-Muster), aber v0.13.0 bewusst in-repo (kein
+   Submodul-Overhead).
+3. **State Machine, kein Agent:** Feste Stufenfolge, jede Stufe hat definierte
+   Nicht-Zuständigkeiten (Theorie §8.5). LLM-Stufen liefern JSON; Validierung in
+   Python (nicht im LLM); bei Schema-Fehler 1× Retry mit Reparaturprompt, dann
+   offener Fehler (kein Schein-Ergebnis — Linie von v0.11.0 fortgesetzt).
+4. **Modelle:** MVP nutzt den vorhandenen Verifikationsmodell-Picker für die
+   Recherche-Calls. Refiner/Mapper/Planner laufen über das Analyse-Modell
+   (vorhandene Client-Factory `create_client()`); separate Modellwahl pro Stufe ist
+   spätere Ausbaustufe (wartet u. a. auf Model-Finder-Resultate).
+
+## 3. Pipeline (MVP)
+
+```text
+Bestehende SOMAS-Analyse mit erzwungenem FAKTENCHECK (unverändert)
+  └─ extract_claims_from_faktencheck (vorhanden)
+       │  [Checkbox AUS] → ClassicVerification (wie bisher)
+       │  [Checkbox AN]  → PlusVerification:
+       ├─ S1 ClaimRefiner        (LLM, 1 Call)
+       ├─ S2 ArgumentMapper      (LLM, 1 Call)
+       ├─ S3 PolicyScorer        (reiner Python-Code, deterministisch)
+       ├─ S4 ResearchPlanner     (LLM, 1 Call für alle selektierten Claims)
+       └─ S5 Recherche+Verdikt   (LLM, 1 Call PRO selektiertem Claim, Web-Modell)
+            └─ Aggregation → Markdown-Abschnitt + Transparenz-Block
+```
+
+### S1 — ClaimRefiner (LLM → JSON)
+
+Input: extrahierte Behauptungen + SOMAS-Kernthese/Framing (nur als Kontext) +
+Video-Metadaten. Aufgabe: Atomisierung (ein Claim = eine Prüfeinheit), Trennung
+Attribution/Objekt-Claim (Theorie §2.2/§2.3), Normalisierung (Entitäten, Zeitraum,
+Metrik), Claim-Typ (Theorie §2.1). **Darf nicht:** Relevanz oder Wahrheit bewerten.
+
+Output je Claim (Dataclass `RefinedClaim`):
+```json
+{
+  "claim_id": "c01a", "parent_id": "c01",
+  "original_text": "…", "normalized_claim": "…",
+  "claim_type": "quantitative | causal | hard_fact | prognosis | source_attribution | methodological",
+  "entities": ["…"], "timeframe": "… | null", "metric": "… | null"
+}
+```
+
+### S2 — ArgumentMapper (LLM → JSON)
+
+Input: RefinedClaims + SOMAS-Kernthese. Aufgabe: Argumentrolle + kontrafaktischer
+Impact + Komponenten-Ratings (0–5) für die Policy-Dimensionen aus Theorie §4.1
+(These-Nähe, Schlussfolgerungsabhängigkeit, Schadenspotenzial, Konkretheit;
+Nicht-Trivialität, Aktualität, Streitigkeit, Quellenzugang, Evidenzlücke,
+Diskrepanzpotenzial). **Darf nicht:** auswählen oder gewichten — nur Felder füllen.
+
+Output je Claim (`ArgumentMapping`): `argument_role`
+(`core_claim | supporting_premise | context | example | metadata`),
+`counterfactual_impact` (`high|medium|low`), `ratings: {…}`, `reason`.
+
+### S3 — PolicyScorer (Python, deterministisch — KEIN LLM)
+
+Neue Konfigurationsdatei `src/config/relevance_policy_v1.json`: Gewichte, Gates,
+Quoten, Budget. Der Scorer implementiert:
+
+- **Gates 1–5** (Theorie §4.2): Meinung/Deutung raus, Kontext markieren, Trivial →
+  `skip_or_fast_verify`, Attribution splitten (kommt gesplittet aus S1), Vage →
+  `under_specified`.
+- **Scores:** `ClaimImportance × ResearchValue × Checkability` aus den
+  S2-Ratings und Policy-Gewichten.
+- **Quotenauswahl** (Theorie §4.3) statt reiner Top-N: erst `core_claims`, dann
+  tragende Subclaims, max. 1–2 Kontextclaims; Budget aus GUI
+  (Default 8, SpinBox, ersetzt im Plus-Modus das bisherige Max-Behauptungen-Limit).
+- **Audit-Output:** je Claim Score-Komponenten + Policy-Version + Auswahlgrund
+  (wird im Transparenz-Block ausgegeben).
+
+→ Vollständig offline testbar; Kern der Regressionstests.
+
+### S4 — ResearchPlanner (LLM → JSON)
+
+Für die ≤ Budget selektierten Claims **eine** Recherchekarte je Claim
+(Theorie §5.1): konkrete Recherchefragen, **Gegenhypothesen**, Quellenprioritäten
+(Hierarchie §5.2), geforderte Evidenzarten, verbotene Abkürzungen. Ein Call für
+alle selektierten Claims (JSON-Array).
+
+### S5 — Recherche + Verdikt (pro Claim ein Call)
+
+Erweiterung des bestehenden Verifikationswegs — **das ist D6a**:
+
+- Ein `send_prompt` **pro Claim** mit dessen Recherchekarte (eigenes Token-Budget
+  je Claim; absorbiert die Backlog-„Zweiteilung").
+- Prompt übernimmt die bestehenden Riegel unverändert: Unabhängigkeits-Riegel,
+  keine erfundenen URLs, `source_hint`-Sanitisierung.
+- **Verdikt:** intern 8-stufig (Theorie §6.3), im Output auf die bestehenden
+  4 UI-Verdikte gemappt + verpflichtende Begründungszeile mit dem internen Grund
+  (z. B. „Teilweise bestätigt — belegter Teilclaim: …" / „Nicht überprüfbar —
+  methodisch nicht herleitbar"). Leitplanke: kein positives Teilverdikt ohne
+  benannten belegten Teilclaim samt Quelle.
+- Scope-Check im Prompt: Akteur/Metrik/Geografie/Zeitraum müssen zur Quelle passen;
+  „ähnliche Zahl, anderer Scope" ist kein Teilbeleg.
+- Fehler eines einzelnen Claim-Calls sind **nicht fatal** (Claim erhält
+  „Prüfung fehlgeschlagen"-Vermerk, Rest läuft weiter); Abbrechen-Button bricht
+  zwischen Claims ab.
+
+### Aggregation & Transparenz-Block
+
+Neues Template `templates/somas_verification_plus.txt` (Jinja2, deterministisch):
+Verdikt-Abschnitt je geprüftem Claim + abschließender Transparenz-Block
+(Theorie §8.7):
+
+```text
+N Behauptungen extrahiert → M atomisiert
+- X deep-recherchiert · Y Schnellprüfung übersprungen (Basisfakten)
+- Z als Kontext dokumentiert, nicht recherchiert
+Policy: relevance_policy_v1 · Budget: 8
+```
+
+## 4. GUI
+
+- Checkbox in der Faktencheck-Sektion: **„Faktencheck Plus (argumentgewichtete
+  Recherche)"**, Tooltip: „Prüft vorrangig zentrale, strittige und folgenreiche
+  Behauptungen. Überspringt Basisfakten und dokumentiert die Auswahlkriterien."
+- Sichtbar/aktiv nur bei aktivierter Verifikation; im Plus-Modus steuert die
+  vorhandene SpinBox das Deep-Research-Budget (Label wechselt entsprechend).
+- Fortschrittsanzeige je Stufe („Verfeinere Behauptungen …", „Recherchiere
+  Claim 3/8 …"); Ausschluss mit Modellvergleich wie beim Classic-Weg.
+- Kostenhinweis im Tooltip: Plus-Modus macht 3 + N Calls statt 1.
+
+## 5. Worker & Persistenz
+
+Neuer `FactcheckPlusWorker` (QThread) orchestriert S1–S5 (Signale: Stufe,
+Claim-Fortschritt, Fehler, Ergebnis). Race-Schutz analog bestehendem
+Verifikations-Worker (Quelle während Lauf gesperrt). Debug-Logger persistiert je
+Stufe Request/Response + `finish_reason` (bestehende Infrastruktur).
+
+## 6. Tests
+
+- **Fixtures:** IRGC-Fall als Referenz (aus `notizen/Faktencheck-Eroerterung…`):
+  Roh-Claims → erwartete Atomisierung (4 Prüfeinheiten), erwartete Klassen.
+- `tests/test_claim_refiner_contract.py`: Schema-Validierung, Attribution-Split,
+  Reparatur-Retry-Pfad (gemockt).
+- `tests/test_policy_scorer.py`: Gates, Quoten, Determinismus (gleicher Input =
+  gleiche Auswahl), Basisfakt-Verdrängungs-Regression („ZDF ist
+  öffentlich-rechtlich" darf nie einen core_claim verdrängen).
+- `tests/test_verdict_mapping.py`: 8→4-Mapping vollständig + Begründungszeile Pflicht.
+- Bestehende Tests bleiben grün (Classic-Weg unverändert).
+
+## 7. PR-Schnitt (Vorschlag)
+
+| PR | Inhalt | Merge-Kriterium |
+| -- | ------ | --------------- |
+| 1 | `factcheck_plus`-Package: Datenmodelle, JSON-Schemas, PolicyScorer + Policy-Datei + Tests | offline grün |
+| 2 | ClaimRefiner + ArgumentMapper (Prompts, Contracts, Retry) + Tests | offline grün (gemockt) |
+| 3 | ResearchPlanner + Pro-Claim-Verifikation (S4/S5) + Verdikt-Mapping + Template | E2E an 1 Realfall |
+| 4 | GUI (Checkbox, Budget, Fortschritt), Worker, Preference, Doku (CLAUDE.md Phase 16, README) | PO-Realtest |
+
+Nur PR 4 fasst `APP_VERSION` an (→ 0.13.0). Reihenfolge nach den bereits
+liegenden Specs (Anthropic-Modellpflege → 0.12.2, Perplexity-Wettbewerbsfähigkeit);
+S5 soll `search_context_size: "high"` aus der Perplexity-Spec bereits voraussetzen.
+
+## 8. PO-Entscheidungen (Thorsten, 2026-07-12)
+
+1. Budget-Default im Plus-Modus: **8**.
+2. Übersprungene Basisfakten erscheinen im Bericht **nur mit Titelzeile**
+   (keine Recherche, keine Verdikte).
+3. Refiner/Mapper laufen über das Analyse-Modell — **kein eigener Picker**.
+
+---
+
+*Änderungen an Prüflogik/Taxonomie zuerst in `FAKTENCHECK_THEORIE.md` klären,
+dann hier nachziehen.*

--- a/specs/STARTPROMPT_Perplexity-Wettbewerbsfaehigkeit_fuer_Kurt.md
+++ b/specs/STARTPROMPT_Perplexity-Wettbewerbsfaehigkeit_fuer_Kurt.md
@@ -1,0 +1,81 @@
+# Startprompt für Kurt (Claude Code) — Perplexity in der Verifikation konkurrenzfähig machen
+
+> Kleiner, gebündelter Zwei-Teil-Fix. Kontext: Beim Faktencheck (Stufe 2) lieferte GPT-5.3-Codex
+> spürbar bessere Verdikte als Perplexity Sonar Pro — Codex fand Belege und differenzierte
+> („teilweise bestätigt"), Sonar griff öfter zur konservativen Schublade „nicht überprüfbar". Zwei
+> Ursachen, beide klein behebbar: (A) Perplexity sucht zu **oberflächlich**, weil der API-Parameter
+> `search_context_size` nie gesetzt wird (Default „low"); (B) dem Verifikations-Prompt fehlt eine
+> **Verdikt-Leitplanke** für „Kern belegt, Details nicht".
+
+---
+
+Du bist der **Programmierer** im SOMAS-Team. Setze zwei unabhängige, kleine Verbesserungen um, die
+zusammen Perplexity als Verifikationsmodell näher an Codex heben. Beide dürfen in einem PR laufen.
+
+## Ausgangslage (verifiziert)
+- `src/core/perplexity_client.py`, `send_prompt()` (~Z.67): Request-Body (~Z.83) setzt nur
+  `model`, `messages`, `max_tokens` — **kein** `web_search_options`. Perplexitys Default für
+  `search_context_size` ist **„low"** = die oberflächlichste Such-Stufe (docs.perplexity.ai →
+  „Search Context Size Guide"). Alle Perplexity-Modelle in SOMAS sind Sonar-Web-Modelle (sonar,
+  sonar-pro, sonar-reasoning-pro, sonar-deep-research), der Parameter ist also immer anwendbar.
+- Verifikation ruft generisch `create_client(...).send_prompt(prompt, model)` auf
+  (`verification_worker.py` Z.94/162; `api_client.py` Z.113).
+- `build_verification_prompt` in `prompt_builder.py` (~Z.1104); Verdikt-Skala-Konstante ~Z.958
+  (`bestätigt` · `teilweise bestätigt` · `widerlegt` · `nicht überprüfbar`).
+
+## Teil A — Such-Tiefe: `search_context_size` setzen
+
+`src/core/perplexity_client.py`:
+- Dem Request-Body (`send_prompt`, ~Z.83) ergänzen:
+  ```json
+  "web_search_options": { "search_context_size": <wert> }
+  ```
+- **Default `"high"`** (gezielt für die Verifikation, wo Belegtiefe zählt). „low" ist zu wenig,
+  „high" zieht deutlich mehr Quellen pro Anfrage.
+- Sauberste Anbindung (Implementierer-Wahl, aber empfohlen): ein **PerplexityClient-Attribut**
+  `self._search_context_size = "high"` (Default), das immer in den Payload geht. Optional per
+  Benutzereinstellung überschreibbar (`perplexity_search_context`, low/medium/high) — wenn ohne
+  großen Aufwand machbar; sonst Default „high" fest und Einstellung als Follow-up notieren.
+- Falls es im Client eine **zweite** Chat-Request-Stelle gibt (~Z.174, evtl. Verbindungstest/
+  Fallback): prüfen, ob sie denselben Parameter braucht — für einen reinen Verbindungstest ist
+  „low" ok, also nur die inhaltlichen Calls auf „high".
+- **Nur** den Perplexity-Client anfassen (der Parameter ist Sonar-spezifisch).
+
+**Caveat (dokumentieren):** höhere Such-Tiefe = mehr Quellen = **höhere Request-Gebühr** pro
+Perplexity-Aufruf. Betrifft nur die (optionale) Verifikationsstufe, ist also gut vertretbar; falls
+als Einstellung umgesetzt, dort kurz erwähnen.
+
+## Teil B — Verdikt-Leitplanke „Kern belegt, Details nicht"
+
+`src/core/prompt_builder.py`, `build_verification_prompt` (~Z.1104):
+- Eine Regel ergänzen (Wortlaut Vorschlag, gern straffen):
+
+  > Wenn der **Kern** einer Behauptung durch eine unabhängige externe Quelle belegt ist, einzelne
+  > **Detailangaben** (Datum, Zahl, Zusatz) aber nicht, dann vergib **„teilweise bestätigt"** und
+  > benenne konkret den belegten Kern sowie das offene Detail — **nicht** pauschal „nicht
+  > überprüfbar".
+
+- Bestehende Riegel unangetastet lassen: Unabhängigkeit (das geprüfte Video zählt NICHT als Beleg),
+  keine erfundenen Quellen, exakt die 4 Verdikt-Werte.
+- Ziel: schwächere/vorsichtigere Modelle (Sonar) an Codex-Granularität heranführen — Codex machte
+  das bereits unaufgefordert (Katar-747-Behauptung: „teilweise bestätigt" statt „nicht überprüfbar").
+
+## Definition of Done
+- Perplexity-Request enthält `web_search_options.search_context_size` (Default „high") — per
+  gemocktem Test verifiziert.
+- `build_verification_prompt` enthält die „teilweise bestätigt"-Leitplanke — Prompt-Test.
+- Manueller Gegentest (PO, optional): dieselbe Behauptung (z.B. Katar-747) mit **Sonar Pro** erneut
+  verifizieren — erwartet: findet jetzt die externe Quelle und liefert „teilweise bestätigt" statt
+  „nicht überprüfbar".
+- Bestehende Faktencheck-/Parser-/Client-Tests grün.
+- Version: mit PO abstimmen (Patch, passt in 0.12.x; nur EIN PR fasst APP_VERSION an — mit
+  Anthropic-Modellpflege koordinieren).
+
+## Nicht in diesem PR (Backlog)
+- Claim-Atomisierung in Stufe 1 (gebündelte Behauptungen splitten) — der tiefere Umbau; separat.
+- `search_context_size` als vollwertige UI-Einstellung, falls in Teil A nur als Default umgesetzt.
+
+## Arbeitsweise
+Bei Unklarheit erst den PO (Thorsten) fragen. Eigener kleiner PR, unabhängig von Anthropic-Modellpflege.
+Wortlaut der Leitplanke ist Vorschlag — Kernaussage („Kern belegt → teilweise bestätigt, nicht
+pauschal nicht-überprüfbar") muss erhalten bleiben.

--- a/specs/STARTPROMPT_faktencheck_stufe1_sortierung_fuer_Kurt.md
+++ b/specs/STARTPROMPT_faktencheck_stufe1_sortierung_fuer_Kurt.md
@@ -1,0 +1,86 @@
+# Startprompt für Kurt: Stufe-1-Sortierung — Basisfakt-Markierung & argumentgewichtete Reihenfolge
+
+**Kontext:** Sofort-PR (Quick Win) vor v0.13.0 „Faktencheck Plus".
+**Grundlage:** `specs/FAKTENCHECK_THEORIE.md` §3 (prüfbar ≠ prüfwürdig) + §2.4.
+**Umfang:** 1 PR, klein. Kein `APP_VERSION`-Bump (fährt mit dem nächsten Release mit);
+README-Changelog-Eintrag unter „Unreleased" o. ä. nach Bestandspraxis.
+
+---
+
+## Problem
+
+Empirisch belegt (4 Realfälle, dokumentiert in
+`notizen/Faktencheck-Eroerterung_Perplexity_2026-07-11md.md`): Die Stufe-1-Sortierung
+verwechselt Prüfbarkeit mit Prüfwürdigkeit. Leicht prüfbare Basisfakten („Das ZDF ist
+öffentlich-rechtlich") landen oben, tragende strittige Claims (z. B. quantitative
+Kernthesen) rutschen unter die Cap-Grenze und werden nie verifiziert. Verstärkt wird
+das durch eine Spannung zwischen zwei Prompt-Bausteinen in
+`src/core/prompt_builder.py`:
+
+- `FAKTENCHECK_FORMAT` (ab :242): ordnet nach „zentral … strittig … folgenreich",
+  Triviales ans Ende.
+- `FAKTENCHECK_NO_LIMIT_HINT` (:259): „Vollständigkeit hat Vorrang vor Kürze" —
+  fördert lange Listen gleichrangiger Neben-Claims ohne Prioritätssignal.
+
+## Aufgabe (3 Teile)
+
+### 1. `FAKTENCHECK_FORMAT` präzisieren
+
+Den Sortierabsatz (Zeilen „Ordne JEDEN Block … ans Ende stellen.") ersetzen durch
+sinngemäß (Formulierung darf geglättet werden, Semantik bindend):
+
+> Ordne die Behauptungen nach argumentativem Gewicht und Recherchewert, NICHT nach
+> Prüfbarkeit: Eine Behauptung steht umso höher, je stärker ihre Widerlegung oder
+> fehlende Belegbarkeit die Kernthese des Beitrags materiell schwächen würde und je
+> mehr eine externe Recherche dazu echten Erkenntnisgewinn verspricht.
+> Biografische, lexikalische, institutionelle und allgemein bekannte Basisfakten:
+> am Listenende einordnen und mit dem Suffix „ [Basisfakt]" kennzeichnen — niemals
+> unter den obersten Prüfkandidaten.
+> Attributionsaussagen („X behauptet/erklärt, dass …") als solche formulieren und
+> nicht mit der Sachaussage selbst verschmelzen.
+
+Meinungen/Interpretationen-Blöcke: Sortierregel unverändert lassen.
+
+### 2. `FAKTENCHECK_NO_LIMIT_HINT` entschärfen
+
+Ersetzen durch sinngemäß:
+
+> Erfasse alle überprüfbaren Behauptungen — Vollständigkeit geht nicht zulasten der
+> Priorisierung: Die Reihenfolge bildet argumentatives Gewicht und Recherchewert ab.
+
+### 3. Parser & Cap: Basisfakten nicht in die Top-N
+
+In `prompt_builder.py`:
+
+- `extract_claims_from_faktencheck` (bzw. nachgelagert): Suffix „[Basisfakt]"
+  (case-insensitiv, mit/ohne eckige Klammern tolerant) erkennen und als Flag am
+  Claim führen; Suffix aus dem Claim-Text entfernen.
+- `cap_claims`: als Basisfakt geflaggte Claims bei der Top-N-Auswahl überspringen
+  (sie zählen nicht gegen das Budget und gehen nicht in die Verifikation).
+  Verhalten bei `0 = unbegrenzt`: Basisfakten trotzdem ausschließen.
+- Anzeige der Stufe-1-Analyse bleibt unverändert (Markierung darf dort sichtbar sein).
+
+## Leitplanken
+
+- **Kein** Eingriff in Stufe 2 (`build_verification_prompt`, Worker, Verdikte).
+- Header bleibt exakt `### FAKTENCHECK`; bestehende Vertrags-Marker und
+  `FINAL_ONLY_FENCE` unangetastet.
+- Robustheit: Wenn ein Modell das Suffix NICHT setzt, muss alles exakt wie bisher
+  funktionieren (reine Zusatzheuristik, kein Pflichtfeld).
+
+## Tests (erweitern: `tests/test_faktencheck_parser.py`)
+
+1. Claim mit Suffix „ [Basisfakt]" → Flag gesetzt, Suffix entfernt.
+2. Schreibweisen-Toleranz: „[basisfakt]", „(Basisfakt)" → ebenfalls erkannt
+   (Umfang nach Ermessen, mindestens eckige Klammern beide Kasus).
+3. `cap_claims(top_n=3)` bei 2 Basisfakten unter den ersten 5 → die 3 Slots gehen
+   an Nicht-Basisfakten.
+4. `cap_claims(0)` → Basisfakten ausgeschlossen, Rest unbegrenzt.
+5. Bestandsfixtures ohne Suffix → Verhalten unverändert (Regression).
+6. Interne Zahlen in Claims („am 7. Oktober 2023") weiterhin kein Split (Regression).
+
+## Definition of Done
+
+- Alle Tests grün (Bestand + neu).
+- README-Changelog-Eintrag; CLAUDE.md-Backlog-/Phasenpflege minimal.
+- Kurzer PR-Text mit Verweis auf `FAKTENCHECK_THEORIE.md` §3.

--- a/specs/STARTPROMPT_leerinhalt_retry_abbrechen_fuer_Kurt.md
+++ b/specs/STARTPROMPT_leerinhalt_retry_abbrechen_fuer_Kurt.md
@@ -1,0 +1,62 @@
+# Startprompt für Kurt: Leer-Inhalt in den Retry-Pfad + Abbrechen-Fix (+ optionaler Reasoning-Cap)
+
+**Kontext:** Realtest 2026-07-12 (Anwalt-Video, DeepSeek V4 Pro, 24k-Zeichen-Prompt):
+drei Fehlversuche in Folge, Debug-Artefakte liegen vor. Kleiner Robustheits-PR,
+kein `APP_VERSION`-Bump nötig (fährt mit nächstem Release mit).
+
+## Befund (aus den Debug-Logs)
+
+| Versuch | Verlauf | App-Verhalten |
+| ------- | ------- | ------------- |
+| 1 (12:39, 168 s) | `finish_reason=length`, Content leer (Reasoning fraß das komplette 8192-Budget) | harter API-Fehler-Dialog, **kein** Auto-Retry |
+| 2 (12:56, 217 s) | HTTP 200, `finish_reason=length`, 1284 Zeichen (FRAMING angebrochen), tokens_total 14790 | Trunkierungs-Gate griff korrekt → Auto-Retry gestartet |
+| 3 (= Auto-Retry, 210 s) | wieder leer + `length` | wieder harter Fehler-Dialog |
+
+Bekannter DeepSeek-Heavy-Reasoner-Modus (kein Bug im Modell-Handling, ehrliche
+Fehler statt Müll = designtes Verhalten). Aber zwei UX-Lücken sind jetzt real belegt:
+
+- **Asymmetrie:** trunkiert-nicht-leer bekommt seit v0.11.0 einen sichtbaren
+  Ein-Retry; Leer-Inhalt (`v0.9.1`-Riegel, `api_error` „Modell lieferte leeren
+  Inhalt") endet hart ohne Retry — obwohl es derselbe Fehlermodus ist
+  (Reasoning verbrennt Budget).
+- **Abbrechen wirkungslos:** Während „Automatischer erneuter Versuch läuft …
+  (kann abgebrochen werden)" ließ sich der Lauf laut PO NICHT abbrechen.
+
+## Aufgabe
+
+1. **Leer-Inhalt → gleicher Eskalationspfad wie Trunkierung:** Die
+   Leer-Inhalt-`APIResponse` (alle 4 Clients werfen sie einheitlich) in
+   `main_window` wie eine ungültige Analyse behandeln: 1× sichtbarer Auto-Retry,
+   danach offener „Modelllauf fehlgeschlagen" — statt sofortigem QMessageBox-Fehler.
+   Der Fehlertext (inkl. `finish_reason`) bleibt im Fehlschlag-Hinweis erhalten.
+2. **Abbrechen reparieren:** Abbrechen-Button muss auch WÄHREND des Auto-Retrys
+   greifen (laufenden Retry-Call verwerfen, UI sauber zurücksetzen, keine
+   Race mit spät eintreffender Response — vorhandenen `_api_worker`-Race-Guard
+   aus v0.10.1 beachten/erweitern). Bitte Ursache kurz diagnostizieren
+   (vermutlich wird der Cancel-Handler nur für den Erst-Call verdrahtet).
+3. **Optional, wenn günstig machbar (PO-Kosten-Tradeoff beachten):** Bei
+   OpenRouter-Analyse-Calls Reasoning-Budget deckeln
+   (`reasoning: {"max_tokens": …, "exclude": true}`), damit fürs sichtbare
+   Ergebnis garantiert Budget übrig bleibt. Konservativer Wert (z. B. 4096),
+   nur OpenRouter, andere Provider unangetastet. Falls Doku/Verhalten unklar →
+   weglassen und als Backlog-Notiz dokumentieren.
+4. **Logging-Kosmetik (Mitnahme):** Fehler-Responses loggen `status_code=500`
+   als Default, auch wenn der echte Pfad HTTP 200 + Leer-Inhalt war —
+   echten Status durchreichen.
+
+## Leitplanken
+
+- Kein Eingriff in Prompt-Aufbau, Validator-Logik oder Verifikation.
+- Fehlermodus bleibt ehrlich: nach fehlgeschlagenem Retry KEIN weiterer
+  automatischer Versuch (Kostenkontrolle), Nutzer entscheidet (neu starten /
+  Modell wechseln).
+- Tests: Leer-Inhalt-Retry-Pfad (gemockt), Abbruch während Retry, Regression
+  Trunkierungs-Retry unverändert.
+
+## Separater Doku-/Housekeeping-Commit (NICHT in diesen PR mischen)
+
+- `notizen/` in `.gitignore` aufnehmen (PO-Entscheidung: Notizen bleiben lokal).
+- `specs/FAKTENCHECK_THEORIE.md`, `specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md`,
+  `specs/STARTPROMPT_faktencheck_stufe1_sortierung_fuer_Kurt.md`,
+  `specs/STATUSBERICHT_2026-07-12.md` sichten und committen (CLAUDE.md-Änderungen
+  vom 2026-07-12 mit dazu).

--- a/specs/STATUSBERICHT_2026-07-12.md
+++ b/specs/STATUSBERICHT_2026-07-12.md
@@ -1,0 +1,176 @@
+# Statusbericht SOMAS Prompt Generator — 2026-07-12
+
+Faktischer Entwicklungsstand-Snapshot. Keine Empfehlungen, keine Änderungen am Code.
+
+---
+
+## 1. Version & Git
+
+### Versions-Abgleich
+
+| Quelle | Wert | Fundstelle |
+| ------ | ---- | ---------- |
+| Code-Konstante | `0.12.1` | `src/core/debug_logger.py:17` (`APP_VERSION`) |
+| CLAUDE.md | `0.12.1` | Projektkontext-Kopf |
+| README-Changelog-Tabelle | `0.12.1` | `README.md:361` |
+
+Die drei maßgeblichen Stellen (Code, CLAUDE.md, README-Changelog) **stimmen bei 0.12.1 überein.**
+
+**Kleine Diskrepanz:** Der README-Prosa-Abschnitt „### Aktuell (v0.12.0)" (`README.md:19`)
+hängt eine Version hinterher — beschreibt noch WordPress-Veröffentlichung (0.12.0),
+während der Zeitanker (0.12.1) nur in der Changelog-Tabelle darunter steht.
+(Der FastAPI-`version="0.1.0"` im Submodul ist unabhängig und irrelevant.)
+
+### Branch, Commits, Working Tree
+
+- **Branch:** `main` (einziger lokaler Branch; nur `origin/main` remote).
+- **Uncommittete Änderungen:**
+  - `M docs/index.html` (modifiziert, nicht committed)
+  - `?? specs/STARTPROMPT_Perplexity-Wettbewerbsfaehigkeit_fuer_Kurt.md` (untracked)
+- **Offene PRs:** keine (`gh pr list` → leer).
+
+### Letzte 15 Commits
+
+| Hash | Datum | Titel |
+| ---- | ----- | ----- |
+| 71a4169 | 2026-07-05 | v0.12.1: Zeitanker im Prompt (gegen Real-als-Fiktion-Fehlrahmung) (#51) |
+| a348eea | 2026-07-04 | v0.12.0: WordPress-Beitragsbild (YouTube-Thumbnail als featured image) (#50) |
+| 1ce172b | 2026-07-02 | Landingpage und Startprompt Anthropic-Modelle-aktualisieren |
+| fdad6c9 | 2026-07-02 | v0.11.0: Reasoning-Leak-Härtung (Increment A + B) (#49) |
+| 6b31c21 | 2026-07-01 | docs: Submodul-Init + optionalen Intake-Core-Install dokumentieren (#48) |
+| 8053e4f | 2026-07-01 | feat: youtube-intake-service Core in-process integrieren (opt-in) (#47) |
+| 8c2c887 | 2026-07-01 | Docs/intake spec revision (#46) |
+| ee9bae4 | 2026-06-26 | Merge branch 'main' of github.com/ddumdi11/somas_prompt_generator |
+| d6607ad | 2026-06-26 | feat: Buy-Me-a-Coffee-Button + Spec youtube-intake-service (#45) |
+| 1385a13 | 2026-06-26 | fix: natuerliche Sprecher-Bezeichnung, Downloads-Default & Reasoning-… (#44) |
+| e1481ca | 2026-06-26 | chore: pip-freeze Snapshot als requirements.lock.txt festhalten |
+| c7196d1 | 2026-06-24 | docs: Finanzierungs-Ideen + Startprompt v0.10.1 ergänzen |
+| 3b0a517 | 2026-06-22 | Feature: WordPress-Export – Analyse als Beitrag senden (Variante A) (#43) |
+| 4017560 | 2026-06-17 | v0.10.1 PR 5: Verifikation erneut versuchen (Retry mit Modellwechsel) (#42) |
+| 977f0ec | 2026-06-16 | v0.10.1: Faktencheck-Härtung & Fixes (PR 1-3, 6, 7) (#41) |
+
+### Submodul `external/youtube-intake-service`
+
+- **Gepinnt auf:** Tag `v1.0.0` (Commit `64d6973`).
+- **Initialisiert:** ja (Git-Status zeigt Commit ohne `-`-Präfix; Adapter-Test `test_intake_adapter.py` läuft grün).
+
+---
+
+## 2. Tests
+
+Ausgeführt mit `venv/Scripts/python.exe -m pytest tests/ -q`
+(die System-`py`/Store-Python haben kein pytest; das Projekt-`venv` schon).
+
+**Ergebnis: 50 bestanden, 0 fehlgeschlagen, 0 übersprungen** (2,97 s).
+
+Testdateien: `test_empty_content.py`, `test_export_header.py`, `test_faktencheck_parser.py`,
+`test_intake_adapter.py`, `test_reasoning_leak_validator.py`, `test_temporal_anchor.py`,
+`test_wordpress_media.py`.
+
+Keine Fehlschläge → keine Ursachenanalyse nötig.
+
+---
+
+## 3. Faktencheck-Modul (Schwerpunkt)
+
+### Ist-Architektur
+
+**Stufe 1 — Dekonstruktion (im selben Analyse-Call):**
+- `FAKTENCHECK_FORMAT` (`prompt_builder.py:242`) definiert das Ausgabeformat mit den drei
+  Blöcken **Meinungen / Interpretationen / Behauptungen (überprüfbar)**, relevanz-sortiert,
+  ein Punkt pro Zeile, Header exakt `### FAKTENCHECK`.
+- Injektion über `_apply_custom_overrides` (`prompt_builder.py:360`): erzwingt FAKTENCHECK
+  als Modul, stellt `FAKTENCHECK_FORMAT` + `FAKTENCHECK_NO_LIMIT_HINT` + `FINAL_ONLY_FENCE`
+  voran und entfernt die Zeichenlimit-Zeilen per Regex (`_CHARLIMIT_LINE_RE`, `:277`).
+- **Parser:** `extract_claims_from_faktencheck` (`:1007`) + `_split_consecutive_claims`
+  (`:962`, trennt nur an FORTLAUFENDEN Nummern-Grenzen n→n+1, damit interne Zahlen wie
+  „am 7. Oktober 2023" einen Claim nicht zerreißen). `cap_claims` (`:1086`) kappt
+  deterministisch auf Top-N.
+
+**Stufe 2 — Verifikation (optional, separater Call):**
+- `verification_item.py` (Config/Result), `verification_worker.py` (QThread).
+- `build_verification_prompt` (`:1104`) enthält AUSSCHLIESSLICH die (bereits gekappten)
+  Behauptungen — kein Transkript, keine Meinungen. Enthält den Unabhängigkeits-Riegel
+  (v0.10.1): geprüftes Video zählt nicht als Beleg, `source_hint` wird als verbotene
+  Eigenquelle geführt und auf 300 Zeichen gegen Prompt-Injection saniert.
+- Ausführung: **ein einziger** `client.send_prompt(prompt, model_id)`
+  (`verification_worker.py:162`) für alle Behauptungen zusammen.
+- `somas_verification.txt` rendert das Ergebnis; `clean_verification_output` bereinigt.
+
+### Hart kodierte Grenzen des aktuellen Ansatzes
+
+- **Verdikt-Skala fest 4-stufig:** `VERDICT_VALUES = (bestätigt, teilweise bestätigt,
+  widerlegt, nicht überprüfbar)` (`prompt_builder.py:957`) — im Prompt erzwungen.
+- **Ein-Call-Verifikation:** alle Behauptungen teilen sich EIN Request-/Token-Budget
+  (`verification_worker.py:162`). FAKTENCHECK-Zweiteilung (getrennte Calls) ist Backlog.
+- **cap_claims-Default:** Code-Fallback in der GUI ist `10` (`main_window.py:196`),
+  **aber** `user_preferences.json` überschreibt auf `verification_max_claims: 30` →
+  effektiver Laufzeit-Default ist **30**. `0` = unbegrenzt.
+- **source_hint** auf 300 Zeichen begrenzt (`:1130`).
+- Halluzinierte Quellen werden nur **prompt-seitig** verboten („Erfinde KEINE URLs"),
+  nicht technisch verhindert.
+
+### Bekannte Schwachstellen (aus Specs/Kommentaren/Backlog)
+
+- **Zeichenlimit vs. Vollständigkeit:** Der ursprüngliche v0.10.0-Ansatz („Gesamtzeichenlimit
+  AUFGEHOBEN"-Klausel voranstellen) war fehlerhaft — die Template-Limitzeile blieb im Prompt,
+  Modell kürzte trotzdem (Merkzettel A2). Behoben in v0.10.1 durch echtes Entfernen der
+  Limitzeilen; als „bewusst dokumentierte Grenze" bleibt: bei **ausgeschalteter** Verifikation
+  kann der FAKTENCHECK-Block durch das Preset-Limit unvollständig sein
+  (SOMAS_v0.10.0_SPEC, Z. 273).
+- **Reasoning-Leak** (v0.11.0): gehärtet (OpenRouter `reasoning.exclude`, `finish_reason`-Gate,
+  `validate_analysis_structure`, 1× Auto-Retry statt Scheinanalyse). Zeichenlimit-Treue ist
+  dabei **bewusst kein** Optimierungsziel (PO-Entscheidung #2).
+- **Ein-Call-Token-Budget:** FAKTENCHECK läuft im selben Call wie die Analyse → geteiltes
+  Budget kann lange Behauptungslisten abschneiden. „FAKTENCHECK-Zweiteilung" nur bei Bedarf
+  (SOMAS_v0.11.0_SPEC, Z. 99; CLAUDE.md-Backlog).
+
+---
+
+## 4. Backlog-Abgleich
+
+### CLAUDE.md-Backlog
+
+| Punkt | Stand |
+| ----- | ----- |
+| A4: erzwungenes Modul aus `MODUL-AUSWAHL`-Liste entfernen | **offen** (FINAL_ONLY_FENCE/Format wird vorangestellt, aber die Auswahlliste selbst nicht bereinigt) |
+| FAKTENCHECK-Zweiteilung (getrennte Calls, eigenes Budget) | **offen** (Verifikation weiterhin Ein-Call, `verification_worker.py:162`) |
+| Docstring-Coverage ≥ 80 % (Test-Funktionen) | **offen** (CodeRabbit-Gate, niedrige Prio) |
+| Wochentags-basierte Perspektive-Defaults | **offen** |
+| Englisch-Support | **offen** (Prompts/UI durchgehend deutsch) |
+| PDF-Export (auch Modellvergleich) | **offen** |
+| Crash-Recovery-Persistenz für Modellvergleich | **offen** (nur Batch hat Persistenz) |
+| N-Wege-Vergleich (> 2 Analyse-Modelle) | **offen** (`ProviderModelPicker` fest 2 Analyse + 1 Synthese) |
+
+### Phase-15-Follow-up: `video_published` im Zeitanker
+
+**Offen (nur vorbereitet).** `_build_temporal_anchor` und `_prepend_temporal_anchor`
+akzeptieren den optionalen Parameter `video_published` (`prompt_builder.py:306/338`),
+**aber** beide Aufrufer rufen ohne Wert auf: `_prepend_temporal_anchor(rendered)`
+(`:483` und `:574`). Es gibt kein Upload-/Publish-Datum in `VideoInfo` (kein `upload_date`
+verdrahtet), daher landet das Veröffentlichungsdatum noch nicht im Anker. Aktuell wird nur
+das taggenaue **aktuelle** Datum (`datetime.now()`, locale-sicher) eingesetzt.
+
+### WordPress Media-Dedup
+
+**Offen.** `wordpress_client.py` hat `upload_media` (`:366`), aber keine Suche vor dem
+Upload → das YouTube-Thumbnail wird bei jedem Senden neu hochgeladen (Media-Dublettenrisiko,
+wie im CLAUDE.md-Backlog notiert).
+
+---
+
+## 5. Auffälligkeiten
+
+- **Keine** TODO/FIXME/HACK/XXX-Kommentare im gesamten `src/`-Baum.
+- **README-Prosa hängt hinterher:** „### Aktuell (v0.12.0)" (`README.md:19`) beschreibt noch
+  0.12.0, obwohl Code und Changelog bei 0.12.1 sind (siehe §1).
+- **cap_claims-Default-Divergenz:** Code-Fallback 10 vs. `user_preferences.json` 30 —
+  dokumentierter/erwarteter Default (Spec, GUI-Tooltip) ist 10, gelebter Laufzeitwert 30 (§3).
+- **`_prepend_temporal_anchor`-Parameter ungenutzt:** `video_published` existiert in der
+  Signatur, wird aber nie befüllt (§4) — toter Pfad bis zum Follow-up.
+- **Untracked/uncommitted:** `docs/index.html` (M) und ein neuer Startprompt-Spec sind noch
+  nicht eingecheckt (§1).
+
+---
+
+*Erstellt: 2026-07-12 · Basis: `main` @ 71a4169 · Tests: 50/50 grün*


### PR DESCRIPTION
## Housekeeping (PO-Entscheidung 2026-07-12)
Bewusst getrennt vom Fix-PR #53 gehalten (so im Startprompt vorgegeben). Architekten-Freigabe erteilt.

- **`notizen/` → `.gitignore`**: Zwischennotizen bleiben lokal (PO-Entscheidung). *Bewusste Nebenwirkung:* auch die zwei `Vorlage_*`-Templates sind damit unversioniert — für Ein-Rechner-Setup ok; bei Repo-Umzug manuell mitnehmen.
- **`specs/FAKTENCHECK_THEORIE.md`** (v0.1): lebendes Referenzdokument (prüfbar ≠ prüfwürdig, AFC-Einordnung, Priorisierungs-Policy, Verdikt-Taxonomie).
- **`specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md`** (Entwurf): argumentgewichtete Recherche als parallele Strategie.
- **Startprompts (historische Referenz):** `STARTPROMPT_faktencheck_stufe1_sortierung` (→ PR #52), `STARTPROMPT_leerinhalt_retry_abbrechen` (→ PR #53), `STARTPROMPT_Perplexity-Wettbewerbsfaehigkeit` (liegender Auftrag).
- **`specs/STATUSBERICHT_2026-07-12.md`**: Entwicklungsstand-Snapshot.

Reine Doku/Config — kein Code, keine Tests berührt, kein `APP_VERSION`-Bump.

## Bewusst NICHT enthalten
- `docs/index.html` (vorbestehende Änderung; gehört zu einem späteren Landing-Page-Commit, nicht ins Housekeeping).

*Hinweis: CodeRabbit kommentiert `specs/` nicht (ausgefiltert) — erwartetes Verhalten.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)