### PR TITLE
feat: Faktencheck Plus PR 1 — factcheck_plus-Package + PolicyScorer (LLM-frei)

### DIFF
--- a/specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md
+++ b/specs/SOMAS_v0.13.0_SPEC_faktencheck_plus.md
@@ -101,6 +101,54 @@ Quoten, Budget. Der Scorer implementiert:
 
 → Vollständig offline testbar; Kern der Regressionstests.
 
+**Policy-Schema (festgezurrt für PR 1; Zahlwerte = Startwerte, Tuning nach
+Realtests):**
+
+```json
+{
+  "policy_version": "relevance-de-v1",
+  "rating_scale": [0, 5],
+  "weights": {
+    "importance": {
+      "thesis_proximity": 1.0,
+      "conclusion_dependency": 1.0,
+      "harm_potential": 1.0,
+      "reach_mobilization": 0.75,
+      "concreteness": 0.5
+    },
+    "research_value": {
+      "non_triviality": 1.0,
+      "recency": 1.0,
+      "contestedness": 1.0,
+      "source_access": 1.0,
+      "evidence_gap": 1.0,
+      "discrepancy_potential": 1.0
+    }
+  },
+  "gates": {
+    "exclude_claim_types": ["opinion", "interpretation"],
+    "basisfakt_route": "skip_listed_only",
+    "triviality_skip_at": 4,
+    "under_specified_route": "flag_not_research"
+  },
+  "quotas": {
+    "core_claims_share": 0.6,
+    "supporting_share": 0.3,
+    "context_max_claims": 2
+  },
+  "budget": {
+    "deep_research_default": 8
+  }
+}
+```
+
+Rechenweg: `importance` und `research_value` = gewichtete Summe der 0–5-Ratings
+aus S2, jeweils auf 0–1 normiert; `priority = importance × research_value ×
+checkability` (checkability 0–1 aus S1-Feldern: Entität/Zeitraum/Metrik
+vorhanden?). Auswahl klassenweise nach Quoten (A vor B vor C), innerhalb der
+Klasse absteigend nach `priority`. Feldnamen sind verbindlich (JSON-Schema);
+Gewichte/Schwellen sind Konfiguration, kein Code.
+
 ### S4 — ResearchPlanner (LLM → JSON)
 
 Für die ≤ Budget selektierten Claims **eine** Recherchekarte je Claim

--- a/src/config/relevance_policy_v1.json
+++ b/src/config/relevance_policy_v1.json
@@ -1,0 +1,35 @@
+{
+  "policy_version": "relevance-de-v1",
+  "rating_scale": [0, 5],
+  "weights": {
+    "importance": {
+      "thesis_proximity": 1.0,
+      "conclusion_dependency": 1.0,
+      "harm_potential": 1.0,
+      "reach_mobilization": 0.75,
+      "concreteness": 0.5
+    },
+    "research_value": {
+      "non_triviality": 1.0,
+      "recency": 1.0,
+      "contestedness": 1.0,
+      "source_access": 1.0,
+      "evidence_gap": 1.0,
+      "discrepancy_potential": 1.0
+    }
+  },
+  "gates": {
+    "exclude_claim_types": ["opinion", "interpretation"],
+    "basisfakt_route": "skip_listed_only",
+    "triviality_skip_at": 4,
+    "under_specified_route": "flag_not_research"
+  },
+  "quotas": {
+    "core_claims_share": 0.6,
+    "supporting_share": 0.3,
+    "context_max_claims": 2
+  },
+  "budget": {
+    "deep_research_default": 8
+  }
+}

