### PR TITLE
fix: 32k-Stage-Budget für OpenRouter + Token-Split im Log (v0.13.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.13.2
+**Version:** 0.13.3
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -712,6 +712,46 @@ aus v0.13.1 hat korrekt und ehrlich gemeldet — jetzt die Ursache adressiert.
 - [ ] NICHT in diesem PR: Thinking-Steuerung für Anthropic direkt (eigene
   API-Semantik, separater PR nach Recherche)
 
+### Phase 25: 32k-Stage-Budget für OpenRouter + Token-Split im Log ✅ (v0.13.3)
+
+Realtest 2026-07-17 08:02 (DeepSeek V4 Pro via OpenRouter, v0.13.2): Der
+Reasoning-Cap wurde korrekt gesendet (Verdrahtung geprüft), aber der **Upstream-
+Host respektierte ihn nicht** — S1 verbrauchte erneut exakt das volle Budget
+(tokens_total 18.348 ≈ ~1,96k Input + 16.384), davon ~11,4k Reasoning, nur ~4,6k
+sichtbarer Content, `finish_reason=length`. Das in v0.13.2 als Doku-Lücke notierte
+Risiko (Compliance = Glückssache bei wechselnden Hosts) ist damit empirisch
+bestätigt. Das Gate (v0.13.1) hat korrekt gemeldet — jetzt braucht der Content mehr
+Luft, unabhängig von Host-Kooperation.
+
+- [x] Teil A · OpenRouter-Stage-Budget `STAGE_MAX_TOKENS_OPENROUTER = 32768`:
+  greift für S1/S2/S4/S5, **wenn der Stufen-Client OpenRouter ist**
+  (~21k Worst Case → ~11k Reserve). `STAGE_MAX_TOKENS = 16384` bleibt für alle
+  anderen Provider. **Ort der Entscheidung:** die Qt↔Package-Naht
+  (`_TokenCountingClient` prüft `PROVIDER_ID == "openrouter"` und hebt das Budget,
+  reicht es wie bisher als `max_tokens` durch) — `llm_stage`/Package bleiben
+  provider-agnostisch. Reasoning-Cap (v0.13.2) bleibt aktiv (schadet nie, spart bei
+  kooperativen Hosts); Trunkierungs-Gate (v0.13.1) bleibt Sicherheitsnetz. Normaler
+  Analyse-Call unverändert (`DEFAULT_MAX_TOKENS`). 402-Vorauth gegen 32768 bei
+  DeepSeek-Preisen akzeptiert (PO); echtes 402 bliebe offener Fehler (v0.13.2-Linie)
+- [x] Teil B · Token-Split im Debug-Log: `APIResponse` trägt jetzt
+  `tokens_input`/`tokens_output`/`reasoning_tokens` (+ `token_log_dict()`-Helfer);
+  alle 4 Clients füllen input/output aus dem `usage`-Objekt (Feldnamen live
+  geprüft: OpenAI-kompatibel `prompt_tokens`/`completion_tokens`, Anthropic
+  `input_tokens`/`output_tokens`), OpenRouter/OpenAI zusätzlich
+  `completion_tokens_details.reasoning_tokens`. `log_response` persistiert
+  `tokens_reasoning` (leer=`null`, wenn nicht geliefert). Alle 5 Log-Aufrufstellen
+  mit echter Response (api/comparison/verification/factcheck_plus_worker) schreiben
+  den Split; die Reasoning-Anteile mussten bisher per Zeichen-Arithmetik geschätzt
+  werden
+- [x] Tests `tests/test_stage_budget_and_tokens.py` (11): OpenRouter-Stage → 32768
+  + Cap; Perplexity/Anthropic-Stage → 16384; normaler OpenRouter-Call → DEFAULT;
+  Token-Split je Provider (inkl. reasoning_tokens); fehlendes `usage` → 0/None kein
+  Crash; Log persistiert den Split. Gesamtsuite 308 grün
+- [x] `APP_VERSION` → 0.13.3, README-Spotlight + „Seit v0.13.2"-Demotion
+- [ ] NICHT in diesem PR: Entkopplung Stufen-/Analyse-Modell (struktureller
+  Folge-PR, PO entscheidet nach mehr Modell-Daten); S1-Schema verschlanken;
+  weitere Cap-Varianten (`effort: "minimal"` — gleiche Compliance-Lotterie)
+
 ### Backlog
 
 - [ ] A4-Feinschliff: erzwungenes Modul aus der `MODUL-AUSWAHL`-Liste entfernen
@@ -761,4 +801,4 @@ Bei Unklarheiten: Frag nach! Lieber einmal zu viel als eine falsche Annahme tref
 
 ---
 
-Letzte Aktualisierung: 2026-07-17
+Letzte Aktualisierung: 2026-07-17 (v0.13.3)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.13.2) — Reasoning-Cap für Stage-Calls
+### Aktuell (v0.13.3) — 32k-Stage-Budget für OpenRouter + Token-Split im Log
+
+Der Reasoning-Cap aus v0.13.2 wurde nachweislich korrekt gesendet, aber der DeepSeek-Upstream-Host **respektierte ihn nicht**: S1 verbrauchte erneut das volle Budget (~11,4k Reasoning, nur ~4,6k sichtbarer Content, `finish_reason=length`). Effort-Compliance ist bei wechselnden Hosts Glückssache – also braucht der Content schlicht mehr Luft, unabhängig von Host-Kooperation.
+
+- **OpenRouter-Stage-Budget auf 32768** – Die Plus-Stufen-Calls (S1/S2/S4/S5) bekommen bei OpenRouter das doppelte Antwort-Budget (11,4–14,7k Reasoning + ~5–6k Content ≈ 21k Worst Case → 32768 lässt ~11k Reserve). Andere Provider bleiben bei 16384; der normale Analyse-Call unverändert. Der Reasoning-Cap bleibt aktiv (schadet nie, spart Geld bei Hosts, die ihn respektieren); das Trunkierungs-Gate bleibt Sicherheitsnetz. Die Provider-Entscheidung sitzt an der Qt↔Package-Naht – das `factcheck_plus`-Package bleibt provider-agnostisch
+- **Token-Split im Debug-Log** – Alle 4 Clients füllen jetzt `tokens_input`/`tokens_output` aus dem `usage`-Objekt (standen bisher immer auf 0); OpenRouter/OpenAI zusätzlich den **Reasoning-Anteil** (`tokens_reasoning`, sonst leer). Damit lässt sich der Reasoning-Verbrauch verschiedener Modelle direkt vergleichen, statt ihn per Zeichen-Arithmetik zu schätzen
+
+### Seit v0.13.2 — Reasoning-Cap für Stage-Calls
 
 Faktencheck Plus S1 scheiterte bei DeepSeek V4 Pro (via OpenRouter) **trotz** des 16384-Budgets aus v0.13.1: Diesmal war nicht der Output zu groß, sondern das (durch `reasoning.exclude=true` unsichtbare) Modell-Reasoning fraß ~14,7k der ~16,4k Tokens – nur ~1,6k kamen als sichtbares JSON an, mitten im Objekt gekappt (`finish_reason=length`). Budget weiter zu erhöhen wäre ein Wettrüsten.
 

