### PR TITLE
fix: Trunkierungs-Härtung der Faktencheck-Plus-Stufen (v0.13.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.13.0
+**Version:** 0.13.1
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -633,6 +633,43 @@ abbrechbar. Der Classic-Weg bleibt unverändert (Parallelbetrieb, Theorie §8.1)
   „unbelegt" bei nicht-leerem `canonical_targets` (Spec: spätere Ausbaustufe);
   die zwei Tuning-Kandidaten (checkability, Quoten-Semantik) nach Realtests
 
+### Phase 23: Faktencheck Plus — Trunkierungs-Härtung der Stufen ✅ (v0.13.1)
+
+PO-Realtest 2026-07-16 (Fable 5 UND Opus 4.8): Plus scheiterte bei einem
+claim-reichen Video (21 Roh-Claims) in S1 mit „kein parsebares JSON-Array". Wahre
+Ursache: **Trunkierung**, kein Formatfehler. Der S1-Output skaliert mit der
+Claim-Zahl (jede Prüfeinheit echot `original_text` + `normalized_claim`), plus
+Anthropic-Thinking gegen `max_tokens` (8192) → valides, aber mitten im String
+abgeschnittenes JSON; der Reparatur-Retry lief mit demselben Budget deterministisch
+erneut ins Limit. Die Debug-Logs bestätigten es (S1-Content 17k Zeichen, doppelt so
+lang wie die 8,5k-Analyse; mid-JSON abgeschnitten).
+
+- [x] Teil A · Trunkierungs-Gate in `llm_stage.run_json_stage`: `finish_reason`
+  wird VOR der JSON-Extraktion geprüft; bei Trunkierung (`length`/`max_tokens`/
+  `truncated`) sofort offener `StageError` mit ehrlicher Meldung, **kein**
+  Reparatur-Retry (das gleiche Budget schnitte erneut ab). Gilt für alle Stufen
+  S1/S2/S4/S5 — der Fix sitzt in der Stufen-Mechanik. Transport-/Leer-Inhalt-
+  Verhalten unverändert (weiterhin kein Reparatur-Retry). Trunkierungs-Werte
+  jetzt zentral in `api_client` (`TRUNCATION_FINISH_REASONS`/
+  `is_truncated_finish_reason`); `main_window` delegiert dorthin (Drift-Schutz)
+- [x] Teil B · `_TokenCountingClient` reicht `response.finish_reason` an
+  `debug_logger.log_response` durch (Parameter existierte, wurde nicht bespielt) —
+  genau diese Lücke hatte die Diagnose verschleppt (Log zeigte immer `""`)
+- [x] Teil C · Ursachen-Fix: Stufen-Calls dürfen bis `STAGE_MAX_TOKENS = 16384`
+  antworten. `send_prompt` aller 4 Clients um optionalen `max_tokens`-Parameter
+  erweitert (Default weiter `DEFAULT_MAX_TOKENS` — kein Verhalten außerhalb von
+  Plus geändert); `_TokenCountingClient` reicht ihn durch. Erhöhung NUR für
+  Stufen-Calls (OpenRouter/Perplexity pre-authen gegen `max_tokens` → HTTP 402,
+  v0.10.1); Teil A bleibt Sicherheitsnetz, falls 16384 dort ein 402 provoziert
+- [x] Tests `tests/test_stage_truncation_gate.py`: Trunkierung → StageError +
+  genau 1 Call (A); kaputtes JSON ohne Trunkierung → weiterhin 1 Reparatur-Retry;
+  Transport-Fehler → kein Retry; `finish_reason` erreicht das Log (B);
+  Stufen-Call setzt 16384, normaler Call weiter Default (C)
+- [x] `APP_VERSION` → 0.13.1, README-Spotlight + „Seit v0.13.0"-Demotion
+- [ ] NICHT in diesem PR (Folge-Kandidaten): Thinking für Struktur-Stufen
+  deaktivieren (braucht Provider-Recherche, gleiche Klasse wie Phase-17-Item 3);
+  S1-Schema verschlanken (`original_text`-Echo halbieren)
+
 ### Backlog
 
 - [ ] A4-Feinschliff: erzwungenes Modul aus der `MODUL-AUSWAHL`-Liste entfernen
@@ -682,4 +719,4 @@ Bei Unklarheiten: Frag nach! Lieber einmal zu viel als eine falsche Annahme tref
 
 ---
 
-Letzte Aktualisierung: 2026-07-15
+Letzte Aktualisierung: 2026-07-16

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.13.0) — Faktencheck Plus
+### Aktuell (v0.13.1) — Faktencheck Plus: Trunkierungs-Härtung
+
+Faktencheck Plus scheiterte bei claim-reichen Videos (21 Roh-Behauptungen) in Stufe 1 mit einer irreführenden Meldung („kein parsebares JSON-Array"). Wahre Ursache war eine **Trunkierung**, kein Formatfehler: Der S1-Output skaliert mit der Behauptungszahl und sprengte zusammen mit dem Modell-Thinking das Antwort-Budget – das JSON brach mitten im String ab, und der Reparatur-Retry lief mit demselben Budget deterministisch erneut ins Limit.
+
+- **Ehrlicher Abbruch statt Reparatur-Schleife** – Die Stufen-Mechanik (S1/S2/S4/S5) prüft `finish_reason` **vor** der JSON-Extraktion. Bei einer abgeschnittenen Antwort bricht sie sofort mit klarer Meldung ab („Antwort abgeschnitten (Token-Limit) — vermutlich zu viele Behauptungen für das Antwort-Budget") – ohne den zwecklosen Reparatur-Retry
+- **Trunkierung wird im Stage-Log sichtbar** – Der `finish_reason` erreicht jetzt das Debug-Log; zuvor stand dort immer `""` und verschleppte genau diese Diagnose
+- **Mehr Antwort-Budget für die Stufen** – Die Plus-Stufen-Calls dürfen bis zu **16384** Tokens antworten (statt der globalen 8192). Die Erhöhung gilt **nur** für die Stufen-Calls, nicht global (OpenRouter/Perplexity pre-authen gegen `max_tokens`, HTTP 402); die Trunkierungs-Bremse bleibt als Sicherheitsnetz
+
+### Seit v0.13.0 — Faktencheck Plus
 
 Der bisherige Faktencheck prüfte, was **prüfbar** war. Faktencheck Plus prüft, was **prüfwürdig** ist: „Das ZDF ist öffentlich-rechtlich" ist perfekt prüfbar und trotzdem wertlos, wenn dafür die tragende strittige These ungeprüft bleibt. Optional zuschaltbar – der bisherige Weg bleibt unverändert erhalten.
 

--- a/src/core/anthropic_client.py
+++ b/src/core/anthropic_client.py
@@ -63,17 +63,22 @@ class AnthropicClient(LLMClient):
         """Gibt Liste der verfügbaren Modelle zurück (statisch)."""
         return self.MODELS
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet Prompt an die Anthropic Messages API.
 
         Args:
             prompt: Der zu sendende Prompt-Text.
             model: Die Modell-ID (z.B. 'claude-sonnet-4-6').
+            max_tokens: Optionale Obergrenze für die Antwortlänge
+                (``None`` → :data:`DEFAULT_MAX_TOKENS`).
 
         Returns:
             APIResponse mit Status und Inhalt.
         """
         logger.info(f"Anthropic API-Call: model={model}, prompt_len={len(prompt)}")
+        tokens_cap = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
 
         try:
             import anthropic
@@ -81,7 +86,7 @@ class AnthropicClient(LLMClient):
             client = anthropic.Anthropic(api_key=self.api_key)
             message = client.messages.create(
                 model=model,
-                max_tokens=DEFAULT_MAX_TOKENS,
+                max_tokens=tokens_cap,
                 messages=[{"role": "user", "content": prompt}],
             )
 

--- a/src/core/api_client.py
+++ b/src/core/api_client.py
@@ -61,6 +61,30 @@ def is_empty_content_error(message: str) -> bool:
     return bool(message) and message.strip().startswith(EMPTY_CONTENT_ERROR_PREFIX)
 
 
+# Finish-Reasons, die eine bei max_tokens abgeschnittene (trunkierte) Antwort
+# signalisieren. Zentral hier definiert (v0.13.1), damit der GUI-Analysepfad
+# (main_window) und die Faktencheck-Plus-Stufen (llm_stage) denselben
+# Trunkierungs-Gate verwenden und nicht auseinanderdriften. Anthropic normalisiert
+# "max_tokens" → "length" schon im Client; die übrigen Varianten bleiben defensiv
+# erfasst.
+TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "truncated"})
+
+
+def is_truncated_finish_reason(finish_reason: str) -> bool:
+    """Erkennt einen finish_reason, der eine abgeschnittene Antwort anzeigt.
+
+    Args:
+        finish_reason: Der von der API gemeldete Stopp-Grund (kann leer sein).
+
+    Returns:
+        True, wenn die Antwort bei der Token-Grenze trunkiert wurde.
+    """
+    return (
+        bool(finish_reason)
+        and finish_reason.strip().lower() in TRUNCATION_FINISH_REASONS
+    )
+
+
 @dataclass
 class APIResponse:
     """Antwort eines LLM-API-Aufrufs."""
@@ -99,7 +123,7 @@ class LLMClient(ABC):
         """Normalisiert den provider-spezifischen Stopp-Grund einheitlich.
 
         Zentralisiert das ``raw or ""`` sowie provider-spezifische Aliasse, damit
-        der Trunkierungs-Gate (main_window `_TRUNCATION_FINISH_REASONS`) über alle
+        der Trunkierungs-Gate (:data:`TRUNCATION_FINISH_REASONS`) über alle
         Clients konsistente Werte bekommt.
 
         Args:
@@ -151,12 +175,19 @@ class LLMClient(ABC):
         """
 
     @abstractmethod
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet einen Prompt an die API und gibt die Antwort zurück.
 
         Args:
             prompt: Der zu sendende Prompt-Text.
             model: Die Modell-ID (z.B. 'sonar-pro').
+            max_tokens: Optionale Obergrenze für die Antwortlänge. ``None`` →
+                :data:`DEFAULT_MAX_TOKENS`. Höhere Werte kommen nur aus den
+                Faktencheck-Plus-Stufen (``llm_stage.STAGE_MAX_TOKENS``), NICHT
+                global — OpenRouter/Perplexity pre-authen gegen ``max_tokens``
+                (HTTP 402, v0.10.1).
 
         Returns:
             APIResponse mit Status und Inhalt.

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.13.0"
+APP_VERSION = "0.13.1"
 
 
 class DebugLogger:

--- a/src/core/factcheck_plus/llm_stage.py
+++ b/src/core/factcheck_plus/llm_stage.py
@@ -17,7 +17,9 @@ import logging
 import re
 from typing import Callable, Protocol
 
-from ..api_client import APIResponse, APIStatus
+from ..api_client import (
+    APIResponse, APIStatus, is_truncated_finish_reason,
+)
 from .prompts import build_repair_prompt
 
 logger = logging.getLogger(__name__)
@@ -33,7 +35,9 @@ class PromptClient(Protocol):
     auch die Test-Doppelgänger.
     """
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet einen Prompt und liefert die Antwort."""
         ...
 
@@ -41,6 +45,16 @@ class PromptClient(Protocol):
 # ein gezielter Nachschlag, dann offener Fehler — keine Retry-Schleifen, die
 # Token verbrennen und Fehler verschleiern.
 MAX_REPAIR_ATTEMPTS = 1
+
+# Antwort-Budget der Plus-Stufen-Calls. Bewusst höher als DEFAULT_MAX_TOKENS (8192):
+# Der S1-Output skaliert mit der Claim-Zahl — jede Prüfeinheit echot ``original_text``
+# + ``normalized_claim`` — und bei Anthropic zählt zusätzlich das Modell-Thinking
+# gegen ``max_tokens``. Bei ~40 Prüfeinheiten (21 Roh-Claims) sprengte 8192 den
+# Deckel: valides, aber mitten im String abgeschnittenes JSON (Realtest 2026-07-16,
+# v0.13.1). 16384 deckt ~40 Einheiten + Thinking. Gilt NUR für Stufen-Calls, nicht
+# global — OpenRouter/Perplexity pre-authen gegen ``max_tokens`` (HTTP 402, v0.10.1);
+# provoziert 16384 dort ein 402, greift der Trunkierungs-Gate unten als Sicherheitsnetz.
+STAGE_MAX_TOKENS = 16384
 
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
 
@@ -165,6 +179,12 @@ def run_json_stage(
     eskalieren sofort; über einen fachlichen Wiederholungslauf entscheidet der
     aufrufende Worker (PR 4).
 
+    **Trunkierung** (``finish_reason`` ∈ ``length``/``max_tokens``/``truncated``)
+    ist ebenfalls kein Vertragsbruch, sondern ein abgeschnittenes — womöglich für
+    sich valides — JSON. Ein Reparatur-Retry liefe mit demselben Budget
+    deterministisch erneut ins Limit; deshalb eskaliert die Stufe sofort mit
+    ehrlicher Meldung, statt einen sinnlosen Nachschlag zu verbrennen (v0.13.1).
+
     Args:
         client: LLM-Client mit ``send_prompt(prompt, model) -> APIResponse``.
         model: Modell-ID (Analyse-Modell; kein eigener Picker, PO-Entscheidung §8.3).
@@ -180,7 +200,8 @@ def run_json_stage(
         Das Ergebnis von ``parse``.
 
     Raises:
-        StageError: Bei API-Fehler oder nach erschöpften Reparaturversuchen.
+        StageError: Bei API-Fehler, Trunkierung oder nach erschöpften
+            Reparaturversuchen.
     """
     current_prompt = prompt
     last_error = ""
@@ -189,12 +210,25 @@ def run_json_stage(
     json_format = "Objekt" if extract is extract_json_object else "Array"
 
     for attempt in range(MAX_REPAIR_ATTEMPTS + 1):
-        response = client.send_prompt(current_prompt, model)
+        response = client.send_prompt(
+            current_prompt, model, max_tokens=STAGE_MAX_TOKENS
+        )
 
         if response.status != APIStatus.RECEIVED:
             # Transport-/Leer-Inhalt-Fehler: kein Vertragsbruch → keine Reparatur.
             raise StageError(
                 f"{stage_name}: API-Fehler — {response.error_message}"
+            )
+
+        # Trunkierung VOR der JSON-Extraktion abfangen: ein bei der Token-Grenze
+        # abgeschnittenes (evtl. für sich valides) JSON ist kein Formatfehler. Ein
+        # Reparatur-Retry liefe mit demselben Budget erneut ins Limit → sofort
+        # offen eskalieren, ohne Nachschlag (v0.13.1).
+        if is_truncated_finish_reason(response.finish_reason):
+            raise StageError(
+                f"{stage_name}: Antwort abgeschnitten (Token-Limit, "
+                f"finish_reason={response.finish_reason}) — vermutlich zu viele "
+                f"Behauptungen für das Antwort-Budget."
             )
 
         try:

--- a/src/core/factcheck_plus_worker.py
+++ b/src/core/factcheck_plus_worker.py
@@ -80,8 +80,17 @@ class _TokenCountingClient:
         self.tokens_used = 0
         self.citations: list[str] = []
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
-        """Reicht den Call durch, misst Dauer, loggt und summiert Tokens."""
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
+        """Reicht den Call durch, misst Dauer, loggt und summiert Tokens.
+
+        Args:
+            prompt: Der Stufen-Prompt.
+            model: Die Modell-ID.
+            max_tokens: Antwort-Budget der Stufe (``llm_stage.STAGE_MAX_TOKENS``);
+                wird unverändert an den echten Client durchgereicht.
+        """
         log_dir = None
         if self._debug_logger:
             endpoint = (
@@ -102,7 +111,7 @@ class _TokenCountingClient:
             )
 
         start = time.time()
-        response = self._client.send_prompt(prompt, model)
+        response = self._client.send_prompt(prompt, model, max_tokens=max_tokens)
         duration = time.time() - start
         response.duration_seconds = duration
 
@@ -125,6 +134,9 @@ class _TokenCountingClient:
                 model_used=response.model_used,
                 citations=response.citations,
                 error=None if ok else (response.error_message or "Fehler"),
+                # v0.13.1: finish_reason durchreichen — sonst stand im Stage-Log
+                # immer "" und verschleppte die Trunkierungs-Diagnose (Teil B).
+                finish_reason=response.finish_reason,
             )
         return response
 

--- a/src/core/openai_client.py
+++ b/src/core/openai_client.py
@@ -53,17 +53,22 @@ class OpenAIClient(LLMClient):
         """Gibt Liste der verfügbaren Modelle zurück (statisch)."""
         return self.MODELS
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet Prompt an die OpenAI Chat Completions API.
 
         Args:
             prompt: Der zu sendende Prompt-Text.
             model: Die Modell-ID (z.B. 'gpt-4o').
+            max_tokens: Optionale Obergrenze für die Antwortlänge
+                (``None`` → :data:`DEFAULT_MAX_TOKENS`).
 
         Returns:
             APIResponse mit Status und Inhalt.
         """
         logger.info(f"OpenAI API-Call: model={model}, prompt_len={len(prompt)}")
+        tokens_cap = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
 
         try:
             from openai import OpenAI
@@ -76,9 +81,9 @@ class OpenAIClient(LLMClient):
                 "messages": [{"role": "user", "content": prompt}],
             }
             if model.startswith("o"):
-                params["max_completion_tokens"] = DEFAULT_MAX_TOKENS
+                params["max_completion_tokens"] = tokens_cap
             else:
-                params["max_tokens"] = DEFAULT_MAX_TOKENS
+                params["max_tokens"] = tokens_cap
 
             response = client.chat.completions.create(**params)
 

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -123,17 +123,22 @@ class OpenRouterClient(LLMClient):
         logger.info("OpenRouter: Verwende Fallback-Modelle")
         return self.FALLBACK_MODELS
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet Prompt an OpenRouter API.
 
         Args:
             prompt: Der zu sendende Prompt-Text.
             model: Die Modell-ID (z.B. 'anthropic/claude-3-haiku').
+            max_tokens: Optionale Obergrenze für die Antwortlänge
+                (``None`` → :data:`DEFAULT_MAX_TOKENS`).
 
         Returns:
             APIResponse mit Status und Inhalt.
         """
         logger.info(f"OpenRouter API-Call: model={model}, prompt_len={len(prompt)}")
+        tokens_cap = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
 
         try:
             response = requests.post(
@@ -145,7 +150,7 @@ class OpenRouterClient(LLMClient):
                     # max_tokens setzen, sonst rechnet OpenRouter mit dem vollen
                     # Context-Window als Worst-Case und blockt bei moderatem
                     # Guthaben mit HTTP 402.
-                    "max_tokens": DEFAULT_MAX_TOKENS,
+                    "max_tokens": tokens_cap,
                     # v0.11.0 (Reasoning-Leak-Härtung, stärkster Hebel): Das Modell
                     # reasont weiterhin INTERN (Qualität bleibt), gibt die Reasoning-
                     # Tokens aber NICHT zurück. Verhindert, dass manche Upstream-

--- a/src/core/perplexity_client.py
+++ b/src/core/perplexity_client.py
@@ -70,17 +70,22 @@ class PerplexityClient(LLMClient):
         """
         return self.MODELS
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Sendet Prompt an Perplexity API.
 
         Args:
             prompt: Der zu sendende Prompt-Text.
             model: Die Modell-ID (z.B. 'sonar-pro').
+            max_tokens: Optionale Obergrenze für die Antwortlänge
+                (``None`` → :data:`DEFAULT_MAX_TOKENS`).
 
         Returns:
             APIResponse mit Status und Inhalt.
         """
         logger.info(f"Perplexity API-Call: model={model}, prompt_len={len(prompt)}")
+        tokens_cap = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
 
         try:
             response = requests.post(
@@ -91,7 +96,7 @@ class PerplexityClient(LLMClient):
                     "messages": [{"role": "user", "content": prompt}],
                     # max_tokens explizit setzen (analog OpenRouter/Anthropic/OpenAI),
                     # um Worst-Case-Pre-Auth zu vermeiden.
-                    "max_tokens": DEFAULT_MAX_TOKENS,
+                    "max_tokens": tokens_cap,
                     # Such-Tiefe hochsetzen (Default wäre "low") — mehr Quellen pro
                     # Anfrage, spürbar bessere Belegtiefe in der Verifikation.
                     "web_search_options": {

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -23,7 +23,9 @@ from src.core.linkedin_formatter import format_for_linkedin
 from src.core.export import (
     export_to_markdown, get_suggested_filename, save_markdown, get_default_save_dir,
 )
-from src.core.api_client import APIResponse, APIStatus, is_empty_content_error
+from src.core.api_client import (
+    APIResponse, APIStatus, is_empty_content_error, is_truncated_finish_reason,
+)
 from src.core.api_worker import APIWorker
 from src.core.debug_logger import DebugLogger, APP_VERSION
 from src.core.rating_store import RatingStore, AnalysisRecord
@@ -50,11 +52,6 @@ from src.config.api_config import (
 
 logger = logging.getLogger(__name__)
 
-# v0.11.0: finish_reason-Werte, die eine bei max_tokens abgeschnittene (trunkierte)
-# Antwort signalisieren. Providerübergreifend normalisiert (Anthropic "max_tokens"
-# → "length" im Client), hier defensiv trotzdem alle Varianten erfasst.
-_TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "truncated"})
-
 # v0.13.0: Die SpinBox der Verifikations-Sektion bedeutet je nach Modus etwas
 # anderes — Classic kappt die Behauptungsliste, Plus vergibt ein
 # Deep-Research-Budget (die Auswahl trifft dort der PolicyScorer).
@@ -76,13 +73,17 @@ PLUS_BUDGET_RANGE = (1, 50)
 def _is_truncated_finish_reason(finish_reason: str) -> bool:
     """Prüft, ob ein finish_reason eine abgeschnittene Antwort anzeigt.
 
+    Dünner Delegat auf :func:`api_client.is_truncated_finish_reason` — die
+    Trunkierungs-Werte leben seit v0.13.1 zentral dort, damit der GUI-Analysepfad
+    und die Faktencheck-Plus-Stufen (``llm_stage``) nicht auseinanderdriften.
+
     Args:
         finish_reason: Der von der API gemeldete Stopp-Grund (kann leer sein).
 
     Returns:
         True, wenn die Antwort bei der Token-Grenze trunkiert wurde.
     """
-    return bool(finish_reason) and finish_reason.strip().lower() in _TRUNCATION_FINISH_REASONS
+    return is_truncated_finish_reason(finish_reason)
 
 
 # Kürzungs-Prompt für Ergebnis-Nachbearbeitung (Teil 3: Zeichenlimit-Reihe)

--- a/tests/factcheck_plus_helpers.py
+++ b/tests/factcheck_plus_helpers.py
@@ -41,6 +41,8 @@ class FakeClient:
     Attributes:
         prompts: Alle gesendeten Prompts in Aufrufreihenfolge.
         models: Alle verwendeten Modell-IDs in Aufrufreihenfolge.
+        max_tokens: Alle übergebenen ``max_tokens``-Werte in Aufrufreihenfolge
+            (``None`` = kein Override) — belegt, dass die Stufen 16384 setzen.
     """
 
     def __init__(self, responses: list) -> None:
@@ -53,11 +55,15 @@ class FakeClient:
         self._responses = list(responses)
         self.prompts: list[str] = []
         self.models: list[str] = []
+        self.max_tokens: list[int | None] = []
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         """Liefert die nächste skriptierte Antwort und protokolliert den Aufruf."""
         self.prompts.append(prompt)
         self.models.append(model)
+        self.max_tokens.append(max_tokens)
         if not self._responses:
             raise AssertionError(
                 f"FakeClient: unerwarteter {len(self.prompts)}. Aufruf — "

--- a/tests/test_factcheck_plus_worker.py
+++ b/tests/test_factcheck_plus_worker.py
@@ -52,7 +52,9 @@ class ScriptedClient:
         self._responses = list(responses)
         self.calls: list[tuple[str, str]] = []
 
-    def send_prompt(self, prompt: str, model: str) -> APIResponse:
+    def send_prompt(
+        self, prompt: str, model: str, max_tokens: int | None = None
+    ) -> APIResponse:
         self.calls.append((prompt, model))
         if not self._responses:
             raise AssertionError(

--- a/tests/test_stage_truncation_gate.py
+++ b/tests/test_stage_truncation_gate.py
@@ -1,0 +1,218 @@
+"""Trunkierungs-Härtung der Faktencheck-Plus-Stufen (v0.13.1).
+
+Deckt die drei Teile des Fixes ab (Realtest 2026-07-16: S1 scheiterte bei 21
+Roh-Claims an einem abgeschnittenen JSON-Array):
+
+- **Teil A** — Trunkierungs-Gate in ``llm_stage.run_json_stage``: eine bei der
+  Token-Grenze abgeschnittene Antwort (``finish_reason`` ∈ length/max_tokens/
+  truncated) bricht SOFORT mit ``StageError`` ab — **kein** Reparatur-Retry
+  (gleiches Budget schnitte erneut ab). Regression: kaputtes JSON OHNE
+  Trunkierung bekommt weiterhin genau einen Reparatur-Retry; ein Transport-
+  Fehler weiterhin keinen.
+- **Teil B** — ``_TokenCountingClient`` reicht ``finish_reason`` an
+  ``debug_logger.log_response`` durch (stand zuvor immer ``""``).
+- **Teil C** — Stufen-Calls setzen ``max_tokens = STAGE_MAX_TOKENS`` (16384);
+  ein normaler Client-Call bleibt bei ``DEFAULT_MAX_TOKENS``.
+
+Alles offline, gemockt — kein Netzwerk.
+
+Lauf (ohne pytest):  QT_QPA_PLATFORM=offscreen python tests/test_stage_truncation_gate.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.api_client import (
+    DEFAULT_MAX_TOKENS, APIResponse, APIStatus,
+)
+from src.core.factcheck_plus.llm_stage import (
+    STAGE_MAX_TOKENS, StageError, run_json_stage,
+)
+from src.core.openrouter_client import OpenRouterClient
+import src.core.factcheck_plus_worker as fpw
+from tests.factcheck_plus_helpers import FakeClient, error_response
+
+
+def _received(content: str, finish_reason: str) -> APIResponse:
+    """Baut eine RECEIVED-Antwort mit gesetztem finish_reason."""
+    return APIResponse(
+        status=APIStatus.RECEIVED, content=content, finish_reason=finish_reason,
+    )
+
+
+# --- Teil A: Trunkierungs-Gate --------------------------------------------
+
+def test_truncated_array_raises_without_repair():
+    """Valides-aber-abgeschnittenes JSON + length → StageError, genau 1 Call."""
+    # Für sich (bis zum Abbruch) valides Array, das mitten im String endet.
+    truncated = _received('[{"claim_id": "c01", "normalized_claim": "Die Zahl', "length")
+    client = FakeClient([truncated])
+
+    with pytest.raises(StageError) as exc:
+        run_json_stage(client, "m", "prompt", parse=lambda raw: raw,
+                       stage_name="ClaimRefiner")
+
+    msg = str(exc.value)
+    assert "abgeschnitten" in msg, msg
+    assert "finish_reason=length" in msg, msg
+    assert client.call_count == 1, "Trunkierung darf KEINEN Reparatur-Retry auslösen"
+    print("  truncated_array_raises_without_repair OK")
+
+
+def test_all_truncation_reasons_gate():
+    """Alle drei Trunkierungs-Werte greifen (max_tokens/truncated/length)."""
+    for reason in ("max_tokens", "truncated", "LENGTH"):
+        client = FakeClient([_received("[teilweise", reason)])
+        with pytest.raises(StageError):
+            run_json_stage(client, "m", "p", parse=lambda raw: raw, stage_name="S")
+        assert client.call_count == 1, reason
+    print("  all_truncation_reasons_gate OK")
+
+
+def test_broken_json_without_truncation_triggers_one_repair():
+    """Regression: kaputtes JSON + end_turn → weiterhin genau 1 Reparatur-Retry."""
+    broken = _received("das ist gar kein JSON", "end_turn")
+    client = FakeClient([broken, broken])
+
+    with pytest.raises(StageError) as exc:
+        run_json_stage(client, "m", "prompt", parse=lambda raw: raw, stage_name="S")
+
+    assert "Reparatur-Retry" in str(exc.value)
+    assert client.call_count == 2, "genau ein Reparatur-Retry (2 Calls insgesamt)"
+    print("  broken_json_without_truncation_triggers_one_repair OK")
+
+
+def test_transport_error_no_repair():
+    """Regression: Transport-/API-Fehler → weiterhin kein Reparatur-Retry."""
+    client = FakeClient([error_response()])
+
+    with pytest.raises(StageError) as exc:
+        run_json_stage(client, "m", "prompt", parse=lambda raw: raw, stage_name="S")
+
+    assert "API-Fehler" in str(exc.value)
+    assert client.call_count == 1
+    print("  transport_error_no_repair OK")
+
+
+def test_empty_finish_reason_still_parses():
+    """Kontrolle: leerer finish_reason ist keine Trunkierung — normal geparst."""
+    client = FakeClient([_received("[]", "")])
+    result = run_json_stage(client, "m", "p", parse=lambda raw: raw, stage_name="S")
+    assert result == []
+    assert client.call_count == 1
+    print("  empty_finish_reason_still_parses OK")
+
+
+# --- Teil C: Stufen-Budget -------------------------------------------------
+
+def test_stage_call_uses_stage_max_tokens():
+    """Der Stufen-Call reicht STAGE_MAX_TOKENS (16384) an den Client durch."""
+    client = FakeClient([_received("[]", "stop")])
+    result = run_json_stage(client, "m", "p", parse=lambda raw: raw, stage_name="S")
+    assert result == []
+    assert STAGE_MAX_TOKENS == 16384
+    assert client.max_tokens == [STAGE_MAX_TOKENS], client.max_tokens
+    print("  stage_call_uses_stage_max_tokens OK")
+
+
+def test_normal_client_call_uses_default_budget():
+    """Ein normaler Client-Call ohne Override bleibt bei DEFAULT_MAX_TOKENS,
+    ein expliziter Override (wie aus der Stufe) landet 1:1 im Payload."""
+    captured = []
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        @staticmethod
+        def json():
+            return {
+                "choices": [{"message": {"content": "Antwort"},
+                             "finish_reason": "stop"}],
+                "usage": {"total_tokens": 3},
+            }
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured.append(json)
+        return _Resp()
+
+    with patch("src.core.openrouter_client.requests.post", side_effect=fake_post):
+        client = OpenRouterClient("k")
+        assert client.send_prompt("p", "some/model").status == APIStatus.RECEIVED
+        client.send_prompt("p", "some/model", max_tokens=STAGE_MAX_TOKENS)
+
+    assert captured[0]["max_tokens"] == DEFAULT_MAX_TOKENS, captured[0]["max_tokens"]
+    assert captured[1]["max_tokens"] == STAGE_MAX_TOKENS, captured[1]["max_tokens"]
+    print("  normal_client_call_uses_default_budget OK")
+
+
+# --- Teil B: finish_reason im Stage-Log -----------------------------------
+
+class _RecordingDebugLogger:
+    """Fake-DebugLogger, der die log_response-Kwargs einsammelt."""
+
+    def __init__(self):
+        self.enabled = True
+        self.responses = []
+
+    def log_request(self, **kwargs):
+        return "logdir"
+
+    def log_response(self, **kwargs):
+        self.responses.append(kwargs)
+
+
+class _StubClient:
+    """Client-Doppelgänger für den _TokenCountingClient-Test."""
+
+    PROVIDER_ID = "anthropic"
+
+    def __init__(self, response: APIResponse):
+        self._response = response
+        self.seen_max_tokens = []
+
+    def send_prompt(self, prompt, model, max_tokens=None):
+        self.seen_max_tokens.append(max_tokens)
+        return self._response
+
+
+def test_finish_reason_reaches_debug_log():
+    """Teil B: der finish_reason der Stufen-Antwort erreicht log_response —
+    und der Wrapper reicht max_tokens an den echten Client durch (Teil C)."""
+    resp = _received("[]", "length")
+    resp.tokens_used = 42
+    client = _StubClient(resp)
+    dbg = _RecordingDebugLogger()
+
+    wrapper = fpw._TokenCountingClient(client, "factcheck_plus.s1_refiner", dbg)
+    wrapper.send_prompt("p", "m", max_tokens=STAGE_MAX_TOKENS)
+
+    assert dbg.responses, "log_response wurde nicht aufgerufen"
+    assert dbg.responses[-1]["finish_reason"] == "length", dbg.responses[-1]
+    assert client.seen_max_tokens == [STAGE_MAX_TOKENS], client.seen_max_tokens
+    print("  finish_reason_reaches_debug_log OK")
+
+
+def main():
+    print("Trunkierungs-Härtung der Plus-Stufen (v0.13.1):")
+    test_truncated_array_raises_without_repair()
+    test_all_truncation_reasons_gate()
+    test_broken_json_without_truncation_triggers_one_repair()
+    test_transport_error_no_repair()
+    test_empty_finish_reason_still_parses()
+    test_stage_call_uses_stage_max_tokens()
+    test_normal_client_call_uses_default_budget()
+    test_finish_reason_reaches_debug_log()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Bug (Realtest 2026-07-16, reproduziert mit Fable 5 UND Opus 4.8)

Faktencheck Plus scheiterte bei claim-reichen Videos (21 Roh-Claims) in **Stufe 1** mit „ClaimRefiner: Ungültige Antwort auch nach Reparatur-Retry — kein parsebares JSON-Array".

**Wahre Ursache — Trunkierung, kein Formatfehler:** Die S1-Antwort ist ein valides JSON-Array, das mitten im String abbricht. Der S1-Output skaliert mit der Claim-Zahl (jede Prüfeinheit echot `original_text` + `normalized_claim`); zusammen mit dem Anthropic-Thinking sprengt das den `DEFAULT_MAX_TOKENS = 8192`-Deckel → `stop_reason=max_tokens`, Text gekappt. Der Reparatur-Retry lief mit demselben Budget deterministisch erneut ins Limit.

Die mitgelieferten Debug-Logs bestätigen es: S1-Content 17k Zeichen (**doppelt** so lang wie die 8,5k-Analyse), mid-JSON abgeschnitten (`…"claim_id": "c15c",`). Der geloggte `finish_reason` stand dabei auf `""` — **genau Teil B**: der Wert erreichte das Log nie und verschleppte die Diagnose.

## Fix (ein PR, drei Teile)

**A · Trunkierungs-Gate in `llm_stage.run_json_stage`** — `finish_reason` wird **vor** der JSON-Extraktion geprüft. Bei Trunkierung (`length`/`max_tokens`/`truncated`) sofort offener `StageError` mit ehrlicher Meldung, **kein** Reparatur-Retry (gleiches Budget schnitte erneut ab). Gilt für alle Stufen S1/S2/S4/S5 — der Fix sitzt in der Stufen-Mechanik. Transport-/Leer-Inhalt-Verhalten unverändert. Die Trunkierungs-Werte leben jetzt zentral in `api_client` (`TRUNCATION_FINISH_REASONS` / `is_truncated_finish_reason`); `main_window` delegiert dorthin (Drift-Schutz statt zweiter Kopie).

**B · Beobachtbarkeit** — `_TokenCountingClient` reicht `response.finish_reason` an `debug_logger.log_response` durch (Parameter existierte, wurde nicht bespielt).

**C · Ursachen-Fix** — Stufen-Calls dürfen bis `STAGE_MAX_TOKENS = 16384` antworten. `send_prompt` aller 4 Clients um optionalen `max_tokens`-Parameter erweitert (Default weiter `DEFAULT_MAX_TOKENS` — **kein** Verhalten außerhalb von Plus geändert); `_TokenCountingClient` reicht ihn durch. Erhöhung **nur** für Stufen-Calls, nicht global (OpenRouter/Perplexity pre-authen gegen `max_tokens` → HTTP 402, v0.10.1); Teil A bleibt als Sicherheitsnetz, falls 16384 dort ein 402 provoziert.

## Ausdrücklich NICHT in diesem PR

Thinking für Struktur-Stufen deaktivieren (braucht Provider-Recherche); S1-Schema verschlanken (`original_text`-Echo halbieren). Beides Folge-Kandidaten.

## Tests

`tests/test_stage_truncation_gate.py` (8, offline/gemockt):
- **A** — Trunkierung → `StageError` mit Trunkierungs-Meldung, **genau 1** LLM-Call (kein Reparatur-Retry); alle drei Trunkierungs-Werte greifen.
- **A-Regression** — kaputtes JSON + `end_turn` → weiterhin genau 1 Reparatur-Retry; Transport-Fehler → kein Retry; leerer `finish_reason` → normal geparst.
- **B** — `finish_reason` erreicht `log_response`.
- **C** — Stufen-Call setzt `max_tokens=16384`; normaler Client-Call bleibt bei `DEFAULT_MAX_TOKENS`, expliziter Override landet 1:1 im Payload.

Gesamtsuite **290 grün** (war 282, +8). `APP_VERSION` → 0.13.1, README-Spotlight + „Seit v0.13.0"-Demotion, CLAUDE.md (Phase 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Antwortlängen können für KI-Anfragen optional begrenzt werden.
  * Faktencheck-Plus-Stufen verwenden ein festgelegtes Token-Budget.
  * Abgeschnittene Antworten werden zuverlässig erkannt und ohne unnötigen Reparaturversuch eskaliert.

* **Fehlerbehebungen**
  * Die Erkennung von Trunkierungen ist in Benutzeroberfläche und Verarbeitung konsistent.
  * Der Abschlussgrund von Antworten wird nun korrekt im Debug-Logging angezeigt.

* **Tests**
  * Umfassende Tests für Token-Limits, abgeschnittene Antworten, Reparaturversuche und Protokollierung ergänzt.

* **Chores**
  * Versionsnummer auf 0.13.1 aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->