### PR TITLE
fix: Reasoning-Cap für OpenRouter-Stage-Calls (v0.13.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.13.1
+**Version:** 0.13.2
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -477,10 +477,10 @@ seit v0.11.0 einen sichtbaren Ein-Retry bekommt.
 - [x] Tests: `tests/test_analysis_retry_cancel.py` (Leer-Inhalt-Retry, 2. Leer→offener
   Fehlschlag, Abbruch während Retry, Trunkierungs-Regression, harter Fehler ohne Retry) +
   Classifier/`http_status` in `tests/test_empty_content.py`
-- [ ] Deferiert (Item 3, PO-Kosten-Tradeoff): OpenRouter-Reasoning-Budget deckeln
-  (`reasoning: {"max_tokens": 4096, "exclude": true}`) — würde die Ursache adressieren,
-  aber `reasoning.max_tokens` wird nicht von allen Modellen gestützt (effort- vs.
-  token-basiert); Risiko, andere Modelle zu stören → separater PR nach Recherche
+- [x] ~~Deferiert (Item 3, PO-Kosten-Tradeoff): OpenRouter-Reasoning-Budget deckeln~~
+  → **umgesetzt in Phase 24 (v0.13.2)**. Recherche bestätigte den effort-/token-
+  Vorbehalt: token-basiert (`max_tokens`) trägt nicht für alle Familien; gewählt
+  wurde die `effort`-Variante (das reale Zielmodell DeepSeek V4 ist effort-gesteuert)
 
 ### Phase 18: Anthropic-Direktmodelle aktualisieren ✅ (v0.12.2)
 
@@ -670,6 +670,48 @@ lang wie die 8,5k-Analyse; mid-JSON abgeschnitten).
   deaktivieren (braucht Provider-Recherche, gleiche Klasse wie Phase-17-Item 3);
   S1-Schema verschlanken (`original_text`-Echo halbieren)
 