--- a/src/core/anthropic_client.py
+++ b/src/core/anthropic_client.py
@@ -115,12 +115,15 @@ class AnthropicClient(LLMClient):
                     "stop_reason", stop_reason, {"max_tokens": "length"}
                 )
 
-            tokens_used = 0
+            # v0.13.3: Token-Split fürs Debug-Log. Anthropic nennt die Felder
+            # input_tokens/output_tokens (kein total). Thinking-Tokens zählen bei
+            # Anthropic in output_tokens — keine separate Reasoning-Zahl → None.
+            tokens_input = 0
+            tokens_output = 0
             if message.usage:
-                tokens_used = (
-                    getattr(message.usage, "input_tokens", 0)
-                    + getattr(message.usage, "output_tokens", 0)
-                )
+                tokens_input = getattr(message.usage, "input_tokens", 0)
+                tokens_output = getattr(message.usage, "output_tokens", 0)
+            tokens_used = tokens_input + tokens_output
 
             # v0.11.0: stop_reason durchreichen. Anthropic nennt Trunkierung
             # "max_tokens" — auf das providerübergreifende "length" normalisieren,
@@ -140,6 +143,8 @@ class AnthropicClient(LLMClient):
                 model_used=model,
                 provider_used=self.PROVIDER_NAME,
                 tokens_used=tokens_used,
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
                 finish_reason=finish_reason,
             )
 

--- a/src/core/api_client.py
+++ b/src/core/api_client.py
@@ -94,6 +94,14 @@ class APIResponse:
     model_used: str = ""
     provider_used: str = ""
     tokens_used: int = 0
+    # v0.13.3: Aufschlüsselung des Token-Verbrauchs für die Debug-Log-Datensammlung
+    # (Modellvergleiche). ``tokens_used`` bleibt die Gesamtsumme (rückwärtskompatibel);
+    # ``tokens_input``/``tokens_output`` kommen aus dem ``usage``-Objekt der Antwort.
+    # ``reasoning_tokens`` ist optional — nur Provider mit entsprechender
+    # ``usage``-Aufschlüsselung (OpenRouter/OpenAI) liefern es, sonst ``None``.
+    tokens_input: int = 0
+    tokens_output: int = 0
+    reasoning_tokens: int | None = None
     citations: list[str] = field(default_factory=list)
     duration_seconds: float = 0.0
     # v0.11.0: Warum das Modell gestoppt hat (z.B. "stop", "length", "max_tokens").
@@ -104,6 +112,22 @@ class APIResponse:
     # Ein Leer-Inhalt-Fehler trägt hier 200 (HTTP war OK, nur der Content leer) —
     # der Worker loggt diesen echten Status statt eines Default-500.
     http_status: int | None = None
+
+    def token_log_dict(self) -> dict:
+        """Baut das ``tokens``-Dict fürs Debug-Log (input/output/total).
+
+        Zentralisiert die Aufschlüsselung, damit alle Log-Aufrufstellen
+        (api_worker, comparison_/verification_/factcheck_plus_worker) den Split
+        einheitlich schreiben statt nur ``{"total": …}``.
+
+        Returns:
+            Dict mit den Schlüsseln ``input``/``output``/``total``.
+        """
+        return {
+            "input": self.tokens_input,
+            "output": self.tokens_output,
+            "total": self.tokens_used,
+        }
 
 
 class LLMClient(ABC):

--- a/src/core/api_worker.py
+++ b/src/core/api_worker.py
@@ -98,11 +98,12 @@ class APIWorker(QThread):
                         log_dir=log_dir,
                         status_code=200,
                         content=response.content,
-                        tokens={"total": response.tokens_used},
+                        tokens=response.token_log_dict(),
                         duration=duration,
                         model_used=response.model_used,
                         citations=response.citations,
                         finish_reason=response.finish_reason,
+                        reasoning_tokens=response.reasoning_tokens,
                     )
             else:
                 self.status_changed.emit(APIStatus.ERROR.value)
@@ -115,11 +116,12 @@ class APIWorker(QThread):
                         log_dir=log_dir,
                         status_code=response.http_status if response.http_status is not None else 500,
                         content=response.content,
-                        tokens={"total": response.tokens_used},
+                        tokens=response.token_log_dict(),
                         duration=duration,
                         model_used=response.model_used,
                         error=response.error_message,
                         finish_reason=response.finish_reason,
+                        reasoning_tokens=response.reasoning_tokens,
                     )
 
         except Exception as e:

--- a/src/core/comparison_worker.py
+++ b/src/core/comparison_worker.py
@@ -290,11 +290,13 @@ class ComparisonWorker(QThread):
                 log_dir=log_dir,
                 status_code=200 if ok else 500,
                 content=response.content,
-                tokens={"total": response.tokens_used},
+                tokens=response.token_log_dict(),
                 duration=duration,
                 model_used=response.model_used,
                 citations=response.citations,
                 error=None if ok else (response.error_message or "Fehler"),
+                finish_reason=response.finish_reason,
+                reasoning_tokens=response.reasoning_tokens,
             )
         return response
 

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.13.2"
+APP_VERSION = "0.13.3"
 
 
 class DebugLogger:
@@ -93,6 +93,7 @@ class DebugLogger:
         citations: list[str] | None = None,
         error: str | None = None,
         finish_reason: str = "",
