### PR TITLE
feat: KI-Kennzeichnung in allen Output-Formen (v0.14.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 🎯 Projektkontext
 
 **Name:** SOMAS Prompt Generator
-**Version:** 0.13.3
+**Version:** 0.14.0
 **Zweck:** Desktop-App zur Generierung und automatischen Ausführung von SOMAS-Analyse-Prompts für YouTube-Videos und manuelle Transkripte
 **Sprache:** Python 3.11+
 **GUI-Framework:** PyQt6
@@ -41,6 +41,7 @@ somas_prompt_generator/
 │   ├── core/               # Business-Logik
 │   │   ├── youtube_client.py   # Metadaten via yt-dlp
 │   │   ├── prompt_builder.py   # SOMAS-Prompt + Preset-Handling + Transkript-Builder
+│   │   ├── ai_disclosure.py    # KI-Kennzeichnung (Art. 50 AI Act) — zentrale Quelle, 3 Formen
 │   │   ├── linkedin_formatter.py # Unicode-Formatierung für LinkedIn
 │   │   ├── export.py           # Markdown-Export
 │   │   ├── api_client.py       # API-Abstraktion (Provider-Routing)
@@ -752,6 +753,43 @@ Luft, unabhängig von Host-Kooperation.
   Folge-PR, PO entscheidet nach mehr Modell-Daten); S1-Schema verschlanken;
   weitere Cap-Varianten (`effort: "minimal"` — gleiche Compliance-Lotterie)
 