--- a/src/core/factcheck_plus/__init__.py
+++ b/src/core/factcheck_plus/__init__.py
@@ -10,14 +10,17 @@ Kein Qt-Import in diesem Package (extrahierbar als ``factcheck_core``, Spec §2.
 from .models import (
     ArgumentMapping, ClaimAudit, ClaimClass, MappedClaim, RefinedClaim,
     ROLE_TO_CLASS, SelectionResult, join_claims,
+    STATUS_BASISFAKT_SKIPPED, STATUS_EXCLUDED_OPINION, STATUS_NOT_SELECTED_BUDGET,
+    STATUS_SELECTED, STATUS_UNDER_SPECIFIED,
 )
 from .policy_scorer import DEFAULT_POLICY_PATH, PolicyScorer, load_policy
 from .schemas import (
-    ARGUMENT_MAPPING_SCHEMA, RATING_DIMS, REFINED_CLAIM_SCHEMA, SchemaError,
-    validate,
+    ARGUMENT_MAPPING_SCHEMA, ARGUMENT_ROLES, CLAIM_TYPES, IMPORTANCE_DIMS,
+    RATING_DIMS, REFINED_CLAIM_SCHEMA, RESEARCH_VALUE_DIMS, SchemaError, validate,
 )
 
 __all__ = [
+    # Datenmodelle
     "ArgumentMapping",
     "ClaimAudit",
     "ClaimClass",
@@ -26,12 +29,24 @@ __all__ = [
     "ROLE_TO_CLASS",
     "SelectionResult",
     "join_claims",
+    # Auswahl-/Ausschluss-Status
+    "STATUS_SELECTED",
+    "STATUS_EXCLUDED_OPINION",
+    "STATUS_BASISFAKT_SKIPPED",
+    "STATUS_UNDER_SPECIFIED",
+    "STATUS_NOT_SELECTED_BUDGET",
+    # Scorer
     "PolicyScorer",
     "load_policy",
     "DEFAULT_POLICY_PATH",
+    # Verträge / Wertemengen
     "ARGUMENT_MAPPING_SCHEMA",
     "REFINED_CLAIM_SCHEMA",
     "RATING_DIMS",
+    "IMPORTANCE_DIMS",
+    "RESEARCH_VALUE_DIMS",
+    "CLAIM_TYPES",
+    "ARGUMENT_ROLES",
     "SchemaError",
     "validate",
 ]

--- a/src/core/factcheck_plus/__init__.py
+++ b/src/core/factcheck_plus/__init__.py
@@ -1,0 +1,37 @@
+"""Faktencheck Plus (v0.13.0) — argumentgewichtete Recherche-Auswahl.
+
+PR 1 liefert das **LLM-freie** Fundament: Datenmodelle + JSON-Verträge (S1/S2)
+und den deterministischen ``PolicyScorer`` (S3) inkl. ``relevance_policy_v1.json``.
+Refiner (S1), Mapper (S2), ResearchPlanner (S4) und Pro-Claim-Verifikation (S5)
+folgen in späteren PRs; hier simulieren Fixtures deren Output.
+
+Kein Qt-Import in diesem Package (extrahierbar als ``factcheck_core``, Spec §2.2).
+"""
+from .models import (
+    ArgumentMapping, ClaimAudit, ClaimClass, MappedClaim, RefinedClaim,
+    ROLE_TO_CLASS, SelectionResult, join_claims,
+)
+from .policy_scorer import DEFAULT_POLICY_PATH, PolicyScorer, load_policy
+from .schemas import (
+    ARGUMENT_MAPPING_SCHEMA, RATING_DIMS, REFINED_CLAIM_SCHEMA, SchemaError,
+    validate,
+)
+
+__all__ = [
+    "ArgumentMapping",
+    "ClaimAudit",
+    "ClaimClass",
+    "MappedClaim",
+    "RefinedClaim",
+    "ROLE_TO_CLASS",
+    "SelectionResult",
+    "join_claims",
+    "PolicyScorer",
+    "load_policy",
+    "DEFAULT_POLICY_PATH",
+    "ARGUMENT_MAPPING_SCHEMA",
+    "REFINED_CLAIM_SCHEMA",
+    "RATING_DIMS",
+    "SchemaError",
+    "validate",
+]

--- a/src/core/factcheck_plus/models.py
+++ b/src/core/factcheck_plus/models.py
@@ -1,0 +1,174 @@
+"""Datenmodelle für Faktencheck Plus (v0.13.0, PR 1).
+
+Bewusst **ohne Qt-Import** — die Stufen kommunizieren nur über diese Dataclasses /
+JSON-Verträge, damit das Package später als eigenständiges ``factcheck_core``
+extrahierbar bleibt (Intake-Muster, Spec §2.2).
+
+- ``RefinedClaim``   – Output S1 (ClaimRefiner)
+- ``ArgumentMapping`` – Output S2 (ArgumentMapper)
+- ``MappedClaim``    – S1+S2 je Claim gejoint (Eingabeeinheit des Scorers)
+- ``ClaimAudit`` / ``SelectionResult`` – Auswahl + Audit-Spur (Datenquelle des
+  späteren Transparenz-Blocks, Spec §3/S3)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .schemas import (
+    ARGUMENT_MAPPING_SCHEMA, REFINED_CLAIM_SCHEMA, validate,
+)
+
+
+class ClaimClass(str, Enum):
+    """Arbeitsklassen der Priorisierung (Theorie §2.4)."""
+    A = "A"  # Kernclaim – trägt die Hauptthese
+    B = "B"  # tragender Subclaim
+    C = "C"  # Kontext-/Beispielclaim
+    D = "D"  # Basis-/Metadatenclaim (Basisfakt)
+
+
+# Argumentrolle (S2) → Arbeitsklasse (Theorie §2.4).
+ROLE_TO_CLASS: dict[str, ClaimClass] = {
+    "core_claim": ClaimClass.A,
+    "supporting_premise": ClaimClass.B,
+    "context": ClaimClass.C,
+    "example": ClaimClass.C,
+    "metadata": ClaimClass.D,
+}
+
+
+@dataclass
+class RefinedClaim:
+    """Atomisierte, normalisierte Behauptung (S1, ClaimRefiner)."""
+    claim_id: str
+    original_text: str
+    normalized_claim: str
+    claim_type: str
+    entities: list[str] = field(default_factory=list)
+    timeframe: str | None = None
+    metric: str | None = None
+    parent_id: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RefinedClaim":
+        """Validiert gegen ``REFINED_CLAIM_SCHEMA`` und baut die Instanz."""
+        validate(data, REFINED_CLAIM_SCHEMA, "$.refined_claim")
+        return cls(
+            claim_id=data["claim_id"],
+            original_text=data["original_text"],
+            normalized_claim=data["normalized_claim"],
+            claim_type=data["claim_type"],
+            entities=list(data.get("entities", [])),
+            timeframe=data.get("timeframe"),
+            metric=data.get("metric"),
+            parent_id=data.get("parent_id"),
+        )
+
+
+@dataclass
+class ArgumentMapping:
+    """Argumentrolle + kontrafaktischer Impact + 0–5-Ratings (S2, ArgumentMapper)."""
+    claim_id: str
+    argument_role: str
+    counterfactual_impact: str
+    ratings: dict[str, int]
+    reason: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ArgumentMapping":
+        """Validiert gegen ``ARGUMENT_MAPPING_SCHEMA`` und baut die Instanz."""
+        validate(data, ARGUMENT_MAPPING_SCHEMA, "$.argument_mapping")
+        return cls(
+            claim_id=data["claim_id"],
+            argument_role=data["argument_role"],
+            counterfactual_impact=data["counterfactual_impact"],
+            ratings=dict(data["ratings"]),
+            reason=data.get("reason", ""),
+        )
+
+
+@dataclass
+class MappedClaim:
+    """S1- und S2-Output eines Claims gejoint — Eingabeeinheit des PolicyScorers."""
+    refined: RefinedClaim
+    mapping: ArgumentMapping
+
+    @property
+    def claim_id(self) -> str:
+        return self.refined.claim_id
+
+
+def join_claims(
+    refined: list[RefinedClaim], mappings: list[ArgumentMapping],
+) -> list[MappedClaim]:
+    """Verbindet Refiner- und Mapper-Output deterministisch über ``claim_id``.
+
+    Die Reihenfolge folgt ``refined`` (stabile Eingabereihenfolge).
+
+    Args:
+        refined: RefinedClaims aus S1.
+        mappings: ArgumentMappings aus S2.
+
+    Returns:
+        Liste gejointer ``MappedClaim`` in ``refined``-Reihenfolge.
+
+    Raises:
+        ValueError: Wenn ein Claim kein Gegenstück in der jeweils anderen Liste hat.
+    """
+    by_id = {m.claim_id: m for m in mappings}
+    if len(by_id) != len(mappings):
+        raise ValueError("Doppelte claim_id in den ArgumentMappings")
+    joined: list[MappedClaim] = []
+    for rc in refined:
+        mapping = by_id.pop(rc.claim_id, None)
+        if mapping is None:
+            raise ValueError(f"Kein ArgumentMapping für claim_id '{rc.claim_id}'")
+        joined.append(MappedClaim(refined=rc, mapping=mapping))
+    if by_id:
+        raise ValueError(
+            f"ArgumentMapping ohne RefinedClaim: {sorted(by_id)}"
+        )
+    return joined
+
+
+@dataclass
+class ClaimAudit:
+    """Auditspur je Claim: Score-Komponenten + Auswahlgrund + Policy-Version.
+
+    Ab Tag eins vollständig (Spec-Leitplanke): Datenquelle des späteren
+    Transparenz-Blocks (PR 3/4).
+    """
+    claim_id: str
+    claim_class: str            # "A" | "B" | "C" | "D"
+    status: str                 # s. STATUS_* unten
+    selected: bool
+    importance: float           # 0–1
+    research_value: float       # 0–1
+    checkability: float         # 0–1
+    priority: float             # importance × research_value × checkability
+    policy_version: str
+    reason: str
+
+
+# Auswahl-/Ausschluss-Status (Route eines Claims durch die Gates + Quotenauswahl).
+STATUS_SELECTED = "selected"                    # in die Deep-Research-Auswahl
+STATUS_EXCLUDED_OPINION = "excluded_opinion"    # Gate 1: Meinung/Deutung
+STATUS_BASISFAKT_SKIPPED = "basisfakt_skipped"  # Gate 3: Basisfakt/trivial – nur gelistet
+STATUS_UNDER_SPECIFIED = "under_specified"      # Gate 5: zu vage – flag, nicht recherchiert
+STATUS_NOT_SELECTED_BUDGET = "not_selected_budget"  # eligible, aber Budget/Quote erschöpft
+
+
+@dataclass
+class SelectionResult:
+    """Ergebnis eines PolicyScorer-Laufs: Auswahl + vollständige Auditspur."""
+    policy_version: str
+    budget: int
+    selected_ids: list[str]
+    audits: list[ClaimAudit]
+    counts: dict[str, int]
+
+    def selected_audits(self) -> list[ClaimAudit]:
+        """Audits der selektierten Claims, in Auswahlreihenfolge (Rang)."""
+        by_id = {a.claim_id: a for a in self.audits}
+        return [by_id[cid] for cid in self.selected_ids]

--- a/src/core/factcheck_plus/models.py
+++ b/src/core/factcheck_plus/models.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from .schemas import (
-    ARGUMENT_MAPPING_SCHEMA, REFINED_CLAIM_SCHEMA, validate,
+    ARGUMENT_MAPPING_SCHEMA, ARGUMENT_ROLES, REFINED_CLAIM_SCHEMA, validate,
 )
 
 
@@ -36,6 +36,14 @@ ROLE_TO_CLASS: dict[str, ClaimClass] = {
     "example": ClaimClass.C,
     "metadata": ClaimClass.D,
 }
+
+# Konsistenzriegel zur Importzeit: jede im S2-Vertrag erlaubte Argumentrolle muss
+# hier auf eine Klasse abgebildet sein (fängt Drift zwischen Schema und Mapping).
+# Der `.get(..., ClaimClass.C)`-Fallback im Scorer bleibt als Laufzeit-Sicherheitsnetz.
+assert set(ROLE_TO_CLASS) == set(ARGUMENT_ROLES), (
+    "ROLE_TO_CLASS deckt nicht exakt ARGUMENT_ROLES ab: "
+    f"{set(ROLE_TO_CLASS) ^ set(ARGUMENT_ROLES)}"
+)
 
 
 @dataclass
@@ -116,6 +124,11 @@ def join_claims(
     Raises:
         ValueError: Wenn ein Claim kein Gegenstück in der jeweils anderen Liste hat.
     """
+    refined_ids = [rc.claim_id for rc in refined]
+    if len(set(refined_ids)) != len(refined_ids):
+        seen: set[str] = set()
+        dupes = sorted({cid for cid in refined_ids if cid in seen or seen.add(cid)})
+        raise ValueError(f"Doppelte claim_id in den RefinedClaims: {dupes}")
     by_id = {m.claim_id: m for m in mappings}
     if len(by_id) != len(mappings):
         raise ValueError("Doppelte claim_id in den ArgumentMappings")

--- a/src/core/factcheck_plus/policy_scorer.py
+++ b/src/core/factcheck_plus/policy_scorer.py
@@ -1,0 +1,273 @@
+"""PolicyScorer — deterministische Claim-Auswahl (v0.13.0, PR 1).
+
+**Streng deterministisch, KEIN LLM, keine Zufälle** (Spec §6): gleicher Input →
+gleiche Auswahl. Der Scorer konsumiert nur Felder, die in PR 2 der Refiner (S1)
+und Mapper (S2) liefern; hier simulieren Fixtures diese.
+
+Ablauf pro Claim (Spec §3/S3, Theorie §4):
+  1. **Gates vor Scores** (Reihenfolge aus Theorie §4.2 ist semantisch):
+     Gate 1 Meinung/Deutung raus · Gate 2 Kontext = eigene (kleine) Quote ·
+     Gate 3 Basisfakt/trivial nur listen · Gate 4 Attribution (kommt aus S1 bereits
+     gesplittet) · Gate 5 zu vage → flaggen, nicht recherchieren.
+  2. **Scores:** importance × research_value × checkability (alle 0–1).
+  3. **Quotenauswahl klassenweise** (A vor B vor C) statt globaler Top-N.
+
+Gewichte/Schwellen/Quoten kommen aus ``relevance_policy_v1.json`` — Konfiguration,
+kein Code. Jede Auswahl trägt eine vollständige Auditspur (``ClaimAudit``).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import (
+    ClaimAudit, ClaimClass, MappedClaim, ROLE_TO_CLASS, SelectionResult,
+    STATUS_BASISFAKT_SKIPPED, STATUS_EXCLUDED_OPINION, STATUS_NOT_SELECTED_BUDGET,
+    STATUS_SELECTED, STATUS_UNDER_SPECIFIED,
+)
+from .schemas import IMPORTANCE_DIMS, RESEARCH_VALUE_DIMS
+
+DEFAULT_POLICY_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "config" / "relevance_policy_v1.json"
+)
+
+
+def load_policy(path: str | Path | None = None) -> dict:
+    """Lädt eine Policy-Datei (Default: ``src/config/relevance_policy_v1.json``)."""
+    p = Path(path) if path is not None else DEFAULT_POLICY_PATH
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+class PolicyScorer:
+    """Wählt aus gejointen Claims (S1+S2) deterministisch die Deep-Research-Menge."""
+
+    def __init__(self, policy: dict) -> None:
+        """Args: policy: geladene Policy-Konfiguration (s. ``load_policy``)."""
+        self._policy = policy
+        self._scale_max = float(policy["rating_scale"][1])
+        self._w_importance = policy["weights"]["importance"]
+        self._w_research = policy["weights"]["research_value"]
+        self._gates = policy["gates"]
+        self._quotas = policy["quotas"]
+
+    @classmethod
+    def from_file(cls, path: str | Path | None = None) -> "PolicyScorer":
+        """Bequemer Konstruktor aus einer Policy-Datei."""
+        return cls(load_policy(path))
+
+    @property
+    def policy_version(self) -> str:
+        return self._policy["policy_version"]
+
+    # --- Scores ------------------------------------------------------------
+
+    def _weighted_norm(self, ratings: dict, weights: dict, dims: tuple) -> float:
+        """Gewichtete Summe der 0–5-Ratings, normiert auf 0–1."""
+        max_sum = sum(weights[d] for d in dims) * self._scale_max
+        if max_sum <= 0:
+            return 0.0
+        got = sum(weights[d] * float(ratings.get(d, 0)) for d in dims)
+        return got / max_sum
+
+    def _checkability(self, claim: MappedClaim) -> float:
+        """0–1 aus S1-Feldern: Entität / Zeitraum / Metrik vorhanden? (Anteil von 3)."""
+        rc = claim.refined
+        present = sum((
+            bool(rc.entities),
+            bool(rc.timeframe),
+            bool(rc.metric),
+        ))
+        return present / 3.0
+
+    # --- Gates (Reihenfolge semantisch, Theorie §4.2) ----------------------
+
+    def _gate_status(self, claim: MappedClaim, checkability: float) -> str | None:
+        """Wendet die harten Gates an; gibt einen Ausschluss-Status oder ``None``
+        (= eligible) zurück. ``None`` bedeutet: geht ins Scoring/Quotenauswahl."""
+        claim_type = claim.refined.claim_type
+        role = claim.mapping.argument_role
+        claim_class = ROLE_TO_CLASS.get(role, ClaimClass.C)
+
+        # Gate 1 — Meinung/Deutung: gar nicht recherchieren.
+        if claim_type in self._gates.get("exclude_claim_types", []):
+            return STATUS_EXCLUDED_OPINION
+
+        # Gate 3 — Basisfakt (Metadaten-Rolle) ODER trivial: nur listen, nicht
+        # recherchieren. Trivialität = (Skalenmax − non_triviality); ab
+        # `triviality_skip_at` gilt der Claim als trivial. (Gate 2 = Kontext hat
+        # keinen Drop, sondern eine eigene kleine Quote in der Auswahl.)
+        if claim_class == ClaimClass.D:
+            return STATUS_BASISFAKT_SKIPPED
+        triviality = self._scale_max - float(claim.mapping.ratings.get("non_triviality", 0))
+        if triviality >= self._gates.get("triviality_skip_at", self._scale_max + 1):
+            return STATUS_BASISFAKT_SKIPPED
+
+        # Gate 4 — Attribution: kommt aus S1 bereits als eigener Claim gesplittet;
+        # hier keine Sonderbehandlung nötig.
+
+        # Gate 5 — zu vage: keinerlei prüfbare Anker (Entität/Zeitraum/Metrik) →
+        # flaggen, nicht recherchieren.
+        if checkability <= 0.0:
+            return STATUS_UNDER_SPECIFIED
+
+        return None
+
+    # --- Hauptlogik --------------------------------------------------------
+
+    def select(
+        self, claims: list[MappedClaim], budget: int | None = None,
+    ) -> SelectionResult:
+        """Wählt deterministisch die zu recherchierenden Claims aus.
+
+        Args:
+            claims: Gejointe S1+S2-Claims (``join_claims``).
+            budget: Deep-Research-Budget; Default aus der Policy
+                (``budget.deep_research_default``).
+
+        Returns:
+            ``SelectionResult`` mit Auswahl, vollständiger Auditspur und Zählwerten
+            für den späteren Transparenz-Block.
+        """
+        if budget is None:
+            budget = int(self._policy["budget"]["deep_research_default"])
+
+        version = self.policy_version
+        audit_by_id: dict[str, ClaimAudit] = {}
+        # eligible-Claims je Klasse, jeweils (priority, claim_id, claim) — Sortierung
+        # deterministisch: priority absteigend, dann claim_id aufsteigend.
+        eligible: dict[ClaimClass, list[tuple[float, str, MappedClaim]]] = {
+            ClaimClass.A: [], ClaimClass.B: [], ClaimClass.C: [],
+        }
+
+        for claim in claims:
+            importance = self._weighted_norm(
+                claim.mapping.ratings, self._w_importance, IMPORTANCE_DIMS
+            )
+            research_value = self._weighted_norm(
+                claim.mapping.ratings, self._w_research, RESEARCH_VALUE_DIMS
+            )
+            checkability = self._checkability(claim)
+            priority = importance * research_value * checkability
+            claim_class = ROLE_TO_CLASS.get(
+                claim.mapping.argument_role, ClaimClass.C
+            )
+
+            status = self._gate_status(claim, checkability)
+            audit_by_id[claim.claim_id] = ClaimAudit(
+                claim_id=claim.claim_id,
+                claim_class=claim_class.value,
+                status=status or STATUS_NOT_SELECTED_BUDGET,  # vorläufig; ggf. selected
+                selected=False,
+                importance=importance,
+                research_value=research_value,
+                checkability=checkability,
+                priority=priority,
+                policy_version=version,
+                reason="",
+            )
+            if status is None:
+                eligible[claim_class].append((priority, claim.claim_id, claim))
+
+        for bucket in eligible.values():
+            bucket.sort(key=lambda t: (-t[0], t[1]))
+
+        selected_ids = self._apply_quotas(eligible, budget)
+
+        # Audits finalisieren (Status + Begründung).
+        for rank, cid in enumerate(selected_ids, 1):
+            a = audit_by_id[cid]
+            a.selected = True
+            a.status = STATUS_SELECTED
+            a.reason = (
+                f"Klasse {a.claim_class}, priority {a.priority:.3f}, "
+                f"Auswahlrang {rank}/{len(selected_ids)} (Budget {budget})"
+            )
+        for a in audit_by_id.values():
+            if not a.reason:
+                a.reason = self._reason_for(a.status, a)
+
+        counts = self._counts(audit_by_id.values())
+        # Auditspur in Eingabereihenfolge der Claims (stabil).
+        audits = [audit_by_id[c.claim_id] for c in claims]
+        return SelectionResult(
+            policy_version=version,
+            budget=budget,
+            selected_ids=selected_ids,
+            audits=audits,
+            counts=counts,
+        )
+
+    def _apply_quotas(
+        self,
+        eligible: dict[ClaimClass, list[tuple[float, str, MappedClaim]]],
+        budget: int,
+    ) -> list[str]:
+        """Klassenweise Quotenauswahl (A vor B vor C), Budget als harte Obergrenze.
+
+        Erst werden die Klassenkontingente gefüllt (core/supporting-Anteil, Kontext-
+        Cap); bleibt danach Budget übrig, füllen die stärksten übrigen eligible
+        Claims in Klassenreihenfolge auf (Spill), damit Budget nicht verfällt.
+        """
+        core_cap = round(budget * self._quotas["core_claims_share"])
+        supp_cap = round(budget * self._quotas["supporting_share"])
+        ctx_cap = int(self._quotas["context_max_claims"])
+        caps = {ClaimClass.A: core_cap, ClaimClass.B: supp_cap, ClaimClass.C: ctx_cap}
+
+        selected: list[str] = []
+        taken: dict[ClaimClass, int] = {ClaimClass.A: 0, ClaimClass.B: 0, ClaimClass.C: 0}
+
+        # 1) Primärauswahl nach Klassenkontingent, in Klassenreihenfolge.
+        for cls in (ClaimClass.A, ClaimClass.B, ClaimClass.C):
+            for priority, cid, _claim in eligible[cls]:
+                if len(selected) >= budget or taken[cls] >= caps[cls]:
+                    break
+                selected.append(cid)
+                taken[cls] += 1
+
+        # 2) Spill: Restbudget mit stärksten übrigen eligible Claims füllen —
+        #    NUR Kern- (A) und tragende Subclaims (B). core/supporting-Anteile sind
+        #    weiche Shares (dürfen ineinander spillen), damit knappe Kontingente kein
+        #    Budget verschenken. `context_max_claims` ist dagegen ein HARTER Cap
+        #    (Theorie §4.3: Kontext ≤ wenige Claims) und wird beim Spill NICHT erhöht.
+        if len(selected) < budget:
+            chosen = set(selected)
+            for cls in (ClaimClass.A, ClaimClass.B):
+                for priority, cid, _claim in eligible[cls]:
+                    if len(selected) >= budget:
+                        break
+                    if cid not in chosen:
+                        selected.append(cid)
+                        chosen.add(cid)
+                if len(selected) >= budget:
+                    break
+
+        return selected
+
+    def _reason_for(self, status: str, audit: ClaimAudit) -> str:
+        """Menschlich lesbare Begründung je Nicht-Auswahl-Status."""
+        if status == STATUS_EXCLUDED_OPINION:
+            return "Gate 1: Meinung/Interpretation — nicht recherchiert"
+        if status == STATUS_BASISFAKT_SKIPPED:
+            return "Gate 3: Basisfakt/trivial — nur gelistet, nicht recherchiert"
+        if status == STATUS_UNDER_SPECIFIED:
+            return "Gate 5: zu vage (kein prüfbarer Anker) — flag, nicht recherchiert"
+        return (
+            f"Klasse {audit.claim_class}, priority {audit.priority:.3f} — "
+            "eligible, aber Budget/Quote erschöpft"
+        )
+
+    @staticmethod
+    def _counts(audits) -> dict[str, int]:
+        """Zählwerte für den späteren Transparenz-Block."""
+        counts = {
+            "extracted": 0,
+            STATUS_SELECTED: 0,
+            STATUS_BASISFAKT_SKIPPED: 0,
+            STATUS_EXCLUDED_OPINION: 0,
+            STATUS_UNDER_SPECIFIED: 0,
+            STATUS_NOT_SELECTED_BUDGET: 0,
+        }
+        for a in audits:
+            counts["extracted"] += 1
+            counts[a.status] = counts.get(a.status, 0) + 1
+        return counts

--- a/src/core/factcheck_plus/policy_scorer.py
+++ b/src/core/factcheck_plus/policy_scorer.py
@@ -25,15 +25,51 @@ from .models import (
     STATUS_BASISFAKT_SKIPPED, STATUS_EXCLUDED_OPINION, STATUS_NOT_SELECTED_BUDGET,
     STATUS_SELECTED, STATUS_UNDER_SPECIFIED,
 )
-from .schemas import IMPORTANCE_DIMS, RESEARCH_VALUE_DIMS
+from .schemas import IMPORTANCE_DIMS, RATING_MAX, RATING_MIN, RESEARCH_VALUE_DIMS
 
 DEFAULT_POLICY_PATH = (
     Path(__file__).resolve().parent.parent.parent / "config" / "relevance_policy_v1.json"
 )
 
+# Unterstützte Gate-Routen → Audit-Status. Die Policy-Felder `basisfakt_route` /
+# `under_specified_route` sind damit wirksam (nicht dekorativ): ein unbekannter
+# Wert schlägt bei der Konstruktion fehl, statt still ignoriert zu werden. Weitere
+# Routen (z.B. eigene Schnellprüfung) hängen sich hier an.
+_BASISFAKT_ROUTE_STATUS = {"skip_listed_only": STATUS_BASISFAKT_SKIPPED}
+_UNDER_SPECIFIED_ROUTE_STATUS = {"flag_not_research": STATUS_UNDER_SPECIFIED}
+
+
+def _resolve_route(route_map: dict, value: str | None, field: str) -> str:
+    """Löst einen konfigurierten Gate-Routen-Wert in seinen Audit-Status auf.
+
+    Args:
+        route_map: Zulässige Routen → Status.
+        value: Der in der Policy konfigurierte Routen-Wert.
+        field: Feldname (für die Fehlermeldung).
+
+    Returns:
+        Der Audit-Status für diese Route.
+
+    Raises:
+        ValueError: Wenn ``value`` keine unterstützte Route ist.
+    """
+    if value not in route_map:
+        raise ValueError(
+            f"Unbekannte {field}={value!r}; unterstützt: {sorted(route_map)}"
+        )
+    return route_map[value]
+
 
 def load_policy(path: str | Path | None = None) -> dict:
-    """Lädt eine Policy-Datei (Default: ``src/config/relevance_policy_v1.json``)."""
+    """Lädt eine Policy-Datei.
+
+    Args:
+        path: Pfad zur Policy-JSON (``str`` oder ``Path``). ``None`` (Default) nutzt
+            ``src/config/relevance_policy_v1.json`` (``DEFAULT_POLICY_PATH``).
+
+    Returns:
+        Die geparste Policy als ``dict``.
+    """
     p = Path(path) if path is not None else DEFAULT_POLICY_PATH
     return json.loads(p.read_text(encoding="utf-8"))
 
@@ -42,13 +78,39 @@ class PolicyScorer:
     """Wählt aus gejointen Claims (S1+S2) deterministisch die Deep-Research-Menge."""
 
     def __init__(self, policy: dict) -> None:
-        """Args: policy: geladene Policy-Konfiguration (s. ``load_policy``)."""
+        """Initialisiert den Scorer aus einer geladenen Policy.
+
+        Args:
+            policy: Policy-Konfiguration (s. :func:`load_policy`) mit
+                ``rating_scale``, ``weights``, ``gates``, ``quotas`` und ``budget``.
+
+        Raises:
+            ValueError: Wenn ``rating_scale`` nicht zu den Schema-Grenzen
+                (``RATING_MIN``/``RATING_MAX``) passt oder eine Gate-Route
+                (``basisfakt_route`` / ``under_specified_route``) unbekannt ist.
+        """
         self._policy = policy
-        self._scale_max = float(policy["rating_scale"][1])
+        # Rating-Skala EINE Quelle: muss zu den Schema-Grenzen passen, damit
+        # Validierung (Schema) und Scoring dieselben Min/Max nutzen.
+        scale = [int(policy["rating_scale"][0]), int(policy["rating_scale"][1])]
+        if scale != [RATING_MIN, RATING_MAX]:
+            raise ValueError(
+                f"rating_scale {scale} passt nicht zu Schema-Grenzen "
+                f"[{RATING_MIN}, {RATING_MAX}]"
+            )
+        self._scale_max = float(RATING_MAX)
         self._w_importance = policy["weights"]["importance"]
         self._w_research = policy["weights"]["research_value"]
         self._gates = policy["gates"]
         self._quotas = policy["quotas"]
+        # Gate-Routen aus der Config auflösen (unbekannter Wert → sofortiger Fehler).
+        self._basisfakt_status = _resolve_route(
+            _BASISFAKT_ROUTE_STATUS, self._gates.get("basisfakt_route"), "basisfakt_route"
+        )
+        self._under_specified_status = _resolve_route(
+            _UNDER_SPECIFIED_ROUTE_STATUS,
+            self._gates.get("under_specified_route"), "under_specified_route",
+        )
 
     @classmethod
     def from_file(cls, path: str | Path | None = None) -> "PolicyScorer":
@@ -57,6 +119,7 @@ class PolicyScorer:
 
     @property
     def policy_version(self) -> str:
+        """Gibt die Versionskennung der aktiven Policy zurück (z.B. ``relevance-de-v1``)."""
         return self._policy["policy_version"]
 
     # --- Scores ------------------------------------------------------------
@@ -81,34 +144,40 @@ class PolicyScorer:
 
     # --- Gates (Reihenfolge semantisch, Theorie §4.2) ----------------------
 
-    def _gate_status(self, claim: MappedClaim, checkability: float) -> str | None:
+    def _gate_status(
+        self, claim: MappedClaim, claim_class: ClaimClass, checkability: float,
+    ) -> str | None:
         """Wendet die harten Gates an; gibt einen Ausschluss-Status oder ``None``
-        (= eligible) zurück. ``None`` bedeutet: geht ins Scoring/Quotenauswahl."""
+        (= eligible) zurück. ``None`` bedeutet: geht ins Scoring/Quotenauswahl.
+
+        Args:
+            claim: Der gejointe Claim (S1+S2).
+            claim_class: Bereits im Aufrufer bestimmte Arbeitsklasse (A/B/C/D).
+            checkability: Vorab berechnete Checkability (0–1).
+        """
         claim_type = claim.refined.claim_type
-        role = claim.mapping.argument_role
-        claim_class = ROLE_TO_CLASS.get(role, ClaimClass.C)
 
         # Gate 1 — Meinung/Deutung: gar nicht recherchieren.
         if claim_type in self._gates.get("exclude_claim_types", []):
             return STATUS_EXCLUDED_OPINION
 
-        # Gate 3 — Basisfakt (Metadaten-Rolle) ODER trivial: nur listen, nicht
-        # recherchieren. Trivialität = (Skalenmax − non_triviality); ab
-        # `triviality_skip_at` gilt der Claim als trivial. (Gate 2 = Kontext hat
+        # Gate 3 — Basisfakt (Metadaten-Rolle) ODER trivial: gemäß `basisfakt_route`
+        # nur listen, nicht recherchieren. Trivialität = (Skalenmax − non_triviality);
+        # ab `triviality_skip_at` gilt der Claim als trivial. (Gate 2 = Kontext hat
         # keinen Drop, sondern eine eigene kleine Quote in der Auswahl.)
         if claim_class == ClaimClass.D:
-            return STATUS_BASISFAKT_SKIPPED
+            return self._basisfakt_status
         triviality = self._scale_max - float(claim.mapping.ratings.get("non_triviality", 0))
         if triviality >= self._gates.get("triviality_skip_at", self._scale_max + 1):
-            return STATUS_BASISFAKT_SKIPPED
+            return self._basisfakt_status
 
         # Gate 4 — Attribution: kommt aus S1 bereits als eigener Claim gesplittet;
         # hier keine Sonderbehandlung nötig.
 
         # Gate 5 — zu vage: keinerlei prüfbare Anker (Entität/Zeitraum/Metrik) →
-        # flaggen, nicht recherchieren.
+        # gemäß `under_specified_route` flaggen, nicht recherchieren.
         if checkability <= 0.0:
-            return STATUS_UNDER_SPECIFIED
+            return self._under_specified_status
 
         return None
 
@@ -152,7 +221,7 @@ class PolicyScorer:
                 claim.mapping.argument_role, ClaimClass.C
             )
 
-            status = self._gate_status(claim, checkability)
+            status = self._gate_status(claim, claim_class, checkability)
             audit_by_id[claim.claim_id] = ClaimAudit(
                 claim_id=claim.claim_id,
                 claim_class=claim_class.value,

--- a/src/core/factcheck_plus/schemas.py
+++ b/src/core/factcheck_plus/schemas.py
@@ -32,6 +32,12 @@ RESEARCH_VALUE_DIMS = (
 )
 RATING_DIMS = IMPORTANCE_DIMS + RESEARCH_VALUE_DIMS
 
+# Rating-Skala (0–5) als EINE benannte Quelle: das Schema (unten) und der
+# PolicyScorer (der policy["rating_scale"] dagegen prüft) teilen sich diese
+# Grenzen, statt 0/5 mehrfach hartzukodieren.
+RATING_MIN = 0
+RATING_MAX = 5
+
 
 # --- Schemas (JSON-Schema-Teilmenge) --------------------------------------
 
@@ -63,7 +69,7 @@ ARGUMENT_MAPPING_SCHEMA: dict = {
             "type": "object",
             "required": list(RATING_DIMS),
             "properties": {
-                dim: {"type": "integer", "minimum": 0, "maximum": 5}
+                dim: {"type": "integer", "minimum": RATING_MIN, "maximum": RATING_MAX}
                 for dim in RATING_DIMS
             },
         },

--- a/src/core/factcheck_plus/schemas.py
+++ b/src/core/factcheck_plus/schemas.py
@@ -1,0 +1,135 @@
+"""JSON-Schema-Verträge für Faktencheck Plus (v0.13.0, PR 1).
+
+Die Feldnamen sind **verbindlich** (Spec §3/S3): Refiner (S1) und Mapper (S2)
+liefern in PR 2 Objekte gegen genau diese Schemas; PR 1 validiert Fixtures damit.
+Bewusst abhängigkeitsfrei — ein kleiner Validator deckt die genutzte
+JSON-Schema-Teilmenge ab (type/enum/required/properties/items/minimum/maximum),
+statt eine externe `jsonschema`-Dependency einzuführen.
+"""
+from __future__ import annotations
+
+# --- Erlaubte Wertemengen (auch von models.py genutzt) --------------------
+
+# Claim-Typen: die 6 faktischen (S1) + opinion/interpretation, damit Gate 1
+# (exclude_claim_types) überhaupt greifen kann, falls ein Nicht-Faktum aus
+# Stufe 1 durchrutscht.
+CLAIM_TYPES = (
+    "quantitative", "causal", "hard_fact", "prognosis",
+    "source_attribution", "methodological", "opinion", "interpretation",
+)
+ARGUMENT_ROLES = (
+    "core_claim", "supporting_premise", "context", "example", "metadata",
+)
+COUNTERFACTUAL_IMPACT = ("high", "medium", "low")
+
+IMPORTANCE_DIMS = (
+    "thesis_proximity", "conclusion_dependency", "harm_potential",
+    "reach_mobilization", "concreteness",
+)
+RESEARCH_VALUE_DIMS = (
+    "non_triviality", "recency", "contestedness",
+    "source_access", "evidence_gap", "discrepancy_potential",
+)
+RATING_DIMS = IMPORTANCE_DIMS + RESEARCH_VALUE_DIMS
+
+
+# --- Schemas (JSON-Schema-Teilmenge) --------------------------------------
+
+REFINED_CLAIM_SCHEMA: dict = {
+    "type": "object",
+    "required": [
+        "claim_id", "original_text", "normalized_claim", "claim_type", "entities",
+    ],
+    "properties": {
+        "claim_id": {"type": "string"},
+        "parent_id": {"type": ["string", "null"]},
+        "original_text": {"type": "string"},
+        "normalized_claim": {"type": "string"},
+        "claim_type": {"enum": list(CLAIM_TYPES)},
+        "entities": {"type": "array", "items": {"type": "string"}},
+        "timeframe": {"type": ["string", "null"]},
+        "metric": {"type": ["string", "null"]},
+    },
+}
+
+ARGUMENT_MAPPING_SCHEMA: dict = {
+    "type": "object",
+    "required": ["claim_id", "argument_role", "counterfactual_impact", "ratings"],
+    "properties": {
+        "claim_id": {"type": "string"},
+        "argument_role": {"enum": list(ARGUMENT_ROLES)},
+        "counterfactual_impact": {"enum": list(COUNTERFACTUAL_IMPACT)},
+        "ratings": {
+            "type": "object",
+            "required": list(RATING_DIMS),
+            "properties": {
+                dim: {"type": "integer", "minimum": 0, "maximum": 5}
+                for dim in RATING_DIMS
+            },
+        },
+        "reason": {"type": "string"},
+    },
+}
+
+
+class SchemaError(ValueError):
+    """Ein Instanzobjekt verletzt seinen JSON-Schema-Vertrag."""
+
+
+_PY_TYPES = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "boolean": bool,
+    "null": type(None),
+}
+
+
+def _matches_type(value: object, type_name: str) -> bool:
+    """Prüft einen einzelnen JSON-Schema-Typ (bool ist NICHT integer/number)."""
+    if type_name in ("integer", "number"):
+        if isinstance(value, bool):
+            return False
+        return isinstance(value, int) if type_name == "integer" else isinstance(value, (int, float))
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    return isinstance(value, _PY_TYPES[type_name])
+
+
+def validate(instance: object, schema: dict, path: str = "$") -> None:
+    """Validiert ``instance`` gegen ``schema`` (unterstützte JSON-Schema-Teilmenge).
+
+    Args:
+        instance: Das zu prüfende Objekt.
+        schema: Schema-Dict (type/enum/required/properties/items/minimum/maximum).
+        path: Pfad zum aktuellen Knoten (für sprechende Fehlermeldungen).
+
+    Raises:
+        SchemaError: Bei der ersten festgestellten Verletzung.
+    """
+    if "enum" in schema:
+        if instance not in schema["enum"]:
+            raise SchemaError(f"{path}: {instance!r} nicht in {schema['enum']}")
+
+    if "type" in schema:
+        types = schema["type"] if isinstance(schema["type"], list) else [schema["type"]]
+        if not any(_matches_type(instance, t) for t in types):
+            raise SchemaError(f"{path}: Typ {type(instance).__name__} passt nicht zu {types}")
+
+    if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+        if "minimum" in schema and instance < schema["minimum"]:
+            raise SchemaError(f"{path}: {instance} < minimum {schema['minimum']}")
+        if "maximum" in schema and instance > schema["maximum"]:
+            raise SchemaError(f"{path}: {instance} > maximum {schema['maximum']}")
+
+    if isinstance(instance, dict):
+        for req in schema.get("required", []):
+            if req not in instance:
+                raise SchemaError(f"{path}: Pflichtfeld '{req}' fehlt")
+        for key, subschema in schema.get("properties", {}).items():
+            if key in instance:
+                validate(instance[key], subschema, f"{path}.{key}")
+
+    if isinstance(instance, list) and "items" in schema:
+        for i, item in enumerate(instance):
+            validate(item, schema["items"], f"{path}[{i}]")

--- a/tests/test_policy_scorer.py
+++ b/tests/test_policy_scorer.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.core.factcheck_plus import (
     ArgumentMapping, MappedClaim, PolicyScorer, RefinedClaim, SchemaError,
-    join_claims, load_policy,
+    SelectionResult, join_claims, load_policy,
 )
 from src.core.factcheck_plus.schemas import IMPORTANCE_DIMS, RESEARCH_VALUE_DIMS
 
@@ -26,9 +26,10 @@ from src.core.factcheck_plus.schemas import IMPORTANCE_DIMS, RESEARCH_VALUE_DIMS
 # --- Fixture-Helfer (simulieren S1/S2, LLM-frei) --------------------------
 
 def _claim(
-    cid, role="core_claim", claim_type="quantitative",
-    entities=("Entität",), timeframe="2025", metric="Prozent",
-    importance=4, research=4, parent_id=None, **rating_overrides,
+    cid: str, role: str = "core_claim", claim_type: str = "quantitative",
+    entities: tuple[str, ...] = ("Entität",), timeframe: str | None = "2025",
+    metric: str | None = "Prozent", importance: int = 4, research: int = 4,
+    parent_id: str | None = None, **rating_overrides: int,
 ) -> MappedClaim:
     refined = RefinedClaim(
         claim_id=cid, original_text=f"o-{cid}", normalized_claim=f"n-{cid}",
@@ -49,7 +50,7 @@ def _scorer() -> PolicyScorer:
     return PolicyScorer.from_file()
 
 
-def _classes(result, ids):
+def _classes(result: SelectionResult, ids: list[str]) -> list[str]:
     by_id = {a.claim_id: a for a in result.audits}
     return [by_id[i].claim_class for i in ids]
 
@@ -217,11 +218,13 @@ def test_refined_claim_from_dict_valid_and_invalid():
     rc = RefinedClaim.from_dict(_valid_refined_dict())
     assert rc.claim_id == "c1" and rc.entities == ["X"]
     # ungültiger claim_type
-    bad = _valid_refined_dict(); bad["claim_type"] = "banana"
+    bad = _valid_refined_dict()
+    bad["claim_type"] = "banana"
     with pytest.raises(SchemaError):
         RefinedClaim.from_dict(bad)
     # Pflichtfeld fehlt
-    missing = _valid_refined_dict(); del missing["normalized_claim"]
+    missing = _valid_refined_dict()
+    del missing["normalized_claim"]
     with pytest.raises(SchemaError):
         RefinedClaim.from_dict(missing)
     print("  refined_claim_from_dict_valid_and_invalid OK")
@@ -231,15 +234,18 @@ def test_argument_mapping_from_dict_validates_ratings():
     am = ArgumentMapping.from_dict(_valid_mapping_dict())
     assert am.argument_role == "core_claim"
     # Rating außerhalb 0–5
-    bad = _valid_mapping_dict(); bad["ratings"]["recency"] = 9
+    bad = _valid_mapping_dict()
+    bad["ratings"]["recency"] = 9
     with pytest.raises(SchemaError):
         ArgumentMapping.from_dict(bad)
     # Rating-Dimension fehlt
-    missing = _valid_mapping_dict(); del missing["ratings"]["harm_potential"]
+    missing = _valid_mapping_dict()
+    del missing["ratings"]["harm_potential"]
     with pytest.raises(SchemaError):
         ArgumentMapping.from_dict(missing)
     # ungültige Rolle
-    role = _valid_mapping_dict(); role["argument_role"] = "boss"
+    role = _valid_mapping_dict()
+    role["argument_role"] = "boss"
     with pytest.raises(SchemaError):
         ArgumentMapping.from_dict(role)
     print("  argument_mapping_from_dict_validates_ratings OK")
@@ -258,6 +264,39 @@ def test_join_claims_matches_and_reports_mismatch():
 
 
 # --- Policy-Datei ---------------------------------------------------------
+
+def test_unsupported_gate_route_raises():
+    import copy
+    base = load_policy()
+    bad_basis = copy.deepcopy(base)
+    bad_basis["gates"]["basisfakt_route"] = "delete_everything"
+    with pytest.raises(ValueError):
+        PolicyScorer(bad_basis)
+    bad_us = copy.deepcopy(base)
+    bad_us["gates"]["under_specified_route"] = "yolo"
+    with pytest.raises(ValueError):
+        PolicyScorer(bad_us)
+    print("  unsupported_gate_route_raises OK")
+
+
+def test_rating_scale_mismatch_raises():
+    import copy
+    base = load_policy()
+    bad = copy.deepcopy(base)
+    bad["rating_scale"] = [0, 4]  # passt nicht zu den Schema-Grenzen [0, 5]
+    with pytest.raises(ValueError):
+        PolicyScorer(bad)
+    print("  rating_scale_mismatch_raises OK")
+
+
+def test_join_duplicate_refined_raises():
+    a = RefinedClaim.from_dict(_valid_refined_dict())
+    b = RefinedClaim.from_dict(_valid_refined_dict())  # gleiche claim_id 'c1'
+    mapping = ArgumentMapping.from_dict(_valid_mapping_dict())
+    with pytest.raises(ValueError):
+        join_claims([a, b], [mapping])
+    print("  join_duplicate_refined_raises OK")
+
 
 def test_policy_file_encodes_po_decisions():
     policy = load_policy()
@@ -287,6 +326,9 @@ def main():
     test_refined_claim_from_dict_valid_and_invalid()
     test_argument_mapping_from_dict_validates_ratings()
     test_join_claims_matches_and_reports_mismatch()
+    test_unsupported_gate_route_raises()
+    test_rating_scale_mismatch_raises()
+    test_join_duplicate_refined_raises()
     test_policy_file_encodes_po_decisions()
     print("ALLE TESTS OK")
 

--- a/tests/test_policy_scorer.py
+++ b/tests/test_policy_scorer.py
@@ -1,0 +1,295 @@
+"""Tests für Faktencheck Plus PR 1: PolicyScorer + Verträge (v0.13.0).
+
+Deckt die Spec-/Architekten-Leitplanken ab:
+- Gates VOR Scores, in semantischer Reihenfolge (Theorie §4.2).
+- Quotenauswahl klassenweise (A vor B vor C) statt globaler Top-N.
+- Strikt deterministisch: gleicher (auch umsortierter) Input → gleiche Auswahl.
+- Basisfakten fallen aus der Auswahl und verdrängen nie einen Kernclaim.
+- Audit ab Tag eins: Score-Komponenten + Policy-Version + Begründung.
+
+Lauf (ohne pytest):  python tests/test_policy_scorer.py
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.factcheck_plus import (
+    ArgumentMapping, MappedClaim, PolicyScorer, RefinedClaim, SchemaError,
+    join_claims, load_policy,
+)
+from src.core.factcheck_plus.schemas import IMPORTANCE_DIMS, RESEARCH_VALUE_DIMS
+
+
+# --- Fixture-Helfer (simulieren S1/S2, LLM-frei) --------------------------
+
+def _claim(
+    cid, role="core_claim", claim_type="quantitative",
+    entities=("Entität",), timeframe="2025", metric="Prozent",
+    importance=4, research=4, parent_id=None, **rating_overrides,
+) -> MappedClaim:
+    refined = RefinedClaim(
+        claim_id=cid, original_text=f"o-{cid}", normalized_claim=f"n-{cid}",
+        claim_type=claim_type, entities=list(entities), timeframe=timeframe,
+        metric=metric, parent_id=parent_id,
+    )
+    ratings = {d: importance for d in IMPORTANCE_DIMS}
+    ratings.update({d: research for d in RESEARCH_VALUE_DIMS})
+    ratings.update(rating_overrides)
+    mapping = ArgumentMapping(
+        claim_id=cid, argument_role=role, counterfactual_impact="high",
+        ratings=ratings, reason="",
+    )
+    return MappedClaim(refined=refined, mapping=mapping)
+
+
+def _scorer() -> PolicyScorer:
+    return PolicyScorer.from_file()
+
+
+def _classes(result, ids):
+    by_id = {a.claim_id: a for a in result.audits}
+    return [by_id[i].claim_class for i in ids]
+
+
+# --- Gates ----------------------------------------------------------------
+
+def test_gate_excludes_opinion_and_interpretation():
+    claims = [
+        _claim("op", claim_type="opinion"),
+        _claim("ip", claim_type="interpretation"),
+        _claim("ok", claim_type="quantitative"),
+    ]
+    res = _scorer().select(claims, budget=8)
+    status = {a.claim_id: a.status for a in res.audits}
+    assert status["op"] == "excluded_opinion"
+    assert status["ip"] == "excluded_opinion"
+    assert "op" not in res.selected_ids and "ip" not in res.selected_ids
+    assert "ok" in res.selected_ids
+    print("  gate_excludes_opinion_and_interpretation OK")
+
+
+def test_gate_basisfakt_metadata_skipped():
+    # Perfekter Basisfakt (max Ratings, volle Checkability) darf NICHT recherchiert werden.
+    claims = [_claim("meta", role="metadata", importance=5, research=5)]
+    res = _scorer().select(claims, budget=8)
+    assert res.audits[0].status == "basisfakt_skipped"
+    assert res.selected_ids == []
+    print("  gate_basisfakt_metadata_skipped OK")
+
+
+def test_gate_triviality_threshold():
+    # triviality = 5 - non_triviality; skip ab >= 4  →  non_triviality <= 1.
+    skipped = _claim("triv", non_triviality=1)      # triviality 4 → skip
+    eligible = _claim("keep", non_triviality=2)     # triviality 3 → eligible
+    res = _scorer().select([skipped, eligible], budget=8)
+    status = {a.claim_id: a.status for a in res.audits}
+    assert status["triv"] == "basisfakt_skipped"
+    assert "keep" in res.selected_ids
+    print("  gate_triviality_threshold OK")
+
+
+def test_gate_under_specified_when_no_anchor():
+    vague = _claim("vague", entities=(), timeframe=None, metric=None)
+    res = _scorer().select([vague], budget=8)
+    assert res.audits[0].status == "under_specified"
+    assert res.audits[0].checkability == 0.0
+    assert res.selected_ids == []
+    print("  gate_under_specified_when_no_anchor OK")
+
+
+# --- Quoten & Klassen-Priorität ------------------------------------------
+
+def test_quota_is_class_wise_not_global_top_n():
+    # B-Claims scoren HÖHER als A-Claims. Globales Top-N würde B bevorzugen;
+    # klassenweise Quote muss trotzdem zuerst die Kernclaims (A) füllen.
+    a_claims = [_claim(f"a{i}", role="core_claim", importance=2, research=2) for i in range(4)]
+    b_claims = [_claim(f"b{i}", role="supporting_premise", importance=5, research=5) for i in range(4)]
+    res = _scorer().select(a_claims + b_claims, budget=5)
+    # budget 5: core_cap=round(3.0)=3, supp_cap=round(1.5)=2 → 3 A + 2 B
+    classes = _classes(res, res.selected_ids)
+    assert classes.count("A") == 3, classes
+    assert classes.count("B") == 2, classes
+    assert len(res.selected_ids) == 5
+    print("  quota_is_class_wise_not_global_top_n OK")
+
+
+def test_context_quota_capped():
+    context = [_claim(f"c{i}", role="context", importance=5, research=5) for i in range(5)]
+    res = _scorer().select(context, budget=8)
+    # context_max_claims = 2 → nur 2 Kontextclaims, Rest not_selected_budget
+    assert len(res.selected_ids) == 2
+    assert all(a.claim_class == "C" for a in res.selected_audits())
+    print("  context_quota_capped OK")
+
+
+def test_basisfakt_never_displaces_core():
+    # Regression: "Das ZDF ist öffentlich-rechtlich" (Basisfakt, perfekt prüfbar)
+    # darf keinen Kernclaim aus der Auswahl drängen.
+    basisfakt = _claim("zdf", role="metadata", importance=5, research=5)
+    core = _claim("kern", role="core_claim", importance=3, research=3)
+    res = _scorer().select([basisfakt, core], budget=1)
+    assert res.selected_ids == ["kern"]
+    status = {a.claim_id: a.status for a in res.audits}
+    assert status["zdf"] == "basisfakt_skipped"
+    print("  basisfakt_never_displaces_core OK")
+
+
+def test_budget_default_from_policy():
+    # Genügend eligible Kernclaims → Auswahl exakt auf Policy-Default (8) gekappt.
+    claims = [_claim(f"a{i}", role="core_claim") for i in range(20)]
+    res = _scorer().select(claims)  # kein budget → Default 8
+    assert res.budget == 8
+    assert len(res.selected_ids) == 8
+    print("  budget_default_from_policy OK")
+
+
+# --- Determinismus --------------------------------------------------------
+
+def test_deterministic_same_and_shuffled_input():
+    claims = (
+        [_claim(f"a{i}", role="core_claim", importance=5 - (i % 3), research=4) for i in range(5)]
+        + [_claim(f"b{i}", role="supporting_premise", importance=3, research=3) for i in range(3)]
+        + [_claim(f"c{i}", role="context") for i in range(3)]
+    )
+    scorer = _scorer()
+    first = scorer.select(list(claims), budget=6).selected_ids
+    again = scorer.select(list(claims), budget=6).selected_ids
+    reversed_in = scorer.select(list(reversed(claims)), budget=6).selected_ids
+    assert first == again, (first, again)
+    assert first == reversed_in, (first, reversed_in)  # unabhängig von Eingabereihenfolge
+    print("  deterministic_same_and_shuffled_input OK")
+
+
+# --- Audit ----------------------------------------------------------------
+
+def test_audit_completeness_and_priority_math():
+    res = _scorer().select([_claim("x", importance=4, research=2)], budget=8)
+    a = res.audits[0]
+    assert a.policy_version == "relevance-de-v1"
+    # priority = importance × research_value × checkability (alle 0–1)
+    assert abs(a.priority - a.importance * a.research_value * a.checkability) < 1e-9
+    assert 0.0 <= a.importance <= 1.0 and 0.0 <= a.research_value <= 1.0
+    assert a.checkability == 1.0  # Entität + Zeitraum + Metrik vorhanden
+    assert a.selected and a.status == "selected" and "Auswahlrang 1/1" in a.reason
+    # counts summieren auf extracted
+    assert res.counts["extracted"] == 1 and res.counts["selected"] == 1
+    print("  audit_completeness_and_priority_math OK")
+
+
+def test_counts_sum_to_extracted():
+    claims = [
+        _claim("sel", role="core_claim"),
+        _claim("op", claim_type="opinion"),
+        _claim("meta", role="metadata"),
+        _claim("vague", entities=(), timeframe=None, metric=None),
+    ]
+    res = _scorer().select(claims, budget=8)
+    total = (res.counts["selected"] + res.counts["excluded_opinion"]
+             + res.counts["basisfakt_skipped"] + res.counts["under_specified"]
+             + res.counts["not_selected_budget"])
+    assert total == res.counts["extracted"] == 4
+    print("  counts_sum_to_extracted OK")
+
+
+# --- Verträge (Schema-Validierung) ----------------------------------------
+
+def _valid_refined_dict():
+    return {
+        "claim_id": "c1", "parent_id": None,
+        "original_text": "o", "normalized_claim": "n",
+        "claim_type": "quantitative", "entities": ["X"],
+        "timeframe": "2025", "metric": "Prozent",
+    }
+
+
+def _valid_mapping_dict():
+    ratings = {d: 3 for d in (IMPORTANCE_DIMS + RESEARCH_VALUE_DIMS)}
+    return {
+        "claim_id": "c1", "argument_role": "core_claim",
+        "counterfactual_impact": "high", "ratings": ratings, "reason": "r",
+    }
+
+
+def test_refined_claim_from_dict_valid_and_invalid():
+    rc = RefinedClaim.from_dict(_valid_refined_dict())
+    assert rc.claim_id == "c1" and rc.entities == ["X"]
+    # ungültiger claim_type
+    bad = _valid_refined_dict(); bad["claim_type"] = "banana"
+    with pytest.raises(SchemaError):
+        RefinedClaim.from_dict(bad)
+    # Pflichtfeld fehlt
+    missing = _valid_refined_dict(); del missing["normalized_claim"]
+    with pytest.raises(SchemaError):
+        RefinedClaim.from_dict(missing)
+    print("  refined_claim_from_dict_valid_and_invalid OK")
+
+
+def test_argument_mapping_from_dict_validates_ratings():
+    am = ArgumentMapping.from_dict(_valid_mapping_dict())
+    assert am.argument_role == "core_claim"
+    # Rating außerhalb 0–5
+    bad = _valid_mapping_dict(); bad["ratings"]["recency"] = 9
+    with pytest.raises(SchemaError):
+        ArgumentMapping.from_dict(bad)
+    # Rating-Dimension fehlt
+    missing = _valid_mapping_dict(); del missing["ratings"]["harm_potential"]
+    with pytest.raises(SchemaError):
+        ArgumentMapping.from_dict(missing)
+    # ungültige Rolle
+    role = _valid_mapping_dict(); role["argument_role"] = "boss"
+    with pytest.raises(SchemaError):
+        ArgumentMapping.from_dict(role)
+    print("  argument_mapping_from_dict_validates_ratings OK")
+
+
+def test_join_claims_matches_and_reports_mismatch():
+    refined = [RefinedClaim.from_dict(_valid_refined_dict())]
+    mapping = [ArgumentMapping.from_dict(_valid_mapping_dict())]
+    joined = join_claims(refined, mapping)
+    assert len(joined) == 1 and joined[0].claim_id == "c1"
+    # fehlendes Mapping
+    orphan = RefinedClaim.from_dict({**_valid_refined_dict(), "claim_id": "c2"})
+    with pytest.raises(ValueError):
+        join_claims([orphan], mapping)
+    print("  join_claims_matches_and_reports_mismatch OK")
+
+
+# --- Policy-Datei ---------------------------------------------------------
+
+def test_policy_file_encodes_po_decisions():
+    policy = load_policy()
+    assert policy["policy_version"] == "relevance-de-v1"
+    assert policy["budget"]["deep_research_default"] == 8  # PO §8.1
+    assert policy["gates"]["basisfakt_route"] == "skip_listed_only"  # PO §8.2
+    assert policy["gates"]["exclude_claim_types"] == ["opinion", "interpretation"]
+    # Alle Rating-Dimensionen haben ein Gewicht
+    weighted = set(policy["weights"]["importance"]) | set(policy["weights"]["research_value"])
+    assert weighted == set(IMPORTANCE_DIMS) | set(RESEARCH_VALUE_DIMS)
+    print("  policy_file_encodes_po_decisions OK")
+
+
+def main():
+    print("Faktencheck Plus PR 1 — PolicyScorer & Verträge:")
+    test_gate_excludes_opinion_and_interpretation()
+    test_gate_basisfakt_metadata_skipped()
+    test_gate_triviality_threshold()
+    test_gate_under_specified_when_no_anchor()
+    test_quota_is_class_wise_not_global_top_n()
+    test_context_quota_capped()
+    test_basisfakt_never_displaces_core()
+    test_budget_default_from_policy()
+    test_deterministic_same_and_shuffled_input()
+    test_audit_completeness_and_priority_math()
+    test_counts_sum_to_extracted()
+    test_refined_claim_from_dict_valid_and_invalid()
+    test_argument_mapping_from_dict_validates_ratings()
+    test_join_claims_matches_and_reports_mismatch()
+    test_policy_file_encodes_po_decisions()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Ziel
Erstes Inkrement von **Faktencheck Plus** (`SOMAS_v0.13.0_SPEC` §7, PR 1): das **LLM-freie Fundament** — Datenmodelle + JSON-Verträge (S1/S2) und der deterministische **PolicyScorer** (S3) inkl. `relevance_policy_v1.json`. Merge-Kriterium: **offline grün, kein `APP_VERSION`-Bump** (erst PR 4).

## Architekten-Leitplanken → umgesetzt
1. **Strikt deterministisch, kein LLM, keine Zufälle** — eigener Determinismus-Test (auch bei umsortiertem Input identische Auswahl). §6.
2. **`relevance_policy_v1.json` kodiert die PO-Entscheidungen (§8):** Budget-Default **8**, Basisfakten **raus** aus der Auswahl (`skip_listed_only`; die „nur Titelzeile"-Darstellung folgt in PR 3/4).
3. **Gates VOR Scores**, in der semantischen Reihenfolge aus Theorie §4.2; **Quotenauswahl klassenweise** (A vor B vor C) statt globaler Top-N (`context_max_claims` = harter Cap).
4. **Audit ab Tag eins:** jede Auswahl trägt Score-Komponenten + Policy-Version + Begründung — Datenquelle des späteren Transparenz-Blocks. **PR 1 bleibt LLM-frei**; der Scorer konsumiert nur Felder, die S1/S2 später liefern, hier per Fixtures simuliert.

## Inhalt
`src/core/factcheck_plus/` (bewusst **ohne Qt-Import** → später als `factcheck_core` extrahierbar, Spec §2.2):
- **`schemas.py`** — `REFINED_CLAIM_SCHEMA` / `ARGUMENT_MAPPING_SCHEMA` (verbindliche Feldnamen) + kleiner **dependency-freier** Validator (keine neue `jsonschema`-Abhängigkeit).
- **`models.py`** — `RefinedClaim` (S1), `ArgumentMapping` (S2), `MappedClaim`, `ClaimAudit`, `SelectionResult`, Rolle→Klasse-Mapping (A/B/C/D), `join_claims`.
- **`policy_scorer.py`** — `checkability` (Entität/Zeitraum/Metrik), `importance × research_value × checkability` (alle 0–1), Gates (Meinung raus · Basisfakt/trivial nur listen · zu vage → flag) und klassenweise Quoten mit Spill nur über A/B.
- **`src/config/relevance_policy_v1.json`** — Gewichte/Gates/Quoten/Budget (Startwerte, Tuning nach Realtests).

## Rechenweg (Spec §3/S3)
`priority = importance × research_value × checkability`; `importance`/`research_value` = gewichtete, auf 0–1 normierte Summe der 0–5-Ratings; Auswahl klassenweise nach Quoten, innerhalb der Klasse absteigend nach `priority` (Tie-Break `claim_id` → deterministisch).

## Tests — **79 passed** (64 + 15 neu)
`tests/test_policy_scorer.py`: Gates (opinion/interpretation raus, metadata & trivial → basisfakt, vage → under_specified) · **klassenweise Quoten statt globaler Top-N** (B scort höher, A wird trotzdem zuerst gefüllt) · Kontext-Cap · **Basisfakt verdrängt nie einen Kernclaim** (ZDF-Regression) · Determinismus · Audit-Vollständigkeit & `priority`-Mathematik · Schema-Validierung (gültig/ungültig) · Policy-Datei kodiert §8-PO-Entscheidungen.

## Scope-Hinweise
- **Mitcommittet:** das in S3 festgezurrte Policy-Schema (`SOMAS_v0.13.0_SPEC`, Architekten-Anweisung).
- **Bewusst NICHT in diesem PR:** die lokal vorliegende `FAKTENCHECK_THEORIE.md` **v0.2** (§5.1 Sprachdimension/Zitat-Retrieval) — betrifft **S4/S5** (ResearchPlanner/Verdikt), nicht den PolicyScorer; gehört thematisch zu PR 3. Ebenso `docs/index.html` (Landing-Page-Commit).
- CLAUDE.md/README-Doku bleibt wie im Spec-PR-Schnitt vorgesehen **PR 4** vorbehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Einführung einer transparenten Relevanzbewertung zur Priorisierung von Faktencheck- und Recherchethemen.
  * Automatische Auswahl wichtiger Aussagen anhand von Relevanz, Prüfbarkeit und festgelegten Kontingenten.
  * Audit-Informationen zeigen Auswahlgründe, Bewertungen und Ausschlusskriterien.
  * Konsistente Validierung von Aussagen und Argumentzuordnungen mit verständlichen Fehlermeldungen.

* **Verbesserungen**
  * Deterministische Ergebnisse unabhängig von der Eingabereihenfolge.
  * Berücksichtigung von Budgets sowie separaten Quoten für Kern-, unterstützende und kontextbezogene Aussagen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->