+### Phase 24: Reasoning-Cap für OpenRouter-Stage-Calls ✅ (v0.13.2)
+
+Setzt das in Phase 17 deferierte Item 3 um (Bedingung war: Recherche zuerst).
+Realtest 2026-07-17 (DeepSeek V4 Pro via OpenRouter): S1 scheiterte **trotz**
+`STAGE_MAX_TOKENS = 16384` — nicht die Output-Größe, sondern das (durch
+`exclude: true` unsichtbare) Reasoning fraß ~14,7k von ~16,4k Tokens, nur ~1,6k
+sichtbares JSON, mid-Objekt gekappt (`finish_reason=length`). Das Trunkierungs-Gate
+aus v0.13.1 hat korrekt und ehrlich gemeldet — jetzt die Ursache adressiert.
+
+- [x] Recherche (OpenRouter-`reasoning`-Doku, live): `effort` XOR `max_tokens`
+  (nicht beide), `exclude` orthogonal kombinierbar. OpenRouter normalisiert
+  zwischen effort und Budget; die **effort→Budget-Richtung ist dokumentiert**, die
+  `max_tokens`→effort-Rückabbildung nur vage. **DeepSeek V4 ist auf OpenRouter
+  effort-gesteuert** (belegt via Issue earendil-works/pi#4055: nutzt effort-Enum,
+  `xhigh`→`max`). Fehlerverhalten bei Mismatch/Non-Reasoning-Modellen: **Doku-Lücke**
+  (nicht explizit; offen als Risiko notiert — Sicherheitsnetz greift, s.u.)
+- [x] Entscheidung: **`effort` statt `max_tokens`** (Startprompt gab die Wahl frei).
+  Das reale Zielmodell ist effort-gesteuert → nativer Konsum statt vager
+  Rückabbildung. `REASONING_CAP_EFFORT = "low"` (≈ 0.2 × max_tokens ≈ 3,3k für
+  token-basierte Familien, über Anthropics 1024-Minimum); `"max"` gemieden
+  (bekannter Mapping-Bug aus #4055)
+- [x] `send_prompt` aller 4 Clients um `cap_reasoning: bool = False` erweitert; **nur
+  `openrouter_client` wertet es aus** (`reasoning: {effort: "low", exclude: true}`),
+  die anderen ignorieren es dokumentiert. `_TokenCountingClient` reicht durch,
+  `run_json_stage` fordert `cap_reasoning=True` für alle Stage-Calls (S1/S2/S4/S5)
+- [x] Normaler Analyse-Call bleibt **ungecappt** (Reasoning erwünscht; v0.11-Gate+
+  Retry deckt Trunkierung); `STAGE_MAX_TOKENS` unverändert (16384); Trunkierungs-Gate
+  (v0.13.1 Teil A) bleibt Sicherheitsnetz, falls ein Modell den Cap ignoriert
+- [x] Nebeneffekt: Reasoning-Tokens werden berechnet → der Cap spart bei
+  reasoning-lastigen Modellen direkt Geld (README-Changelog)
+- [x] Tests `tests/test_reasoning_cap.py` (7): Stage-Call sendet Effort-Cap +
+  `exclude`; normaler Call unverändert; Perplexity/OpenAI/Anthropic ignorieren das
+  Flag (kein Payload-Feld, kein Fehler); `run_json_stage` fordert den Cap an.
+  Gesamtsuite 297 grün
+- [x] `APP_VERSION` → 0.13.2, README-Spotlight + „Seit v0.13.1"-Demotion
+- [ ] Offene Risiken (Doku-Lücke, PO-Realtest = Merge-Kriterium): exaktes
+  Reasoning-Budget für „low" bei DeepSeek V4 nicht garantiert (empirisch << 14,7k);
+  Mismatch-/Non-Reasoning-Verhalten unspezifiziert — ein Fehler degradiert aber zu
+  einem ehrlichen `StageError`, nicht zu stiller Korruption
+- [ ] NICHT in diesem PR: Thinking-Steuerung für Anthropic direkt (eigene
+  API-Semantik, separater PR nach Recherche)
+
 ### Backlog
 
 - [ ] A4-Feinschliff: erzwungenes Modul aus der `MODUL-AUSWAHL`-Liste entfernen
@@ -719,4 +761,4 @@ Bei Unklarheiten: Frag nach! Lieber einmal zu viel als eine falsche Annahme tref
 
 ---
 
-Letzte Aktualisierung: 2026-07-16
+Letzte Aktualisierung: 2026-07-17

--- a/README.md
+++ b/README.md
@@ -16,7 +16,16 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.13.1) — Faktencheck Plus: Trunkierungs-Härtung
+### Aktuell (v0.13.2) — Reasoning-Cap für Stage-Calls
+
+Faktencheck Plus S1 scheiterte bei DeepSeek V4 Pro (via OpenRouter) **trotz** des 16384-Budgets aus v0.13.1: Diesmal war nicht der Output zu groß, sondern das (durch `reasoning.exclude=true` unsichtbare) Modell-Reasoning fraß ~14,7k der ~16,4k Tokens – nur ~1,6k kamen als sichtbares JSON an, mitten im Objekt gekappt (`finish_reason=length`). Budget weiter zu erhöhen wäre ein Wettrüsten.
+
+- **Reasoning gedeckelt, wo es nicht gebraucht wird** – Die strukturierten Stage-Calls (S1/S2/S4/S5) senden an OpenRouter jetzt einen **Effort-Cap** (`reasoning: {effort: "low", exclude: true}`). Die JSON-Extraktion braucht kein ausuferndes Reasoning; der normale Analyse-Call bleibt **ungecappt** (dort ist Reasoning erwünscht, und der v0.11-Gate+Retry-Pfad fängt Trunkierung ab)
+- **`effort` statt Token-Budget – bewusst** – Das reale Zielmodell DeepSeek V4 ist auf OpenRouter effort-gesteuert; `effort` wird nativ verstanden, statt über die vage `max_tokens`→effort-Rückabbildung zu laufen. Nur OpenRouter wertet den Cap aus; die anderen Provider ignorieren ihn dokumentiert (Anthropic/OpenAI haben eigene Reasoning-Semantik → separater PR)
+- **Spart nebenbei Geld** – Reasoning-Tokens werden berechnet; der Cap vermeidet bei reasoning-lastigen Modellen die verschwendeten Tokens (im Fehlerfall oben: ~14,7k Tokens für einen Fehlschlag)
+- **Sicherheitsnetz bleibt** – Das Trunkierungs-Gate aus v0.13.1 greift weiterhin, falls ein Modell den Cap ignoriert
+
+### Seit v0.13.1 — Faktencheck Plus: Trunkierungs-Härtung
 
 Faktencheck Plus scheiterte bei claim-reichen Videos (21 Roh-Behauptungen) in Stufe 1 mit einer irreführenden Meldung („kein parsebares JSON-Array"). Wahre Ursache war eine **Trunkierung**, kein Formatfehler: Der S1-Output skaliert mit der Behauptungszahl und sprengte zusammen mit dem Modell-Thinking das Antwort-Budget – das JSON brach mitten im String ab, und der Reparatur-Retry lief mit demselben Budget deterministisch erneut ins Limit.
 

--- a/src/core/anthropic_client.py
+++ b/src/core/anthropic_client.py
@@ -64,7 +64,8 @@ class AnthropicClient(LLMClient):
         return self.MODELS
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet Prompt an die Anthropic Messages API.
 
@@ -73,6 +74,9 @@ class AnthropicClient(LLMClient):
             model: Die Modell-ID (z.B. 'claude-sonnet-4-6').
             max_tokens: Optionale Obergrenze für die Antwortlänge
                 (``None`` → :data:`DEFAULT_MAX_TOKENS`).
+            cap_reasoning: Wird hier bewusst **ignoriert** (v0.13.2) — der
+                Reasoning-Cap ist OpenRouter-spezifisch; Anthropics
+                Thinking-Steuerung hat eigene API-Semantik (separater PR).
 
         Returns:
             APIResponse mit Status und Inhalt.

--- a/src/core/api_client.py
+++ b/src/core/api_client.py
@@ -176,7 +176,8 @@ class LLMClient(ABC):
 
     @abstractmethod
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet einen Prompt an die API und gibt die Antwort zurück.
 
@@ -188,6 +189,11 @@ class LLMClient(ABC):
                 Faktencheck-Plus-Stufen (``llm_stage.STAGE_MAX_TOKENS``), NICHT
                 global — OpenRouter/Perplexity pre-authen gegen ``max_tokens``
                 (HTTP 402, v0.10.1).
+            cap_reasoning: Bittet um ein gedeckeltes Reasoning-Budget für
+                strukturierte Stage-Calls (v0.13.2). **Nur OpenRouter** wertet das
+                Flag aus (Effort-Cap); die anderen Clients ignorieren es
+                dokumentiert — sie kennen kein providerübergreifendes
+                Reasoning-Steuer-Feld. Default ``False`` = heutiges Verhalten.
 
         Returns:
             APIResponse mit Status und Inhalt.

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.13.1"
+APP_VERSION = "0.13.2"
 
 
 class DebugLogger:

--- a/src/core/factcheck_plus/llm_stage.py
+++ b/src/core/factcheck_plus/llm_stage.py
@@ -36,7 +36,8 @@ class PromptClient(Protocol):
     """
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet einen Prompt und liefert die Antwort."""
         ...
@@ -210,8 +211,12 @@ def run_json_stage(
     json_format = "Objekt" if extract is extract_json_object else "Array"
 
     for attempt in range(MAX_REPAIR_ATTEMPTS + 1):
+        # cap_reasoning=True: Stage-Calls sind strukturierte JSON-Extraktion, kein
+        # Freitext — ausuferndes Reasoning fraß bei DeepSeek V4 Pro das Antwort-
+        # Budget auf (v0.13.2). Nur OpenRouter wertet das Flag aus; die anderen
+        # Clients ignorieren es. Das Trunkierungs-Gate unten bleibt Sicherheitsnetz.
         response = client.send_prompt(
-            current_prompt, model, max_tokens=STAGE_MAX_TOKENS
+            current_prompt, model, max_tokens=STAGE_MAX_TOKENS, cap_reasoning=True,
         )
 
         if response.status != APIStatus.RECEIVED:

--- a/src/core/factcheck_plus_worker.py
+++ b/src/core/factcheck_plus_worker.py
@@ -81,7 +81,8 @@ class _TokenCountingClient:
         self.citations: list[str] = []
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Reicht den Call durch, misst Dauer, loggt und summiert Tokens.
 
@@ -90,6 +91,8 @@ class _TokenCountingClient:
             model: Die Modell-ID.
             max_tokens: Antwort-Budget der Stufe (``llm_stage.STAGE_MAX_TOKENS``);
                 wird unverändert an den echten Client durchgereicht.
+            cap_reasoning: Reasoning-Cap-Wunsch der Stufe (v0.13.2); wird
+                unverändert durchgereicht (nur OpenRouter wertet ihn aus).
         """
         log_dir = None
         if self._debug_logger:
@@ -111,7 +114,9 @@ class _TokenCountingClient:
             )
 
         start = time.time()
-        response = self._client.send_prompt(prompt, model, max_tokens=max_tokens)
+        response = self._client.send_prompt(
+            prompt, model, max_tokens=max_tokens, cap_reasoning=cap_reasoning,
+        )
         duration = time.time() - start
         response.duration_seconds = duration
 

--- a/src/core/openai_client.py
+++ b/src/core/openai_client.py
@@ -54,7 +54,8 @@ class OpenAIClient(LLMClient):
         return self.MODELS
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet Prompt an die OpenAI Chat Completions API.
 
@@ -63,6 +64,10 @@ class OpenAIClient(LLMClient):
             model: Die Modell-ID (z.B. 'gpt-4o').
             max_tokens: Optionale Obergrenze für die Antwortlänge
                 (``None`` → :data:`DEFAULT_MAX_TOKENS`).
+            cap_reasoning: Wird hier bewusst **ignoriert** (v0.13.2) — der
+                Reasoning-Cap ist OpenRouter-spezifisch; die o-Series steuert
+                Reasoning über ``reasoning_effort`` mit eigener Semantik
+                (separater PR).
 
         Returns:
             APIResponse mit Status und Inhalt.

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -22,6 +22,21 @@ class OpenRouterClient(LLMClient):
     PROVIDER_ID = "openrouter"
     PROVIDER_NAME = "OpenRouter"
 
+    # v0.13.2: Reasoning-Cap für strukturierte Stage-Calls (Faktencheck Plus).
+    # DeepSeek V4 Pro reasonte bei der JSON-Extraktion ~14,7k Tokens (durch
+    # `exclude: true` unsichtbar, zählt aber voll gegen `max_tokens`) → trotz
+    # 16384-Budget `finish_reason=length`, kein verwertbarer Output. Ein Effort-Cap
+    # deckelt das Reasoning für Stage-Calls.
+    #
+    # BEWUSST `effort` statt `max_tokens`: Das reale Zielmodell DeepSeek V4 ist auf
+    # OpenRouter effort-gesteuert (Issue earendil-works/pi#4055). Die
+    # effort→Budget-Normalisierung ist die dokumentierte Richtung; die
+    # `max_tokens`→effort-Rückabbildung nur vage. `"max"` gemieden (bekannter
+    # Mapping-Bug); `"low"` ist ein valider normalisierter Enum-Wert und liegt für
+    # token-basierte Familien (0.2 × max_tokens ≈ 3,3k) über Anthropics 1024-Minimum.
+    # Kombinierbar mit `exclude` (laut Doku orthogonal).
+    REASONING_CAP_EFFORT = "low"
+
     # Fallback-Modelle falls /models nicht erreichbar (Stand Januar 2026)
     FALLBACK_MODELS: ClassVar[list[dict]] = [
         {
@@ -124,7 +139,8 @@ class OpenRouterClient(LLMClient):
         return self.FALLBACK_MODELS
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet Prompt an OpenRouter API.
 
@@ -133,12 +149,28 @@ class OpenRouterClient(LLMClient):
             model: Die Modell-ID (z.B. 'anthropic/claude-3-haiku').
             max_tokens: Optionale Obergrenze für die Antwortlänge
                 (``None`` → :data:`DEFAULT_MAX_TOKENS`).
+            cap_reasoning: Wenn ``True``, wird das Reasoning zusätzlich per
+                Effort-Cap gedeckelt (:data:`REASONING_CAP_EFFORT`) — nur für
+                strukturierte Stage-Calls, nicht für die normale Analyse (dort ist
+                Reasoning erwünscht). Einziger Consumer dieses Flags: OpenRouter.
 
         Returns:
             APIResponse mit Status und Inhalt.
         """
         logger.info(f"OpenRouter API-Call: model={model}, prompt_len={len(prompt)}")
         tokens_cap = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
+
+        # v0.11.0 (Reasoning-Leak-Härtung, stärkster Hebel): Das Modell reasont
+        # weiterhin INTERN (Qualität bleibt), gibt die Reasoning-Tokens aber NICHT
+        # zurück. Verhindert, dass manche Upstream-Backends das Reasoning inline in
+        # `content` serialisieren, das Token-Budget auffressen und die finale
+        # Analyse abschneiden (realer Iran-DeepSeek-Fall 2026-07-01). Nur OpenRouter
+        # — andere Provider haben eigene Reasoning-Semantik und bleiben unangetastet.
+        reasoning: dict = {"exclude": True}
+        # v0.13.2: Für Stage-Calls zusätzlich das Reasoning-Budget kappen (s.
+        # REASONING_CAP_EFFORT). `exclude` bleibt orthogonal aktiv.
+        if cap_reasoning:
+            reasoning["effort"] = self.REASONING_CAP_EFFORT
 
         try:
             response = requests.post(
@@ -151,14 +183,7 @@ class OpenRouterClient(LLMClient):
                     # Context-Window als Worst-Case und blockt bei moderatem
                     # Guthaben mit HTTP 402.
                     "max_tokens": tokens_cap,
-                    # v0.11.0 (Reasoning-Leak-Härtung, stärkster Hebel): Das Modell
-                    # reasont weiterhin INTERN (Qualität bleibt), gibt die Reasoning-
-                    # Tokens aber NICHT zurück. Verhindert, dass manche Upstream-
-                    # Backends das Reasoning inline in `content` serialisieren, das
-                    # Token-Budget auffressen und die finale Analyse abschneiden
-                    # (realer Iran-DeepSeek-Fall 2026-07-01). Nur OpenRouter — andere
-                    # Provider haben eigene Reasoning-Semantik und bleiben unangetastet.
-                    "reasoning": {"exclude": True},
+                    "reasoning": reasoning,
                 },
                 timeout=120,
             )

--- a/src/core/perplexity_client.py
+++ b/src/core/perplexity_client.py
@@ -71,7 +71,8 @@ class PerplexityClient(LLMClient):
         return self.MODELS
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Sendet Prompt an Perplexity API.
 
@@ -80,6 +81,9 @@ class PerplexityClient(LLMClient):
             model: Die Modell-ID (z.B. 'sonar-pro').
             max_tokens: Optionale Obergrenze für die Antwortlänge
                 (``None`` → :data:`DEFAULT_MAX_TOKENS`).
+            cap_reasoning: Wird hier bewusst **ignoriert** (v0.13.2) — der
+                Reasoning-Cap ist OpenRouter-spezifisch; Perplexity hat kein
+                entsprechendes Steuer-Feld.
 
         Returns:
             APIResponse mit Status und Inhalt.

--- a/tests/factcheck_plus_helpers.py
+++ b/tests/factcheck_plus_helpers.py
@@ -43,6 +43,8 @@ class FakeClient:
         models: Alle verwendeten Modell-IDs in Aufrufreihenfolge.
         max_tokens: Alle übergebenen ``max_tokens``-Werte in Aufrufreihenfolge
             (``None`` = kein Override) — belegt, dass die Stufen 16384 setzen.
+        cap_reasoning: Alle übergebenen ``cap_reasoning``-Flags in
+            Aufrufreihenfolge — belegt, dass die Stufen den Cap anfordern.
     """
 
     def __init__(self, responses: list) -> None:
@@ -56,14 +58,17 @@ class FakeClient:
         self.prompts: list[str] = []
         self.models: list[str] = []
         self.max_tokens: list[int | None] = []
+        self.cap_reasoning: list[bool] = []
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         """Liefert die nächste skriptierte Antwort und protokolliert den Aufruf."""
         self.prompts.append(prompt)
         self.models.append(model)
         self.max_tokens.append(max_tokens)
+        self.cap_reasoning.append(cap_reasoning)
         if not self._responses:
             raise AssertionError(
                 f"FakeClient: unerwarteter {len(self.prompts)}. Aufruf — "

--- a/tests/test_factcheck_plus_worker.py
+++ b/tests/test_factcheck_plus_worker.py
@@ -53,7 +53,8 @@ class ScriptedClient:
         self.calls: list[tuple[str, str]] = []
 
     def send_prompt(
-        self, prompt: str, model: str, max_tokens: int | None = None
+        self, prompt: str, model: str, max_tokens: int | None = None,
+        cap_reasoning: bool = False,
     ) -> APIResponse:
         self.calls.append((prompt, model))
         if not self._responses:

--- a/tests/test_reasoning_cap.py
+++ b/tests/test_reasoning_cap.py
@@ -1,0 +1,200 @@
+"""Reasoning-Cap für OpenRouter-Stage-Calls (v0.13.2).
+
+Anlass (Realtest 2026-07-17, DeepSeek V4 Pro via OpenRouter): S1 scheiterte trotz
+``STAGE_MAX_TOKENS = 16384`` — ~14,7k Tokens gingen ins (durch ``exclude`` unsicht-
+bare) Reasoning, nur ~1,6k in den sichtbaren JSON-Output → ``finish_reason=length``.
+
+Der Fix cappt das Reasoning für strukturierte Stage-Calls per Effort-Cap. Bewusst
+``effort`` statt ``max_tokens``: DeepSeek V4 ist auf OpenRouter effort-gesteuert;
+``effort`` wird nativ verstanden statt über die vage ``max_tokens``→effort-
+Rückabbildung zu laufen.
+
+Deckt die vier Testpunkte des Startprompts ab:
+1. OpenRouter-Stage-Call: Payload enthält den Effort-Cap + weiterhin ``exclude``.
+2. Normaler OpenRouter-Analyse-Call: Payload unverändert (nur ``exclude``).
+3. Andere Provider (Anthropic/OpenAI/Perplexity): Parameter ignoriert, kein
+   Payload-Feld, kein Fehler.
++ Verdrahtung: ``run_json_stage`` fordert ``cap_reasoning=True`` an.
+
+Alles offline, gemockt — kein Netzwerk.
+
+Lauf (ohne pytest):  python tests/test_reasoning_cap.py
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.api_client import APIStatus
+from src.core.openrouter_client import OpenRouterClient
+from src.core.perplexity_client import PerplexityClient
+from src.core.factcheck_plus.llm_stage import run_json_stage
+from tests.factcheck_plus_helpers import FakeClient
+
+
+class _Resp:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+_OK_PAYLOAD = {
+    "choices": [{"message": {"content": "Antwort"}, "finish_reason": "stop"}],
+    "usage": {"total_tokens": 3},
+}
+
+
+def _capture_openrouter(cap_reasoning: bool) -> dict:
+    """Ruft OpenRouter.send_prompt und gibt den gesendeten JSON-Payload zurück."""
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _Resp(_OK_PAYLOAD)
+
+    with patch("src.core.openrouter_client.requests.post", side_effect=fake_post):
+        r = OpenRouterClient("k").send_prompt(
+            "p", "deepseek/deepseek-v4-pro", max_tokens=16384,
+            cap_reasoning=cap_reasoning,
+        )
+    assert r.status == APIStatus.RECEIVED, r.error_message
+    return captured["json"]
+
+
+# --- Punkt 1: Stage-Call bekommt den Effort-Cap ---------------------------
+
+def test_stage_call_sends_effort_cap():
+    """cap_reasoning=True → reasoning enthält effort-Cap UND weiterhin exclude."""
+    payload = _capture_openrouter(cap_reasoning=True)
+    assert payload["reasoning"] == {
+        "exclude": True, "effort": OpenRouterClient.REASONING_CAP_EFFORT,
+    }, payload["reasoning"]
+    assert OpenRouterClient.REASONING_CAP_EFFORT == "low"
+    print("  stage_call_sends_effort_cap OK")
+
+
+# --- Punkt 2: Normaler Analyse-Call unverändert ---------------------------
+
+def test_normal_call_has_no_cap():
+    """Default cap_reasoning=False → reasoning bleibt nur {exclude: True}."""
+    payload = _capture_openrouter(cap_reasoning=False)
+    assert payload["reasoning"] == {"exclude": True}, payload["reasoning"]
+    assert "effort" not in payload["reasoning"]
+    print("  normal_call_has_no_cap OK")
+
+
+def test_default_is_no_cap():
+    """Ohne das Argument bleibt das Verhalten unverändert (nur exclude)."""
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _Resp(_OK_PAYLOAD)
+
+    with patch("src.core.openrouter_client.requests.post", side_effect=fake_post):
+        OpenRouterClient("k").send_prompt("p", "some/model")  # kein cap_reasoning
+    assert captured["json"]["reasoning"] == {"exclude": True}
+    print("  default_is_no_cap OK")
+
+
+# --- Punkt 3: Andere Provider ignorieren das Flag -------------------------
+
+def test_perplexity_ignores_cap():
+    """Perplexity-Payload bekommt KEIN reasoning-Feld, auch mit cap_reasoning."""
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _Resp(_OK_PAYLOAD)
+
+    with patch("src.core.perplexity_client.requests.post", side_effect=fake_post):
+        r = PerplexityClient("k").send_prompt(
+            "p", "sonar-pro", max_tokens=16384, cap_reasoning=True,
+        )
+    assert r.status == APIStatus.RECEIVED, r.error_message
+    assert "reasoning" not in captured["json"], captured["json"]
+    print("  perplexity_ignores_cap OK")
+
+
+def test_openai_ignores_cap():
+    """OpenAI: cap_reasoning=True bricht nicht und setzt kein reasoning-kwarg."""
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        print("  openai_ignores_cap: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.openai_client import OpenAIClient
+
+    resp = MagicMock()
+    resp.choices[0].message.content = "Antwort"
+    resp.choices[0].finish_reason = "stop"
+    resp.usage.total_tokens = 3
+
+    with patch("openai.OpenAI") as M:
+        create = M.return_value.chat.completions.create
+        create.return_value = resp
+        r = OpenAIClient("k").send_prompt("p", "gpt-4o", cap_reasoning=True)
+    assert r.status == APIStatus.RECEIVED
+    assert "reasoning" not in create.call_args.kwargs, create.call_args.kwargs
+    print("  openai_ignores_cap OK")
+
+
+def test_anthropic_ignores_cap():
+    """Anthropic: cap_reasoning=True bricht nicht und setzt kein reasoning-kwarg."""
+    try:
+        import anthropic  # noqa: F401
+    except ImportError:
+        print("  anthropic_ignores_cap: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.anthropic_client import AnthropicClient
+
+    block = MagicMock()
+    block.text = "Hallo"
+    msg = MagicMock()
+    msg.content = [block]
+    msg.stop_reason = "end_turn"
+    msg.usage.input_tokens = 1
+    msg.usage.output_tokens = 2
+
+    with patch("anthropic.Anthropic") as M:
+        create = M.return_value.messages.create
+        create.return_value = msg
+        r = AnthropicClient("k").send_prompt(
+            "p", "claude-sonnet-4-6", cap_reasoning=True,
+        )
+    assert r.status == APIStatus.RECEIVED and r.content == "Hallo"
+    assert "reasoning" not in create.call_args.kwargs, create.call_args.kwargs
+    print("  anthropic_ignores_cap OK")
+
+
+# --- Verdrahtung: die Stufe fordert den Cap an ----------------------------
+
+def test_run_json_stage_requests_cap():
+    """run_json_stage reicht cap_reasoning=True an den Client durch (alle Stufen)."""
+    client = FakeClient(["[]"])
+    result = run_json_stage(client, "m", "p", parse=lambda raw: raw, stage_name="S")
+    assert result == []
+    assert client.cap_reasoning == [True], client.cap_reasoning
+    print("  run_json_stage_requests_cap OK")
+
+
+def main():
+    print("Reasoning-Cap für OpenRouter-Stage-Calls (v0.13.2):")
+    test_stage_call_sends_effort_cap()
+    test_normal_call_has_no_cap()
+    test_default_is_no_cap()
+    test_perplexity_ignores_cap()
+    test_openai_ignores_cap()
+    test_anthropic_ignores_cap()
+    test_run_json_stage_requests_cap()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stage_truncation_gate.py
+++ b/tests/test_stage_truncation_gate.py
@@ -179,7 +179,7 @@ class _StubClient:
         self._response = response
         self.seen_max_tokens = []
 
-    def send_prompt(self, prompt, model, max_tokens=None):
+    def send_prompt(self, prompt, model, max_tokens=None, cap_reasoning=False):
         self.seen_max_tokens.append(max_tokens)
         return self._response
 


### PR DESCRIPTION
## Anlass (Realtest 2026-07-17, DeepSeek V4 Pro via OpenRouter)

Faktencheck Plus S1 scheiterte **trotz** `STAGE_MAX_TOKENS = 16384` aus v0.13.1. Diesmal nicht die Output-Größe: Von ~16,4k Budget kamen nur ~1,6k Tokens sichtbarer Content an (valides JSON, mid-Objekt gekappt) — **~14,7k Tokens gingen ins Modell-Reasoning** (durch `reasoning.exclude=true` seit v0.11.0 unsichtbar, zählt aber voll gegen `max_tokens`). Das Trunkierungs-Gate aus v0.13.1 hat korrekt und ehrlich gemeldet (`finish_reason=length`, kein Reparatur-Retry) — dieser PR adressiert die **Ursache**. Budget weiter erhöhen wäre ein Wettrüsten (+ OpenRouter-402-Historie).

Bemerkenswert: Der große Analyse-Call (180k-Prompt) lief mit wenig Reasoning sauber durch — der Reasoning-Exzess tritt gerade bei der strukturierten JSON-Extraktion auf.

## Recherche (Bedingung aus Phase 17 — vor dem Code)

OpenRouters vereinheitlichter `reasoning`-Parameter (Live-Doku + API-Referenz):

- **Felder:** `effort` (`max`/`high`/`medium`/`low`/`minimal`/`none`) **XOR** `max_tokens` (nicht beide); `exclude` (bool) ist **orthogonal** und mit beiden kombinierbar; `enabled` (bool).
- **Normalisierung:** OpenRouter rechnet zwischen effort und Budget um. Die **`effort`→Budget-Richtung ist explizit dokumentiert** (`budget = clamp(max_tokens × ratio, 1024, 128000)`, ratio `low`=0.2); die **`max_tokens`→effort-Rückabbildung nur vage** („based on the percentages above").
- **DeepSeek V4** (unser Zielmodell) ist auf OpenRouter **effort-gesteuert** — belegt via [earendil-works/pi#4055](https://github.com/earendil-works/pi/issues/4055) (nutzt Effort-Enum, `xhigh`→`max`; OpenRouter lehnt out-of-enum `max` ab → Fallback auf Default).
- **Non-Reasoning-Modelle:** Doku sagt, das `reasoning`-Feld werde „omitted" → impliziert ignoriert. **Fehlerverhalten bei Mismatch ist eine Doku-Lücke** (nicht explizit).
- `max_tokens` + `exclude: true` sind **kombinierbar** (Doku zeigt es direkt).

Quellen: [Reasoning Tokens](https://openrouter.ai/docs/use-cases/reasoning-tokens) · [API-Parameter](https://openrouter.ai/docs/api-reference/parameters) · [Issue #4055](https://github.com/earendil-works/pi/issues/4055)

## Entscheidung: `effort: "low"` statt `max_tokens: 4096`

Der Startprompt gab die Wahl frei („die Form, die die Recherche als tragfähig ausweist"). Die Recherche weist **effort** aus:

- Das reale Zielmodell (DeepSeek V4) ist effort-gesteuert → `effort` wird **nativ** verstanden, statt über die vage `max_tokens`→effort-Rückabbildung zu laufen.
- Die effort→Budget-Normalisierung (für token-native Familien wie Anthropic/Qwen) ist die **dokumentierte** Richtung: `low` ≈ 0.2 × 16384 ≈ 3,3k Tokens, über Anthropics 1024-Minimum.
- `"max"` gemieden (bekannter Mapping-Bug aus #4055); `"low"` ist ein valider normalisierter Enum-Wert. Mit `exclude` kombinierbar.

## Implementation

- `send_prompt` aller 4 Clients um `cap_reasoning: bool = False` erweitert. **Nur `openrouter_client`** wertet es aus (`reasoning: {effort: "low", exclude: true}`); die anderen ignorieren es **dokumentiert** (Anthropic/OpenAI haben eigene Reasoning-Semantik → separater PR). Verdrahtung analog zum `max_tokens`-Muster aus #61: `_TokenCountingClient` reicht durch, `run_json_stage` fordert `cap_reasoning=True` für alle Stage-Calls (S1/S2/S4/S5).
- **Normaler Analyse-Call bleibt ungecappt** — dort ist Reasoning erwünscht, und der v0.11-Gate+Retry-Pfad deckt Trunkierung ab.
- `STAGE_MAX_TOKENS` unverändert (16384). Das **Trunkierungs-Gate (v0.13.1 Teil A) bleibt Sicherheitsnetz**, falls ein Modell den Cap ignoriert.

## Offene Risiken (Doku-Lücke)

- Das exakte Reasoning-Budget, das DeepSeek V4 für `"low"` bekommt, ist nicht doku-garantiert (empirisch aber << 14,7k).
- Mismatch-/Non-Reasoning-Fehlerverhalten ist unspezifiziert. **Degradiert aber sauber:** ein hypothetischer Fehler landet als ehrlicher `StageError` (via `run_json_stage`), nicht als stille Korruption — wir sind nie schlechter als heute (wo DeepSeek ohnehin scheitert).

## Nebeneffekt

Reasoning-Tokens werden berechnet → der Cap spart bei reasoning-lastigen Modellen direkt Geld (im Fehlerfall oben: ~14,7k verschwendete Tokens für einen Fehlschlag).

## Ausdrücklich NICHT in diesem PR

Thinking-Steuerung für Anthropic direkt (eigene API-Semantik); `STAGE_MAX_TOKENS` ändern (16384 bleibt); S1-Schema verschlanken.

## Tests

`tests/test_reasoning_cap.py` (7, offline/gemockt):
1. OpenRouter-Stage-Call → Payload `reasoning == {exclude: true, effort: "low"}`.
2. Normaler OpenRouter-Call → `reasoning == {exclude: true}`, kein `effort` (auch ohne das Argument).
3. Perplexity/OpenAI/Anthropic → `cap_reasoning=True` ignoriert: kein `reasoning`-Payload-Feld, kein Fehler.
4. Verdrahtung: `run_json_stage` reicht `cap_reasoning=True` durch.

Gesamtsuite **297 grün** (war 290, +7). `APP_VERSION` → 0.13.2, README-Spotlight + „Seit v0.13.1"-Demotion, CLAUDE.md (Phase 24; Phase-17-Item-3 aufgelöst).

## Merge-Kriterium (PO-Realtest)

DeepSeek V4 Pro via OpenRouter, dasselbe 21-Claim-Video + Katar-747 — S1 läuft durch statt `finish_reason=length`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Reasoning-Budgets können bei strukturierten Aufrufen optional begrenzt werden.
  * Diese Begrenzung wird für OpenRouter angewendet; andere Anbieter ignorieren die Einstellung.

* **Verbesserungen**
  * Stufenaufrufe nutzen automatisch die Reasoning-Begrenzung für verlässlichere Ergebnisse.
  * Die Anwendungsversion wurde auf 0.13.2 aktualisiert.

* **Tests**
  * Neue automatisierte Prüfungen stellen die korrekte Weitergabe und Anbieter-spezifische Verarbeitung sicher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->