+### Phase 26: KI-Kennzeichnung in allen Output-Formen ✅ (v0.14.0)
+
+Seit 2026-08-02 gilt Art. 50 EU AI Act (Transparenzpflichten). Rechtlich geprüft:
+SOMAS-Beiträge fallen unter die **Ausnahme (Art. 50(4))** (menschliche Prüfung/
+Kuration + redaktionelle Verantwortung) — die Kennzeichnung ist **freiwillige
+Transparenz**, keine Pflichterfüllung. PO will sie trotzdem, in allen Output-Formen,
+immer an. PO-Entscheidungen (final): Fuß-Platzierung überall · EU-Icon per Hotlink ·
+eine Zeile Text überall.
+
+- [x] Zentrales Modul `src/core/ai_disclosure.py` (eine Quelle der Wahrheit, drei
+  Formen): `AI_DISCLOSURE_TEXT` (LinkedIn, nur Text), `AI_DISCLOSURE_MARKDOWN`
+  (EU-`<img>` width=90 + `alt` + `**Label**`-Zeile), `AI_DISCLOSURE_HTML` (`<p>`-
+  Block, Inline-Icon + `<strong>`). Alle drei teilen `_CORE` (Drift-Schutz). Kein
+  GUI-Toggle (PO-Linie: Transparenz ist Standard). Docstring mit Rechtsgrundlage +
+  Quellen (Art. 50, EU-Icon-Seite, „freiwillig — Ausnahme greift")
+- [x] Auffindbarkeit: jede Einbaustelle trägt das grepbare Tag
+  `# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py` →
+  `grep "Art. 50"` findet Modul + alle drei Integrationspunkte
+- [x] LinkedIn (`linkedin_formatter.format_for_linkedin`): Textzeile als letzte
+  Zeile (Fuß), NUR Text — kein `<img>`/keine URL (LinkedIn kann keine Icons im
+  Text; nackte Bild-URL wäre Linkmüll)
+- [x] Markdown (`export.py`): Fußblock mit `---`-Trenner. **Beide Pfade** explizit
+  (kein gemeinsamer Chokepoint): `get_markdown_content` (Einzelanalyse) UND
+  `save_markdown` (Modellvergleich); Konsistenztest sichert Gleichlauf.
+  `sanitize_unicode_for_export` lässt den `<img>`-Tag intakt (getestet)
+- [x] WordPress (`wordpress_client.assemble_content`): `AI_DISCLOSURE_HTML` am Fuß
+  nach dem Outro — deckt Vorschau UND Senden ab (beide über `_assembled_markdown`).
+  Der `<p>`-Block überlebt `markdown_to_html` (Roh-HTML durchgereicht, getestet)
+- [x] Tests `tests/test_ai_disclosure.py` (9): LinkedIn nur Text; Markdown Einzel+
+  Vergleich mit Icon+Text; WordPress hängt an + leeres Outro; Konsistenz aller drei
+  Formen; Sanitize lässt `<img>` intakt; HTML überlebt Markdown-Konvertierung.
+  Gesamtsuite 317 grün
+- [x] `APP_VERSION` → 0.14.0, README-Spotlight + Feature-Absatz, CLAUDE.md
+- [ ] NICHT in diesem PR: PDF-Export (erbt Kennzeichnung später über Markdown-Pfad);
+  prozentuale Mensch/KI-Anteilsberechnung (bewusst verworfen); Icon lokal bündeln/
+  WP-Mediathek (PO: Hotlink; bricht die EU-URL, bleibt der Text stehen)
+
 ### Backlog
 
 - [ ] A4-Feinschliff: erzwungenes Modul aus der `MODUL-AUSWAHL`-Liste entfernen
@@ -801,4 +839,4 @@ Bei Unklarheiten: Frag nach! Lieber einmal zu viel als eine falsche Annahme tref
 
 ---
 
-Letzte Aktualisierung: 2026-07-17 (v0.13.3)
+Letzte Aktualisierung: 2026-08-02 (v0.14.0)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Diese App automatisiert den Workflow zur Erstellung strukturierter Quellenanalys
 
 ## ✨ Features
 
-### Aktuell (v0.13.3) — 32k-Stage-Budget für OpenRouter + Token-Split im Log
+### Aktuell (v0.14.0) — KI-Kennzeichnung in allen Output-Formen
+
+Seit **02.08.2026** gelten die Transparenzpflichten aus **Art. 50 EU AI Act**. SOMAS-Beiträge durchlaufen menschliche Prüfung, Quellenauswahl und redaktionelle Verantwortung und fallen damit unter die **Ausnahme (Art. 50(4))** – die Kennzeichnung ist also **freiwillige Transparenz**, keine Pflichterfüllung. Sie ist trotzdem überall an, so knapp wie möglich, und **immer aktiv** (kein Toggle: Transparenz ist Standard, nicht Option).
+
+- **Eine Quelle der Wahrheit** – `src/core/ai_disclosure.py` liefert die Kennzeichnung in drei Formen (Text / Markdown / HTML), alle mit demselben Kerntext (Drift-Schutz per Konsistenztest)
+- **Fuß-Platzierung überall** – LinkedIn bekommt **nur die Textzeile** (kein Icon-Linkmüll); Markdown-Export (Einzelanalyse **und** Modellvergleich) und WordPress bekommen zusätzlich das **EU-Basiszeichen „AI"** als Icon (Hotlink, mit `alt`-Text für Barrierefreiheit)
+- **Auffindbar für künftige Gesetzesänderungen** – jede Einbaustelle trägt ein grepbares Tag: `grep "Art. 50"` findet in Sekunden das zentrale Modul und alle drei Integrationspunkte
+
+### Seit v0.13.3 — 32k-Stage-Budget für OpenRouter + Token-Split im Log
 
 Der Reasoning-Cap aus v0.13.2 wurde nachweislich korrekt gesendet, aber der DeepSeek-Upstream-Host **respektierte ihn nicht**: S1 verbrauchte erneut das volle Budget (~11,4k Reasoning, nur ~4,6k sichtbarer Content, `finish_reason=length`). Effort-Compliance ist bei wechselnden Hosts Glückssache – also braucht der Content schlicht mehr Luft, unabhängig von Host-Kooperation.
 

--- a/src/core/ai_disclosure.py
+++ b/src/core/ai_disclosure.py
@@ -1,0 +1,68 @@
+"""Zentrale KI-Kennzeichnung für alle SOMAS-Output-Formen (v0.14.0).
+
+Eine Quelle der Wahrheit für die Transparenz-Kennzeichnung KI-generierter
+Analysen, in drei Formen (Text / Markdown / HTML). Wird an drei Stellen
+eingebunden — LinkedIn, Markdown-Export, WordPress —, jeweils am Fuß des
+Beitrags. Alle drei Formen teilen denselben Kerntext (:data:`_CORE`), damit sie
+nicht auseinanderdriften (Drift-Schutz per Konsistenztest, analog Modelllisten).
+
+Rechtsgrundlage & Auffindbarkeit
+--------------------------------
+Art. 50 EU AI Act (Verordnung (EU) 2024/1689, Transparenzpflichten),
+**anwendbar seit 2026-08-02**.
+
+**Diese Kennzeichnung ist FREIWILLIG, keine Pflichterfüllung:** SOMAS-Beiträge
+durchlaufen menschliche Prüfung, Quellenauswahl und redaktionelle Verantwortung
+durch den Herausgeber und fallen damit unter die **Ausnahme nach Art. 50(4)**
+(kein rein automatisiert veröffentlichter Inhalt). Der Herausgeber möchte die
+Transparenz dennoch — als Standard, nicht als Option (daher kein GUI-Toggle).
+
+EU-Icon (Basiszeichen „AI", für „KI beteiligt + eigene Textkennzeichnung"):
+https://digital-strategy.ec.europa.eu/en/policies/eu-icons-labelling-ai-generated-content
+Lizenz: frei nutzbar, keine Attribution nötig. Eingebunden per Hotlink
+(PO-Entscheidung); bricht die EU-URL, bleibt die Textzeile bestehen.
+
+Bei künftigen Regulierungs-Änderungen: ``grep "Art. 50"`` über das Projekt
+findet dieses Modul UND jede Einbaustelle (einheitliches Kommentar-Tag
+``# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py``).
+Geändert wird idealerweise nur dieses Modul.
+"""
+
+#: Label der Kennzeichnungszeile (in allen drei Formen identisch).
+_LABEL = "KI-Kennzeichnung:"
+
+#: Kerntext — die EINE Quelle der Wahrheit. Kommt in allen drei Formen wörtlich
+#: vor; der Konsistenztest wacht darüber.
+_CORE = (
+    "Analyse KI-generiert · Idee, Quellenauswahl & Kuration: Mensch · "
+    "Veröffentlichung nach menschlicher Prüfung."
+)
+
+#: Basis-URL des EU-Icons (Basiszeichen „AI", schwarz, 3x2). Hotlink.
+AI_DISCLOSURE_ICON_URL = (
+    "https://digital-strategy.ec.europa.eu/sites/default/files/2026-06/"
+    "AI%20LABELS_3x2_AI_black.png"
+)
+
+#: Alt-Text des Icons (Barrierefreiheits-Empfehlung der EU).
+AI_DISCLOSURE_ICON_ALT = "EU-KI-Kennzeichen: KI-generierter Inhalt"
+
+#: Reiner Text (für LinkedIn — kein Icon, keine URL, nur die Zeile).
+AI_DISCLOSURE_TEXT = f"{_LABEL} {_CORE}"
+
+#: Markdown (für den Markdown-Export). Markdown kann keine Bildgröße setzen,
+#: daher das EU-Icon als HTML-``<img>`` (width), darunter die Textzeile mit
+#: fett gesetztem Label.
+AI_DISCLOSURE_MARKDOWN = (
+    f'<img src="{AI_DISCLOSURE_ICON_URL}" alt="{AI_DISCLOSURE_ICON_ALT}" '
+    f'width="90">\n\n'
+    f"**{_LABEL}** {_CORE}"
+)
+
+#: HTML (für WordPress). Ein ``<p>``-Block mit Inline-Icon (vertikal zentriert)
+#: und fett gesetztem Label.
+AI_DISCLOSURE_HTML = (
+    f'<p><img src="{AI_DISCLOSURE_ICON_URL}" alt="{AI_DISCLOSURE_ICON_ALT}" '
+    f'width="90" style="vertical-align: middle; margin-right: 8px;">'
+    f"<strong>{_LABEL}</strong> {_CORE}</p>"
+)

--- a/src/core/debug_logger.py
+++ b/src/core/debug_logger.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "0.13.3"
+APP_VERSION = "0.14.0"
 
 
 class DebugLogger:

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -16,6 +16,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+from src.core.ai_disclosure import AI_DISCLOSURE_MARKDOWN
 from src.config.defaults import VideoInfo
 
 
@@ -257,6 +259,12 @@ def get_markdown_content(
         for i, url in enumerate(sources, 1):
             parts.append(f"[{i}] {url}  ")
 
+    # KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+    # Fußblock mit ---Trenner davor. Der <img>-Tag ist bewusst unsanitisiert
+    # (parts hier werden nicht durch sanitize_unicode_for_export geschickt).
+    parts.append("\n---\n")
+    parts.append(AI_DISCLOSURE_MARKDOWN)
+
     return '\n'.join(parts)
 
 
@@ -281,6 +289,10 @@ def save_markdown(
     Returns:
         Pfad zur geschriebenen Datei.
     """
+    # KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+    # Modellvergleich-Pfad (rendert eigenes Jinja-Layout); Fußblock mit Trenner.
+    # Vor der Sanitisierung angehängt, damit der <img>-Tag mitläuft (bleibt intakt).
+    content = content.rstrip() + "\n\n---\n\n" + AI_DISCLOSURE_MARKDOWN + "\n"
     safe_content = sanitize_unicode_for_export(content)
 
     if not output_path:

--- a/src/core/linkedin_formatter.py
+++ b/src/core/linkedin_formatter.py
@@ -5,6 +5,9 @@ LinkedIn unterstützt kein Markdown, aber Unicode-Zeichen für Fett/Kursiv.
 
 import re
 
+# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+from src.core.ai_disclosure import AI_DISCLOSURE_TEXT
+
 # Unicode Bold (Sans-Serif Bold)
 UNICODE_BOLD = {
     'A': '𝗔', 'B': '𝗕', 'C': '𝗖', 'D': '𝗗', 'E': '𝗘', 'F': '𝗙', 'G': '𝗚',
@@ -305,6 +308,11 @@ def format_for_linkedin(
             source_parts.append(f"{nums}: {domain}")
 
         formatted_text += "\n\nQuellen: " + " | ".join(source_parts)
+
+    # KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+    # Nur Text als letzte Zeile (Fuß): LinkedIn kann keine Icons im Text, eine
+    # nackte Bild-URL wäre störender Linkmüll.
+    formatted_text += "\n\n" + AI_DISCLOSURE_TEXT
 
     # Detail-Quellen: nummerierte Liste mit vollen URLs
     detailed_sources = ""

--- a/src/core/wordpress_client.py
+++ b/src/core/wordpress_client.py
@@ -22,6 +22,9 @@ import keyring
 import requests
 from requests.auth import HTTPBasicAuth
 
+# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+from src.core.ai_disclosure import AI_DISCLOSURE_HTML
+
 from src.config.api_config import (
     SERVICE_NAME,
     load_preferences,
@@ -206,19 +209,28 @@ def assemble_content(intro_md: str, analysis_md: str, outro_md: str) -> str:
     Leere Felder werden ausgelassen, sodass bei leerem Intro/Outro nur die
     Analyse gesendet wird (Variante A: getrennte Felder).
 
+    Am Fuß wird die KI-Kennzeichnung (Art. 50 AI Act) als HTML-Block angehängt —
+    sie gehört zum Beitrag und ist damit auch in der Dialog-Vorschau sichtbar.
+    Der ``<p>``-Block überlebt die spätere ``markdown_to_html``-Konvertierung
+    (Python-Markdown reicht block-level Roh-HTML unverändert durch).
+
     Args:
         intro_md: Optionaler Einleitungstext (Markdown).
         analysis_md: Die SOMAS-Analyse (Markdown).
         outro_md: Optionaler Ausleitungstext (Markdown).
 
     Returns:
-        Zusammengesetzter Markdown-String (Teile durch Leerzeile getrennt).
+        Zusammengesetzter Markdown-String (Teile durch Leerzeile getrennt),
+        mit KI-Kennzeichnung als letztem Block.
     """
     parts = [
         part.strip()
         for part in (intro_md, analysis_md, outro_md)
         if part and part.strip()
     ]
+    # KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py
+    # Immer an (PO-Linie: Transparenz ist Standard), am Fuß nach dem Outro.
+    parts.append(AI_DISCLOSURE_HTML)
     return "\n\n".join(parts)
 
 

--- a/tests/test_ai_disclosure.py
+++ b/tests/test_ai_disclosure.py
@@ -1,0 +1,165 @@
+"""KI-Kennzeichnung in allen Output-Formen (v0.14.0, Art. 50 AI Act).
+
+Prüft die zentrale Quelle (``ai_disclosure``) und die drei Einbaustellen:
+LinkedIn (nur Text), Markdown-Export (Einzelanalyse UND Modellvergleich) und
+WordPress (``assemble_content``). Plus Drift-Schutz (eine Quelle der Wahrheit)
+und dass die Unicode-Sanitisierung den ``<img>``-Tag nicht zerlegt.
+
+Alles offline — kein Netzwerk.
+
+Lauf (ohne pytest):  python tests/test_ai_disclosure.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.config.defaults import VideoInfo
+from src.core.ai_disclosure import (
+    AI_DISCLOSURE_HTML,
+    AI_DISCLOSURE_ICON_ALT,
+    AI_DISCLOSURE_ICON_URL,
+    AI_DISCLOSURE_MARKDOWN,
+    AI_DISCLOSURE_TEXT,
+    _CORE,
+)
+from src.core.export import (
+    get_markdown_content,
+    sanitize_unicode_for_export,
+    save_markdown,
+)
+from src.core.linkedin_formatter import format_for_linkedin
+from src.core.wordpress_client import assemble_content
+
+_ANALYSIS = "### FRAMING\nEin **Testtext** zur Analyse.\n\n### KERNTHESE\nThese."
+
+
+# --- 1 · LinkedIn: nur Text, kein Icon/URL --------------------------------
+
+def test_linkedin_ends_with_disclosure_text_only() -> None:
+    """LinkedIn-Output endet mit der Kennzeichnungszeile; kein <img>/URL."""
+    text, _ = format_for_linkedin(_ANALYSIS, "Videotitel", "Kanal")
+    assert text.rstrip().endswith(AI_DISCLOSURE_TEXT), text[-200:]
+    assert "<img" not in text
+    assert AI_DISCLOSURE_ICON_URL not in text
+    assert "http" not in AI_DISCLOSURE_TEXT  # die Zeile selbst ist link-frei
+    print("  linkedin_ends_with_disclosure_text_only OK")
+
+
+# --- 2 · Markdown: Einzelanalyse UND Modellvergleich ----------------------
+
+def _assert_markdown_footer(doc: str, label: str) -> None:
+    assert AI_DISCLOSURE_MARKDOWN in doc, f"{label}: Fußblock fehlt"
+    assert f'width="90"' in doc, f"{label}: img width fehlt"
+    assert f'alt="{AI_DISCLOSURE_ICON_ALT}"' in doc, f"{label}: alt-Text fehlt"
+    assert _CORE in doc, f"{label}: Kerntext fehlt"
+
+
+def test_markdown_single_analysis_has_footer() -> None:
+    """Einzelanalyse (get_markdown_content) enthält den Fußblock."""
+    info = VideoInfo(title="Titel", channel="Kanal", url="", duration=0)
+    doc = get_markdown_content(_ANALYSIS, info)
+    _assert_markdown_footer(doc, "Einzelanalyse")
+    # Fuß: die Kennzeichnung steht am Ende.
+    assert doc.rstrip().endswith(AI_DISCLOSURE_MARKDOWN.rstrip())
+    print("  markdown_single_analysis_has_footer OK")
+
+
+def test_markdown_single_without_videoinfo_has_footer() -> None:
+    """Auch ohne Video-Metadaten (reiner Analyse-String) ist die Kennzeichnung da."""
+    doc = get_markdown_content(_ANALYSIS, None)
+    _assert_markdown_footer(doc, "Einzelanalyse ohne VideoInfo")
+    print("  markdown_single_without_videoinfo_has_footer OK")
+
+
+def test_markdown_comparison_has_footer(tmp_path) -> None:
+    """Modellvergleich (save_markdown) enthält den Fußblock."""
+    doc = "# Modellvergleich\n\nFertiges Jinja-Layout.\n"
+    out = tmp_path / "vergleich.md"
+    save_markdown(doc, "Titel", str(out))
+    written = out.read_text(encoding="utf-8-sig")
+    _assert_markdown_footer(written, "Modellvergleich")
+    print("  markdown_comparison_has_footer OK")
+
+
+# --- 3 · WordPress: HTML-Block am Ende ------------------------------------
+
+def test_wordpress_assemble_appends_html() -> None:
+    """assemble_content hängt den HTML-Block ans Ende an."""
+    md = assemble_content("Intro", "Analyse", "Outro")
+    assert md.rstrip().endswith(AI_DISCLOSURE_HTML)
+    assert md.index("Outro") < md.index(AI_DISCLOSURE_HTML)
+    print("  wordpress_assemble_appends_html OK")
+
+
+def test_wordpress_empty_outro_still_works() -> None:
+    """Leeres Outro: nur Intro/Analyse + Kennzeichnung, kein Crash/Leerblock."""
+    md = assemble_content("", "Nur Analyse", "")
+    assert md.rstrip().endswith(AI_DISCLOSURE_HTML)
+    assert "Nur Analyse" in md
+    # Keine führenden/leeren Doppelblöcke durch das weggefallene Outro.
+    assert "\n\n\n" not in md
+    print("  wordpress_empty_outro_still_works OK")
+
+
+def test_wordpress_html_survives_markdown_conversion() -> None:
+    """Der <p>-Block überlebt markdown_to_html (Roh-HTML wird durchgereicht)."""
+    try:
+        import markdown  # noqa: F401
+    except ImportError:
+        print("  wordpress_html_survives_markdown_conversion: markdown fehlt -> skip")
+        return
+    from src.core.wordpress_client import markdown_to_html
+
+    html = markdown_to_html(assemble_content("", "Analyse", ""))
+    assert AI_DISCLOSURE_ICON_URL in html
+    assert "<strong>" in html and _CORE in html
+    print("  wordpress_html_survives_markdown_conversion OK")
+
+
+# --- 4 · Konsistenz (eine Quelle der Wahrheit) ----------------------------
+
+def test_all_three_forms_share_core_text() -> None:
+    """Alle drei Formen enthalten denselben Kerntext (Drift-Schutz)."""
+    for name, form in (
+        ("TEXT", AI_DISCLOSURE_TEXT),
+        ("MARKDOWN", AI_DISCLOSURE_MARKDOWN),
+        ("HTML", AI_DISCLOSURE_HTML),
+    ):
+        assert _CORE in form, f"{name}: Kerntext weicht ab"
+        assert "KI-Kennzeichnung" in form, f"{name}: Label weicht ab"
+    # Icon nur in Markdown/HTML, nicht im reinen Text.
+    assert AI_DISCLOSURE_ICON_URL in AI_DISCLOSURE_MARKDOWN
+    assert AI_DISCLOSURE_ICON_URL in AI_DISCLOSURE_HTML
+    assert AI_DISCLOSURE_ICON_URL not in AI_DISCLOSURE_TEXT
+    print("  all_three_forms_share_core_text OK")
+
+
+# --- 5 · Sanitisierung zerlegt den <img>-Tag nicht ------------------------
+
+def test_sanitize_keeps_img_tag_intact() -> None:
+    """sanitize_unicode_for_export lässt den <img>-Tag (und Kerntext) intakt."""
+    cleaned = sanitize_unicode_for_export(AI_DISCLOSURE_MARKDOWN)
+    assert f'<img src="{AI_DISCLOSURE_ICON_URL}"' in cleaned
+    assert f'alt="{AI_DISCLOSURE_ICON_ALT}"' in cleaned
+    assert 'width="90"' in cleaned
+    assert _CORE in cleaned
+    print("  sanitize_keeps_img_tag_intact OK")
+
+
+def main() -> None:
+    print("KI-Kennzeichnung (v0.14.0):")
+    test_linkedin_ends_with_disclosure_text_only()
+    test_markdown_single_analysis_has_footer()
+    test_markdown_single_without_videoinfo_has_footer()
+    print("  (Modellvergleich-Test läuft nur unter pytest — braucht tmp_path)")
+    test_wordpress_assemble_appends_html()
+    test_wordpress_empty_outro_still_works()
+    test_wordpress_html_survives_markdown_conversion()
+    test_all_three_forms_share_core_text()
+    test_sanitize_keeps_img_tag_intact()
+    print("ALLE TESTS OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ai_disclosure.py
+++ b/tests/test_ai_disclosure.py
@@ -50,7 +50,7 @@ def test_linkedin_ends_with_disclosure_text_only() -> None:
 
 def _assert_markdown_footer(doc: str, label: str) -> None:
     assert AI_DISCLOSURE_MARKDOWN in doc, f"{label}: Fußblock fehlt"
-    assert f'width="90"' in doc, f"{label}: img width fehlt"
+    assert 'width="90"' in doc, f"{label}: img width fehlt"
     assert f'alt="{AI_DISCLOSURE_ICON_ALT}"' in doc, f"{label}: alt-Text fehlt"
     assert _CORE in doc, f"{label}: Kerntext fehlt"
 


### PR DESCRIPTION
## Kontext

Seit **02.08.2026** gilt Art. 50 EU AI Act (Transparenzpflichten). Rechtlich geprüft: SOMAS-Beiträge durchlaufen menschliche Prüfung, Quellenauswahl und redaktionelle Verantwortung und fallen damit unter die **Ausnahme (Art. 50(4))** — die Kennzeichnung ist **freiwillige Transparenz**, keine Pflichterfüllung. Der PO will sie trotzdem, in allen Output-Formen, so knapp wie möglich und **immer an** (kein Toggle: Transparenz ist Standard, nicht Option).

PO-Entscheidungen (final): **Fuß-Platzierung überall · EU-Icon per Hotlink · eine Zeile Text überall.**

## Umsetzung

### 1 · Zentrales Modul `src/core/ai_disclosure.py` (eine Quelle der Wahrheit)

Drei Formen, gemeinsamer Kerntext (`_CORE`):
- `AI_DISCLOSURE_TEXT` — reiner Text (LinkedIn)
- `AI_DISCLOSURE_MARKDOWN` — EU-`<img>` (`width="90"`, `alt`-Text) + `**KI-Kennzeichnung:** …`-Zeile
- `AI_DISCLOSURE_HTML` — `<p>`-Block, Inline-Icon (`vertical-align: middle`) + `<strong>`-Label

Kein GUI-Toggle (PO-Linie). Docstring trägt Rechtsgrundlage + Quellen (Art. 50, EU-Icon-Seite, „freiwillig — Ausnahme Art. 50(4) greift").

**Auffindbarkeit für künftige Gesetzesänderungen:** Jede Einbaustelle trägt das grepbare Tag `# KI-Kennzeichnung (Art. 50 AI Act) — zentral in ai_disclosure.py`. `grep "Art. 50"` findet in Sekunden das Modul **und** alle drei Integrationspunkte.

### 2 · Integration (Fuß, alle drei Pfade)

- **LinkedIn** (`format_for_linkedin`): Textzeile als letzte Zeile — **nur Text**, kein `<img>`/keine URL (LinkedIn kann keine Icons im Text; nackte Bild-URL wäre Linkmüll).
- **Markdown** (`export.py`): Fußblock mit `---`-Trenner. **Beide Pfade explizit**, da es keinen gemeinsamen Chokepoint gibt: `get_markdown_content` (Einzelanalyse) **und** `save_markdown` (Modellvergleich, eigenes Jinja-Layout) — ein Konsistenztest sichert den Gleichlauf. `sanitize_unicode_for_export` lässt den `<img>`-Tag intakt (getestet).
- **WordPress** (`assemble_content`): `AI_DISCLOSURE_HTML` am Fuß nach dem Outro. Deckt **Vorschau UND Senden** ab (beide über `_assembled_markdown()`). Der `<p>`-Block überlebt `markdown_to_html` (Python-Markdown reicht block-level Roh-HTML durch — real gerendert verifiziert: Outro und Kennzeichnung werden zwei saubere `<p>`-Absätze).

### 3 · Bewusst NICHT in diesem PR

PDF-Export (existiert noch nicht — erbt die Kennzeichnung später über den Markdown-Pfad); prozentuale Mensch/KI-Anteilsberechnung (verworfen — eine ehrliche qualitative Zeile genügt); Icon lokal bündeln/WP-Mediathek (PO: Hotlink; bricht die EU-URL, bleibt der Text stehen).

## Tests

`tests/test_ai_disclosure.py` (9, offline):
1. LinkedIn endet mit der Kennzeichnungszeile, enthält **kein** `<img>`/URL.
2. Markdown Einzelanalyse **und** Modellvergleich: Fußblock mit EU-`<img>` (width + alt) + Textzeile; auch ohne Video-Metadaten.
3. WordPress `assemble_content` hängt den HTML-Block ans Ende; leeres Outro funktioniert; HTML überlebt die Markdown-Konvertierung.
4. Konsistenz: alle drei Formen teilen `_CORE` + Label (Drift-Schutz wie bei den Modelllisten).
5. `sanitize_unicode_for_export` lässt den `<img>`-Tag intakt.

Gesamtsuite **317 grün** (war 308, +9). `APP_VERSION` → 0.14.0, README-Spotlight + Feature-Absatz, CLAUDE.md (Phase 26).

## Merge-Kriterium (PO-Realtest)

Je ein LinkedIn-, Markdown- und WordPress-Output prüfen (Screenshot-tauglich).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * KI-generierte Inhalte werden in LinkedIn-, Markdown- und WordPress-Ausgaben einheitlich gekennzeichnet.
  * Die Kennzeichnung erscheint in Vorschauen sowie in veröffentlichten WordPress-Beiträgen und enthält ein barrierefreies EU-Symbol.

* **Verbesserungen**
  * Markdown-Exporte enthalten einen klar abgegrenzten Hinweis zur KI-Erstellung.
  * Die WordPress-Darstellung bewahrt die Kennzeichnung auch nach der Konvertierung.

* **Tests**
  * Umfassende Prüfungen für alle Ausgabeformate, Konvertierungen und Sonderfälle ergänzt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->