+        reasoning_tokens: int | None = None,
     ) -> None:
         """Logs received API response.
 
@@ -108,6 +109,9 @@ class DebugLogger:
             finish_reason: Stopp-Grund des Modells (z.B. "stop", "length"). v0.11.0:
                 persistiert, weil "length"/"max_tokens" eine Trunkierung verraten —
                 im Iran-Sample fehlte genau dieses Feld.
+            reasoning_tokens: Reasoning-Anteil der Output-Tokens (v0.13.3, nur
+                Provider mit ``usage``-Aufschlüsselung). ``None`` = nicht geliefert;
+                wird dann als ``null`` persistiert (statt fälschlich als 0).
         """
         if not self.enabled or log_dir is None:
             return
@@ -121,6 +125,7 @@ class DebugLogger:
             "tokens_input": tokens.get("input", 0),
             "tokens_output": tokens.get("output", 0),
             "tokens_total": tokens.get("total", 0),
+            "tokens_reasoning": reasoning_tokens,
             "content_length_chars": len(content),
             "error": error is not None,
         }

--- a/src/core/factcheck_plus_worker.py
+++ b/src/core/factcheck_plus_worker.py
@@ -47,6 +47,17 @@ NO_CLAIMS_SECTION = (
 # Stufenanzahl für die Fortschrittsanzeige (S1, S2, S3, S4, S5).
 TOTAL_STAGES = 5
 
+# v0.13.3: Größeres Antwort-Budget für OpenRouter-Stage-Calls. DeepSeek-Upstream-
+# Hosts respektieren den Reasoning-Cap (v0.13.2) nicht zuverlässig — das Reasoning
+# frisst weiter das Budget (~11–15k), der sichtbare JSON-Content braucht schlicht
+# mehr Luft (~5–6k bei 19–21 Claims). 32768 lässt ~11k Reserve über den Worst Case.
+# Die Provider-Kenntnis sitzt bewusst HIER an der Qt↔Package-Naht, nicht im
+# client-agnostischen ``llm_stage`` (das Package kennt keine Provider). Andere
+# Provider bleiben bei ``llm_stage.STAGE_MAX_TOKENS`` (16384). 402-Vorauth gegen
+# 32768 ist bei DeepSeek-Preisen vernachlässigbar (PO-Entscheidung); ein echtes 402
+# bliebe ein offener Fehler (nicht still absenken, Linie aus v0.13.2).
+STAGE_MAX_TOKENS_OPENROUTER = 32768
+
 
 class _TokenCountingClient:
     """Zählt Tokens und loggt Requests, ohne die Stufen davon wissen zu lassen.
@@ -113,9 +124,21 @@ class _TokenCountingClient:
                 },
             )
 
+        # v0.13.3: OpenRouter-Stufen bekommen das größere Budget (s.
+        # STAGE_MAX_TOKENS_OPENROUTER). Die Anhebung greift nur, wenn die Stufe
+        # überhaupt ein Budget anfordert (max_tokens gesetzt) und der echte Client
+        # OpenRouter ist — die Provider-Wahl bleibt an dieser Naht, nicht im Package.
+        effective_max_tokens = max_tokens
+        if (
+            max_tokens is not None
+            and getattr(self._client, "PROVIDER_ID", "") == "openrouter"
+        ):
+            effective_max_tokens = STAGE_MAX_TOKENS_OPENROUTER
+
         start = time.time()
         response = self._client.send_prompt(
-            prompt, model, max_tokens=max_tokens, cap_reasoning=cap_reasoning,
+            prompt, model, max_tokens=effective_max_tokens,
+            cap_reasoning=cap_reasoning,
         )
         duration = time.time() - start
         response.duration_seconds = duration
@@ -134,7 +157,7 @@ class _TokenCountingClient:
                     else (200 if ok else 500)
                 ),
                 content=response.content,
-                tokens={"total": response.tokens_used},
+                tokens=response.token_log_dict(),
                 duration=duration,
                 model_used=response.model_used,
                 citations=response.citations,
@@ -142,6 +165,8 @@ class _TokenCountingClient:
                 # v0.13.1: finish_reason durchreichen — sonst stand im Stage-Log
                 # immer "" und verschleppte die Trunkierungs-Diagnose (Teil B).
                 finish_reason=response.finish_reason,
+                # v0.13.3: Token-Split + Reasoning-Anteil (Datensammlung).
+                reasoning_tokens=response.reasoning_tokens,
             )
         return response
 

--- a/src/core/openai_client.py
+++ b/src/core/openai_client.py
@@ -105,7 +105,17 @@ class OpenAIClient(LLMClient):
                     "finish_reason", finish_reason
                 )
 
-            tokens_used = response.usage.total_tokens if response.usage else 0
+            # v0.13.3: Token-Split fürs Debug-Log. usage nennt prompt_tokens/
+            # completion_tokens/total_tokens; die o-Series liefert den Reasoning-
+            # Anteil unter completion_tokens_details.reasoning_tokens.
+            usage = response.usage
+            tokens_used = usage.total_tokens if usage else 0
+            tokens_input = getattr(usage, "prompt_tokens", 0) if usage else 0
+            tokens_output = getattr(usage, "completion_tokens", 0) if usage else 0
+            reasoning_tokens = None
+            if usage is not None:
+                details = getattr(usage, "completion_tokens_details", None)
+                reasoning_tokens = getattr(details, "reasoning_tokens", None)
 
             logger.info(
                 f"OpenAI Antwort: {len(content)} Zeichen, "
@@ -118,6 +128,9 @@ class OpenAIClient(LLMClient):
                 model_used=model,
                 provider_used=self.PROVIDER_NAME,
                 tokens_used=tokens_used,
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+                reasoning_tokens=reasoning_tokens,
                 finish_reason=self._normalize_finish_reason(finish_reason),
             )
 

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -221,7 +221,15 @@ class OpenRouterClient(LLMClient):
                         "finish_reason", finish_reason
                     )
 
-                tokens = data.get("usage", {}).get("total_tokens", 0)
+                # v0.13.3: Token-Split fürs Debug-Log. OpenRouter (OpenAI-kompatibel)
+                # liefert usage immer mit: prompt_tokens/completion_tokens/total_tokens
+                # + optional completion_tokens_details.reasoning_tokens (gegen die
+                # Live-Doku „Usage Accounting" geprüft).
+                usage = data.get("usage") or {}
+                tokens = usage.get("total_tokens", 0)
+                reasoning_tokens = (
+                    usage.get("completion_tokens_details") or {}
+                ).get("reasoning_tokens")
 
                 logger.info(
                     f"OpenRouter Antwort: {len(content)} Zeichen, "
@@ -234,6 +242,9 @@ class OpenRouterClient(LLMClient):
                     model_used=model,
                     provider_used=self.PROVIDER_NAME,
                     tokens_used=tokens,
+                    tokens_input=usage.get("prompt_tokens", 0),
+                    tokens_output=usage.get("completion_tokens", 0),
+                    reasoning_tokens=reasoning_tokens,
                     finish_reason=self._normalize_finish_reason(finish_reason),
                 )
 

--- a/src/core/perplexity_client.py
+++ b/src/core/perplexity_client.py
@@ -137,7 +137,10 @@ class PerplexityClient(LLMClient):
                         "finish_reason", finish_reason
                     )
 
-                tokens = data.get("usage", {}).get("total_tokens", 0)
+                # v0.13.3: Token-Split fürs Debug-Log (OpenAI-kompatibles usage).
+                # Perplexity liefert keine Reasoning-Aufschlüsselung → None.
+                usage = data.get("usage") or {}
+                tokens = usage.get("total_tokens", 0)
                 citations = data.get("citations", [])
 
                 logger.info(
@@ -151,6 +154,8 @@ class PerplexityClient(LLMClient):
                     model_used=model,
                     provider_used=self.PROVIDER_NAME,
                     tokens_used=tokens,
+                    tokens_input=usage.get("prompt_tokens", 0),
+                    tokens_output=usage.get("completion_tokens", 0),
                     citations=citations,
                     finish_reason=self._normalize_finish_reason(finish_reason),
                 )

--- a/src/core/verification_worker.py
+++ b/src/core/verification_worker.py
@@ -169,11 +169,13 @@ class VerificationWorker(QThread):
                 log_dir=log_dir,
                 status_code=200 if ok else 500,
                 content=response.content,
-                tokens={"total": response.tokens_used},
+                tokens=response.token_log_dict(),
                 duration=duration,
                 model_used=response.model_used,
                 citations=response.citations,
                 error=None if ok else (response.error_message or "Fehler"),
+                finish_reason=response.finish_reason,
+                reasoning_tokens=response.reasoning_tokens,
             )
         return response
 

--- a/tests/test_stage_budget_and_tokens.py
+++ b/tests/test_stage_budget_and_tokens.py
@@ -1,0 +1,296 @@
+"""32k-Stage-Budget für OpenRouter + Token-Split im Debug-Log (v0.13.3).
+
+Teil A — OpenRouter-Stage-Calls bekommen an der Qt↔Package-Naht
+(``_TokenCountingClient``) das größere Budget ``STAGE_MAX_TOKENS_OPENROUTER``
+(32768), weil DeepSeek-Hosts den Reasoning-Cap aus v0.13.2 nicht zuverlässig
+respektieren. Andere Provider bleiben bei ``STAGE_MAX_TOKENS`` (16384); der
+Reasoning-Cap bleibt aktiv.
+
+Teil B — Alle 4 Clients füllen ``tokens_input``/``tokens_output`` aus dem
+``usage``-Objekt; OpenRouter/OpenAI zusätzlich ``reasoning_tokens``. Das
+Debug-Log persistiert den Split (bisher standen ``tokens_input/output`` immer 0).
+
+Alles offline, gemockt — kein Netzwerk.
+
+Lauf (ohne pytest):  QT_QPA_PLATFORM=offscreen python tests/test_stage_budget_and_tokens.py
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.api_client import DEFAULT_MAX_TOKENS, APIResponse, APIStatus
+from src.core.debug_logger import DebugLogger
+from src.core.openrouter_client import OpenRouterClient
+from src.core.perplexity_client import PerplexityClient
+from src.core.factcheck_plus.llm_stage import STAGE_MAX_TOKENS
+import src.core.factcheck_plus_worker as fpw
+from src.core.factcheck_plus_worker import STAGE_MAX_TOKENS_OPENROUTER, _TokenCountingClient
+
+
+class _Resp:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _ok_payload(usage=None):
+    return {
+        "choices": [{"message": {"content": "Antwort"}, "finish_reason": "stop"}],
+        "usage": usage if usage is not None else {"total_tokens": 3},
+    }
+
+
+def _capture(module_path: str):
+    """Patch-Kontext, der den gesendeten JSON-Payload einsammelt."""
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _Resp(_ok_payload())
+
+    return captured, patch(f"{module_path}.requests.post", side_effect=fake_post)
+
+
+class _RecordingStub:
+    """Client-Doppelgänger mit PROVIDER_ID, der die Aufrufe protokolliert."""
+
+    def __init__(self, provider_id: str):
+        self.PROVIDER_ID = provider_id
+        self.seen_max_tokens = []
+
+    def send_prompt(self, prompt, model, max_tokens=None, cap_reasoning=False):
+        self.seen_max_tokens.append(max_tokens)
+        return APIResponse(status=APIStatus.RECEIVED, content="[]", tokens_used=1)
+
+
+# === Teil A: 32k-Budget für OpenRouter-Stage-Calls ========================
+
+def test_openrouter_stage_call_uses_32k():
+    """Durch die Naht: OpenRouter-Stage-Call → Payload max_tokens=32768 + Cap."""
+    captured, ctx = _capture("src.core.openrouter_client")
+    wrapped = _TokenCountingClient(OpenRouterClient("k"), "s1_refiner")
+    with ctx:
+        # llm_stage fordert 16384 an; die Naht hebt es für OpenRouter auf 32768.
+        r = wrapped.send_prompt("p", "deepseek/deepseek-v4-pro",
+                                max_tokens=STAGE_MAX_TOKENS, cap_reasoning=True)
+    assert r.status == APIStatus.RECEIVED, r.error_message
+    assert STAGE_MAX_TOKENS_OPENROUTER == 32768
+    assert captured["json"]["max_tokens"] == 32768, captured["json"]["max_tokens"]
+    # Reasoning-Cap bleibt unverändert aktiv.
+    assert captured["json"]["reasoning"] == {"exclude": True, "effort": "low"}
+    print("  openrouter_stage_call_uses_32k OK")
+
+
+def test_perplexity_stage_call_stays_16k():
+    """Nicht-OpenRouter-Stage-Call bleibt bei 16384, kein reasoning-Feld."""
+    captured, ctx = _capture("src.core.perplexity_client")
+    wrapped = _TokenCountingClient(PerplexityClient("k"), "s5_verifier")
+    with ctx:
+        r = wrapped.send_prompt("p", "sonar-pro",
+                                max_tokens=STAGE_MAX_TOKENS, cap_reasoning=True)
+    assert r.status == APIStatus.RECEIVED, r.error_message
+    assert captured["json"]["max_tokens"] == STAGE_MAX_TOKENS == 16384
+    assert "reasoning" not in captured["json"], captured["json"]
+    print("  perplexity_stage_call_stays_16k OK")
+
+
+def test_non_openrouter_budget_unchanged_at_seam():
+    """Die Naht hebt nur für OpenRouter an — Anthropic bleibt bei 16384."""
+    stub = _RecordingStub("anthropic")
+    _TokenCountingClient(stub, "s1_refiner").send_prompt(
+        "p", "claude-sonnet-4-6", max_tokens=STAGE_MAX_TOKENS, cap_reasoning=True,
+    )
+    assert stub.seen_max_tokens == [STAGE_MAX_TOKENS]
+    # Gegenprobe: OpenRouter-Stub bekommt 32768.
+    orb = _RecordingStub("openrouter")
+    _TokenCountingClient(orb, "s1_refiner").send_prompt(
+        "p", "x", max_tokens=STAGE_MAX_TOKENS, cap_reasoning=True,
+    )
+    assert orb.seen_max_tokens == [STAGE_MAX_TOKENS_OPENROUTER]
+    print("  non_openrouter_budget_unchanged_at_seam OK")
+
+
+def test_normal_openrouter_call_unchanged():
+    """Normaler (nicht durch die Naht laufender) OpenRouter-Call: DEFAULT + nur exclude."""
+    captured, ctx = _capture("src.core.openrouter_client")
+    with ctx:
+        OpenRouterClient("k").send_prompt("p", "some/model")
+    assert captured["json"]["max_tokens"] == DEFAULT_MAX_TOKENS
+    assert captured["json"]["reasoning"] == {"exclude": True}
+    print("  normal_openrouter_call_unchanged OK")
+
+
+# === Teil B: Token-Split im Debug-Log =====================================
+
+def test_openrouter_token_split_and_reasoning():
+    """OpenRouter füllt input/output + reasoning_tokens aus usage."""
+    usage = {
+        "prompt_tokens": 1960, "completion_tokens": 16384, "total_tokens": 18344,
+        "completion_tokens_details": {"reasoning_tokens": 11400},
+    }
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _Resp(_ok_payload(usage))
+
+    with patch("src.core.openrouter_client.requests.post", side_effect=fake_post):
+        r = OpenRouterClient("k").send_prompt("p", "deepseek/deepseek-v4-pro")
+    assert r.tokens_input == 1960 and r.tokens_output == 16384
+    assert r.tokens_used == 18344
+    assert r.reasoning_tokens == 11400
+    print("  openrouter_token_split_and_reasoning OK")
+
+
+def test_openrouter_missing_usage_no_crash():
+    """Fehlt usage, bleiben die Felder 0/None — kein Crash."""
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _Resp({"choices": [{"message": {"content": "Antwort"},
+                                   "finish_reason": "stop"}]})  # kein usage
+
+    with patch("src.core.openrouter_client.requests.post", side_effect=fake_post):
+        r = OpenRouterClient("k").send_prompt("p", "some/model")
+    assert r.status == APIStatus.RECEIVED
+    assert r.tokens_input == 0 and r.tokens_output == 0
+    assert r.reasoning_tokens is None
+    print("  openrouter_missing_usage_no_crash OK")
+
+
+def test_perplexity_token_split_no_reasoning():
+    """Perplexity füllt input/output, aber kein reasoning_tokens."""
+    usage = {"prompt_tokens": 50, "completion_tokens": 200, "total_tokens": 250}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _Resp({"choices": [{"message": {"content": "A"},
+                                   "finish_reason": "stop"}], "usage": usage})
+
+    with patch("src.core.perplexity_client.requests.post", side_effect=fake_post):
+        r = PerplexityClient("k").send_prompt("p", "sonar-pro")
+    assert r.tokens_input == 50 and r.tokens_output == 200
+    assert r.reasoning_tokens is None
+    print("  perplexity_token_split_no_reasoning OK")
+
+
+def test_anthropic_token_split():
+    """Anthropic füllt input/output aus usage; kein separates reasoning."""
+    try:
+        import anthropic  # noqa: F401
+    except ImportError:
+        print("  anthropic_token_split: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.anthropic_client import AnthropicClient
+
+    block = MagicMock()
+    block.text = "Hallo"
+    msg = MagicMock()
+    msg.content = [block]
+    msg.stop_reason = "end_turn"
+    msg.usage.input_tokens = 120
+    msg.usage.output_tokens = 40
+    with patch("anthropic.Anthropic") as M:
+        M.return_value.messages.create.return_value = msg
+        r = AnthropicClient("k").send_prompt("p", "claude-sonnet-4-6")
+    assert r.tokens_input == 120 and r.tokens_output == 40 and r.tokens_used == 160
+    assert r.reasoning_tokens is None
+    print("  anthropic_token_split OK")
+
+
+def test_openai_token_split_with_reasoning():
+    """OpenAI füllt input/output + reasoning_tokens (o-Series)."""
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        print("  openai_token_split: SDK nicht installiert -> uebersprungen")
+        return
+    from src.core.openai_client import OpenAIClient
+
+    resp = MagicMock()
+    resp.choices[0].message.content = "Antwort"
+    resp.choices[0].finish_reason = "stop"
+    resp.usage.total_tokens = 300
+    resp.usage.prompt_tokens = 100
+    resp.usage.completion_tokens = 200
+    resp.usage.completion_tokens_details.reasoning_tokens = 150
+    with patch("openai.OpenAI") as M:
+        M.return_value.chat.completions.create.return_value = resp
+        r = OpenAIClient("k").send_prompt("p", "o3")
+    assert r.tokens_input == 100 and r.tokens_output == 200
+    assert r.reasoning_tokens == 150
+    print("  openai_token_split_with_reasoning OK")
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.enabled = True
+        self.kwargs = None
+
+    def log_request(self, **kw):
+        return "logdir"
+
+    def log_response(self, **kw):
+        self.kwargs = kw
+
+
+def test_token_counting_client_forwards_split_to_log():
+    """_TokenCountingClient reicht token_log_dict + reasoning_tokens ans Log."""
+    resp = APIResponse(
+        status=APIStatus.RECEIVED, content="[]",
+        tokens_used=250, tokens_input=50, tokens_output=200, reasoning_tokens=42,
+    )
+    client = _RecordingStub("openrouter")
+    client.send_prompt = lambda p, m, max_tokens=None, cap_reasoning=False: resp
+    logger = _RecordingLogger()
+    _TokenCountingClient(client, "s1_refiner", logger).send_prompt("p", "m")
+    assert logger.kwargs["tokens"] == {"input": 50, "output": 200, "total": 250}
+    assert logger.kwargs["reasoning_tokens"] == 42
+    print("  token_counting_client_forwards_split_to_log OK")
+
+
+def test_debug_log_persists_token_split():
+    """log_response schreibt tokens_input/output/tokens_reasoning in response.json."""
+    import json
+
+    dbg = DebugLogger(enabled=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        log_dir = Path(tmp)
+        dbg.log_response(
+            log_dir=log_dir, status_code=200, content="x",
+            tokens={"input": 50, "output": 200, "total": 250},
+            duration=1.0, reasoning_tokens=42,
+        )
+        data = json.loads((log_dir / "response.json").read_text(encoding="utf-8"))
+    assert data["tokens_input"] == 50 and data["tokens_output"] == 200
+    assert data["tokens_total"] == 250 and data["tokens_reasoning"] == 42
+    print("  debug_log_persists_token_split OK")
+
+
+def main():
+    print("32k-Stage-Budget + Token-Split (v0.13.3):")
+    test_openrouter_stage_call_uses_32k()
+    test_perplexity_stage_call_stays_16k()
+    test_non_openrouter_budget_unchanged_at_seam()
+    test_normal_openrouter_call_unchanged()
+    test_openrouter_token_split_and_reasoning()
+    test_openrouter_missing_usage_no_crash()
+    test_perplexity_token_split_no_reasoning()
+    test_anthropic_token_split()
+    test_openai_token_split_with_reasoning()
+    test_token_counting_client_forwards_split_to_log()
+    test_debug_log_persists_token_split()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stage_budget_and_tokens.py
+++ b/tests/test_stage_budget_and_tokens.py
@@ -21,6 +21,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -30,33 +31,41 @@ from src.core.debug_logger import DebugLogger
 from src.core.openrouter_client import OpenRouterClient
 from src.core.perplexity_client import PerplexityClient
 from src.core.factcheck_plus.llm_stage import STAGE_MAX_TOKENS
-import src.core.factcheck_plus_worker as fpw
 from src.core.factcheck_plus_worker import STAGE_MAX_TOKENS_OPENROUTER, _TokenCountingClient
 
 
 class _Resp:
-    status_code = 200
-    text = ""
+    """Minimaler requests-Response-Doppelgänger."""
 
-    def __init__(self, payload):
+    status_code: int = 200
+    text: str = ""
+
+    def __init__(self, payload: dict) -> None:
         self._payload = payload
 
-    def json(self):
+    def json(self) -> dict:
         return self._payload
 
 
-def _ok_payload(usage=None):
+def _ok_payload(usage: dict | None = None) -> dict:
+    """Baut einen erfolgreichen chat/completions-Payload (optional mit usage)."""
     return {
         "choices": [{"message": {"content": "Antwort"}, "finish_reason": "stop"}],
         "usage": usage if usage is not None else {"total_tokens": 3},
     }
 
 
-def _capture(module_path: str):
-    """Patch-Kontext, der den gesendeten JSON-Payload einsammelt."""
-    captured = {}
+def _capture(module_path: str) -> tuple[dict, Any]:
+    """Patch-Kontext, der den gesendeten JSON-Payload einsammelt.
 
-    def fake_post(url, headers=None, json=None, timeout=None):
+    Returns:
+        Tuple aus dem (nach dem Call gefüllten) ``captured``-Dict und dem
+        ``patch``-Kontextmanager, der ``requests.post`` ersetzt.
+    """
+    captured: dict = {}
+
+    def fake_post(url: str, headers: dict | None = None,
+                  json: dict | None = None, timeout: float | None = None) -> _Resp:
         captured["json"] = json
         return _Resp(_ok_payload())
 
@@ -66,18 +75,19 @@ def _capture(module_path: str):
 class _RecordingStub:
     """Client-Doppelgänger mit PROVIDER_ID, der die Aufrufe protokolliert."""
 
-    def __init__(self, provider_id: str):
-        self.PROVIDER_ID = provider_id
-        self.seen_max_tokens = []
+    def __init__(self, provider_id: str) -> None:
+        self.PROVIDER_ID: str = provider_id
+        self.seen_max_tokens: list[int | None] = []
 
-    def send_prompt(self, prompt, model, max_tokens=None, cap_reasoning=False):
+    def send_prompt(self, prompt: str, model: str, max_tokens: int | None = None,
+                    cap_reasoning: bool = False) -> APIResponse:
         self.seen_max_tokens.append(max_tokens)
         return APIResponse(status=APIStatus.RECEIVED, content="[]", tokens_used=1)
 
 
 # === Teil A: 32k-Budget für OpenRouter-Stage-Calls ========================
 
-def test_openrouter_stage_call_uses_32k():
+def test_openrouter_stage_call_uses_32k() -> None:
     """Durch die Naht: OpenRouter-Stage-Call → Payload max_tokens=32768 + Cap."""
     captured, ctx = _capture("src.core.openrouter_client")
     wrapped = _TokenCountingClient(OpenRouterClient("k"), "s1_refiner")
@@ -93,7 +103,7 @@ def test_openrouter_stage_call_uses_32k():
     print("  openrouter_stage_call_uses_32k OK")
 
 
-def test_perplexity_stage_call_stays_16k():
+def test_perplexity_stage_call_stays_16k() -> None:
     """Nicht-OpenRouter-Stage-Call bleibt bei 16384, kein reasoning-Feld."""
     captured, ctx = _capture("src.core.perplexity_client")
     wrapped = _TokenCountingClient(PerplexityClient("k"), "s5_verifier")
@@ -106,7 +116,7 @@ def test_perplexity_stage_call_stays_16k():
     print("  perplexity_stage_call_stays_16k OK")
 
 
-def test_non_openrouter_budget_unchanged_at_seam():
+def test_non_openrouter_budget_unchanged_at_seam() -> None:
     """Die Naht hebt nur für OpenRouter an — Anthropic bleibt bei 16384."""
     stub = _RecordingStub("anthropic")
     _TokenCountingClient(stub, "s1_refiner").send_prompt(
@@ -122,7 +132,7 @@ def test_non_openrouter_budget_unchanged_at_seam():
     print("  non_openrouter_budget_unchanged_at_seam OK")
 
 
-def test_normal_openrouter_call_unchanged():
+def test_normal_openrouter_call_unchanged() -> None:
     """Normaler (nicht durch die Naht laufender) OpenRouter-Call: DEFAULT + nur exclude."""
     captured, ctx = _capture("src.core.openrouter_client")
     with ctx:
@@ -134,15 +144,16 @@ def test_normal_openrouter_call_unchanged():
 
 # === Teil B: Token-Split im Debug-Log =====================================
 
-def test_openrouter_token_split_and_reasoning():
+def test_openrouter_token_split_and_reasoning() -> None:
     """OpenRouter füllt input/output + reasoning_tokens aus usage."""
     usage = {
         "prompt_tokens": 1960, "completion_tokens": 16384, "total_tokens": 18344,
         "completion_tokens_details": {"reasoning_tokens": 11400},
     }
-    captured = {}
+    captured: dict = {}
 
-    def fake_post(url, headers=None, json=None, timeout=None):
+    def fake_post(url: str, headers: dict | None = None,
+                  json: dict | None = None, timeout: float | None = None) -> _Resp:
         captured["json"] = json
         return _Resp(_ok_payload(usage))
 
@@ -154,9 +165,10 @@ def test_openrouter_token_split_and_reasoning():
     print("  openrouter_token_split_and_reasoning OK")
 
 
-def test_openrouter_missing_usage_no_crash():
+def test_openrouter_missing_usage_no_crash() -> None:
     """Fehlt usage, bleiben die Felder 0/None — kein Crash."""
-    def fake_post(url, headers=None, json=None, timeout=None):
+    def fake_post(url: str, headers: dict | None = None,
+                  json: dict | None = None, timeout: float | None = None) -> _Resp:
         return _Resp({"choices": [{"message": {"content": "Antwort"},
                                    "finish_reason": "stop"}]})  # kein usage
 
@@ -168,11 +180,12 @@ def test_openrouter_missing_usage_no_crash():
     print("  openrouter_missing_usage_no_crash OK")
 
 
-def test_perplexity_token_split_no_reasoning():
+def test_perplexity_token_split_no_reasoning() -> None:
     """Perplexity füllt input/output, aber kein reasoning_tokens."""
     usage = {"prompt_tokens": 50, "completion_tokens": 200, "total_tokens": 250}
 
-    def fake_post(url, headers=None, json=None, timeout=None):
+    def fake_post(url: str, headers: dict | None = None,
+                  json: dict | None = None, timeout: float | None = None) -> _Resp:
         return _Resp({"choices": [{"message": {"content": "A"},
                                    "finish_reason": "stop"}], "usage": usage})
 
@@ -183,7 +196,7 @@ def test_perplexity_token_split_no_reasoning():
     print("  perplexity_token_split_no_reasoning OK")
 
 
-def test_anthropic_token_split():
+def test_anthropic_token_split() -> None:
     """Anthropic füllt input/output aus usage; kein separates reasoning."""
     try:
         import anthropic  # noqa: F401
@@ -207,7 +220,7 @@ def test_anthropic_token_split():
     print("  anthropic_token_split OK")
 
 
-def test_openai_token_split_with_reasoning():
+def test_openai_token_split_with_reasoning() -> None:
     """OpenAI füllt input/output + reasoning_tokens (o-Series)."""
     try:
         import openai  # noqa: F401
@@ -232,33 +245,38 @@ def test_openai_token_split_with_reasoning():
 
 
 class _RecordingLogger:
-    def __init__(self):
-        self.enabled = True
-        self.kwargs = None
+    """DebugLogger-Doppelgänger, der die log_response-Kwargs einsammelt."""
 
-    def log_request(self, **kw):
+    def __init__(self) -> None:
+        self.enabled: bool = True
+        self.kwargs: dict | None = None
+
+    def log_request(self, **kwargs: object) -> str:
         return "logdir"
 
-    def log_response(self, **kw):
-        self.kwargs = kw
+    def log_response(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
 
 
-def test_token_counting_client_forwards_split_to_log():
+def test_token_counting_client_forwards_split_to_log() -> None:
     """_TokenCountingClient reicht token_log_dict + reasoning_tokens ans Log."""
     resp = APIResponse(
         status=APIStatus.RECEIVED, content="[]",
         tokens_used=250, tokens_input=50, tokens_output=200, reasoning_tokens=42,
     )
     client = _RecordingStub("openrouter")
-    client.send_prompt = lambda p, m, max_tokens=None, cap_reasoning=False: resp
+    client.send_prompt = (  # type: ignore[method-assign]
+        lambda p, m, max_tokens=None, cap_reasoning=False: resp
+    )
     logger = _RecordingLogger()
     _TokenCountingClient(client, "s1_refiner", logger).send_prompt("p", "m")
+    assert logger.kwargs is not None
     assert logger.kwargs["tokens"] == {"input": 50, "output": 200, "total": 250}
     assert logger.kwargs["reasoning_tokens"] == 42
     print("  token_counting_client_forwards_split_to_log OK")
 
 
-def test_debug_log_persists_token_split():
+def test_debug_log_persists_token_split() -> None:
     """log_response schreibt tokens_input/output/tokens_reasoning in response.json."""
     import json
 
@@ -276,7 +294,7 @@ def test_debug_log_persists_token_split():
     print("  debug_log_persists_token_split OK")
 
 
-def main():
+def main() -> None:
     print("32k-Stage-Budget + Token-Split (v0.13.3):")
     test_openrouter_stage_call_uses_32k()
     test_perplexity_stage_call_stays_16k()


### PR DESCRIPTION
## Anlass (Realtest 2026-07-17 08:02, DeepSeek V4 Pro via OpenRouter, v0.13.2)

Der Reasoning-Cap aus #62 wurde **korrekt gesendet** (`reasoning: {effort: "low", exclude: true}`, Verdrahtung geprüft), aber der **Upstream-Host hat ihn nicht respektiert**: S1 verbrauchte erneut exakt das volle Budget (`tokens_total 18.348` ≈ ~1,96k Input + 16.384), davon ~11,4k Reasoning und nur ~4,6k sichtbarer Content (valides JSON, mid-Feld gekappt), `finish_reason=length`, 682s. Damit ist das in #62 als **Doku-Lücke** notierte Risiko empirisch bestätigt: effort-Compliance ist bei wechselnden DeepSeek-Upstream-Hosts Glückssache. Das Gate (v0.13.1) hat korrekt und ehrlich gemeldet — jetzt braucht der Content schlicht mehr Luft, unabhängig von Host-Kooperation.

Rechnung: Reasoning-Appetit 11,4–14,7k + Content-Bedarf ~5–6k (19–21 Claims) ≈ 21k Worst Case → **32768 lässt ~11k Reserve**.

## Teil A · OpenRouter-Stage-Budget auf 32768

- Neue Konstante `STAGE_MAX_TOKENS_OPENROUTER = 32768`; greift für die Plus-Stufen (S1/S2/S4/S5), **wenn der Stufen-Client OpenRouter ist**. `STAGE_MAX_TOKENS = 16384` bleibt für alle anderen Provider (Anthropic direkt hat damit Luft).
- **Ort der Entscheidung:** die Qt↔Package-Naht (`_TokenCountingClient` prüft `PROVIDER_ID == "openrouter"` und hebt das Budget, reicht es wie bisher als `max_tokens` durch). `llm_stage`/das `factcheck_plus`-Package bleiben **provider-agnostisch** (kennen keine Provider) — genau die Trennlinie, die der Startprompt vorgab.
- Der Reasoning-Cap (`cap_reasoning=True` → effort low + exclude) **bleibt unverändert aktiv**: schadet nie, spart Geld bei Hosts, die ihn respektieren.
- Normaler Analyse-Call: unverändert (`DEFAULT_MAX_TOKENS`, v0.11-Gate+Retry). Das **Trunkierungs-Gate (v0.13.1) bleibt Sicherheitsnetz**.
- **402:** Pre-Auth gegen 32768 ≈ wenige Cent bei DeepSeek-Preisen (PO-Entscheidung). Ein echtes 402 bliebe ein offener Fehler, nicht still absenken (Linie aus v0.13.2).

## Teil B · Token-Split im Debug-Log

Bisher standen `tokens_input`/`tokens_output` in jeder `response.json` **immer auf 0** (nur `tokens_total` befüllt) — die Reasoning-Anteile mussten per Zeichen-Arithmetik geschätzt werden.

- `APIResponse` trägt jetzt `tokens_input` / `tokens_output` / `reasoning_tokens` (+ `token_log_dict()`-Helfer).
- **Feldnamen live geprüft** (nicht geraten): OpenAI-kompatibel (OpenRouter/Perplexity/OpenAI) `prompt_tokens` / `completion_tokens` / `total_tokens`; Anthropic `input_tokens` / `output_tokens`. OpenRouter/OpenAI liefern zusätzlich `completion_tokens_details.reasoning_tokens` (OpenRouter [Usage-Accounting-Doku](https://openrouter.ai/docs/use-cases/usage-accounting): „always included", mit Beispiel-JSON, das genau diesen Pfad zeigt).
- `log_response` persistiert `tokens_reasoning` (leer=`null`, wenn nicht geliefert). Alle 5 Log-Aufrufstellen mit echter Response (`api_worker` ×2, `comparison_worker`, `verification_worker`, `factcheck_plus_worker`) schreiben den Split. Kein GUI-Anteil.

> Hinweis zur Live-Verifikation: Die pre-fix-Realtest-Logs (v0.13.2) belegen die Diagnose (`total 18.348`, `finish=length`) und zeigen genau das alte Log-Format (`input/output=0`, kein `tokens_reasoning`). Den `reasoning_tokens`-Wert selbst zeigt erst das neue Log nach Merge — der Feldpfad ist über die Usage-Accounting-Doku (Beispiel-JSON) belegt.

## Ausdrücklich NICHT in diesem PR

Entkopplung Stufen-/Analyse-Modell (struktureller Folge-PR); S1-Schema verschlanken; weitere Cap-Varianten (`effort: "minimal"` — gleiche Compliance-Lotterie).

## Tests

`tests/test_stage_budget_and_tokens.py` (11, offline/gemockt):
- **A:** OpenRouter-Stage durch die Naht → Payload `max_tokens=32768` + `reasoning: {effort, exclude}`; Perplexity/Anthropic-Stage → 16384 (Anthropic ohne reasoning-Feld); normaler OpenRouter-Call → `DEFAULT_MAX_TOKENS`, nur `exclude`.
- **B:** Token-Split je Provider inkl. `reasoning_tokens` (OpenRouter/OpenAI); fehlendes `usage` → 0/None, kein Crash; `_TokenCountingClient` reicht `token_log_dict` + `reasoning_tokens` ans Log; `log_response` persistiert den Split in `response.json`.

Gesamtsuite **308 grün** (war 297, +11). `APP_VERSION` → 0.13.3, README-Spotlight + „Seit v0.13.2"-Demotion, CLAUDE.md (Phase 25).

## Merge-Kriterium (PO-Realtest)

DeepSeek V4 Pro via OpenRouter, dasselbe 21-Claim-Video + Katar-747 — S1 läuft durch statt `finish_reason=length`. Bonus: Das neue Log zeigt erstmals den echten Reasoning-Anteil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Neue Funktionen**
  - Tokenverbrauch wird nun nach Eingabe, Ausgabe und Gesamtzahl aufgeschlüsselt.
  - Optional werden Reasoning-Tokens separat erfasst und in Antwortprotokollen gespeichert.
  - Die detaillierte Tokenübersicht steht für mehrere unterstützte Anbieter bereit.

- **Verbesserungen**
  - OpenRouter-Schritte können mit einem größeren Antwortbudget ausgeführt werden.
  - Debug- und Diagnoseprotokolle enthalten nun konsistente Tokeninformationen – auch bei fehlenden Nutzungsdaten.
  - Die Anwendungsversion wurde auf 0.13.3 aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->